### PR TITLE
Audit fixes: evaluator correctness, Nix-faithful path lexing, C hardening

### DIFF
--- a/cbits/nn_attrset.h
+++ b/cbits/nn_attrset.h
@@ -16,7 +16,10 @@
  * Values are opaque void* — Haskell passes StablePtr Thunk.  The C
  * side never dereferences them.
  *
- * Lifecycle: caller owns the nn_attrset_t* and must call nn_attrset_free.
+ * Lifecycle: arena-managed.  Every set is tracked at creation and bulk-freed
+ * by nn_attrset_free_all at evaluation teardown; nn_attrset_free is that
+ * teardown's per-set primitive and must not be called on a tracked set (it
+ * would then be double-freed by nn_attrset_free_all).
  * Values (StablePtrs) are NOT freed by nn_attrset_free — Haskell owns them.
  */
 

--- a/cbits/nn_env.c
+++ b/cbits/nn_env.c
@@ -251,12 +251,24 @@ void *
 nn_env_lookup_resolved(const nn_env_t *env, int level, int idx)
 {
     NN_ASSERT(env != NULL, "nn_env_lookup_resolved: NULL env");
+    if (env == NULL) {
+        return NULL;
+    }
     while (level > 0) {
         NN_ASSERT(env->parent != NULL, "nn_env_lookup_resolved: parent chain too short for level");
+        if (env->parent == NULL) {
+            return NULL;
+        }
         env = env->parent;
         level--;
     }
+    /* The resolver supplies these indices; guard the slot read in release
+       builds too (NDEBUG strips the assert) so a resolver bug surfaces as a
+       NULL rather than an out-of-bounds read past the slot array. */
     NN_ASSERT(idx >= 0 && (uint32_t)idx < env->slot_count, "nn_env_lookup_resolved: idx out of bounds");
+    if (idx < 0 || (uint32_t)idx >= env->slot_count) {
+        return NULL;
+    }
     return env->slots[idx];
 }
 

--- a/src/Nix/Eval.hs
+++ b/src/Nix/Eval.hs
@@ -331,11 +331,22 @@ evalAddWithCoercion left right = case (left, right) of
   -- String-like: direct concat when both are string/path
   (VStr {}, VStr {}) -> evalBinary force OpAdd left right
   (VStr {}, VPath _) -> evalBinary force OpAdd left right
-  -- Otherwise: coerce both to strings via concatStrings (matching C++ Nix)
+  -- Otherwise: string concatenation with STRICT coercion (Nix coerceMore=false)
+  -- — only strings and sets with __toString/outPath coerce; numbers, bools,
+  -- null, lists, and functions are type errors, matching C++ Nix's `+`.
   _ -> do
-    (leftStr, leftCtx) <- coerceToString force applyValue left
-    (rightStr, rightCtx) <- coerceToString force applyValue right
+    (leftStr, leftCtx) <- coerceAddOperand left
+    (rightStr, rightCtx) <- coerceAddOperand right
     pure (VStr (leftStr <> rightStr) (leftCtx <> rightCtx))
+
+-- | Strict string coercion for the @+@ operator (Nix @coerceMore = false@):
+-- strings, and sets with @__toString@/@outPath@, coerce; numbers, booleans,
+-- null, lists, and functions are type errors.
+coerceAddOperand :: (MonadEval m) => NixValue -> m (Text, StringContext)
+coerceAddOperand v@(VStr {}) = coerceToString force applyValue v
+coerceAddOperand v@(VAttrs {}) = coerceToString force applyValue v
+coerceAddOperand v =
+  throwEvalError ("cannot coerce " <> typeName v <> " to a string with the + operator")
 
 -- | Bytecode short-circuit &&
 evalShortCircuitAnd :: (MonadEval m) => Env -> Word32 -> Word32 -> m NixValue
@@ -2124,7 +2135,7 @@ builtinConcatLists other =
   throwEvalError ("builtins.concatLists: expected a list, got " <> typeName other)
 
 builtinLessThan :: (MonadEval m) => NixValue -> NixValue -> m NixValue
-builtinLessThan a b = VBool <$> nixCompare a b
+builtinLessThan a b = VBool <$> nixCompare force a b
 
 -- ---------------------------------------------------------------------------
 -- Builtin implementations — arithmetic + bitwise
@@ -2171,12 +2182,12 @@ builtinMod l r = throwEvalError ("builtins.mod: expected two integers, got " <> 
 
 builtinMin :: (MonadEval m) => NixValue -> NixValue -> m NixValue
 builtinMin a b = do
-  aIsLess <- nixCompare a b
+  aIsLess <- nixCompare force a b
   pure (if aIsLess then a else b)
 
 builtinMax :: (MonadEval m) => NixValue -> NixValue -> m NixValue
 builtinMax a b = do
-  aIsLess <- nixCompare a b
+  aIsLess <- nixCompare force a b
   pure (if aIsLess then b else a)
 
 builtinBitAnd :: (MonadEval m) => NixValue -> NixValue -> m NixValue
@@ -2480,8 +2491,17 @@ ordToNix GT = 1
 
 compareVersionParts :: [Text] -> [Text] -> Int64
 compareVersionParts [] [] = 0
-compareVersionParts [] (_ : _) = -1
-compareVersionParts (_ : _) [] = 1
+-- When one version runs out, Nix pads the shorter side with an empty
+-- component and keeps comparing — so "1.0" > "1.0pre" (empty sorts AFTER
+-- "pre"), not "<" as a naive length comparison would give.
+compareVersionParts [] (b : bs) =
+  case compareComponent "" b of
+    EQ -> compareVersionParts [] bs
+    cmp -> ordToNix cmp
+compareVersionParts (a : as) [] =
+  case compareComponent a "" of
+    EQ -> compareVersionParts as []
+    cmp -> ordToNix cmp
 compareVersionParts (a : as) (b : bs) =
   case compareComponent a b of
     EQ -> compareVersionParts as bs

--- a/src/Nix/Eval/CAttrSet.hs
+++ b/src/Nix/Eval/CAttrSet.hs
@@ -17,8 +17,6 @@ module Nix.Eval.CAttrSet
 
     -- * Lifecycle
     cattrsetNew,
-    cattrsetFree,
-    withCAttrSet,
 
     -- * Construction
     cattrsetInsert,
@@ -62,9 +60,6 @@ type CAttrSet = Ptr NnAttrSet
 foreign import ccall unsafe "nn_attrset_new"
   c_nn_attrset_new :: Word32 -> IO CAttrSet
 
-foreign import ccall unsafe "nn_attrset_free"
-  c_nn_attrset_free :: CAttrSet -> IO ()
-
 foreign import ccall unsafe "nn_attrset_insert"
   c_nn_attrset_insert :: CAttrSet -> Word32 -> Ptr () -> IO ()
 
@@ -105,18 +100,6 @@ foreign import ccall unsafe "nn_attrset_remove_keys"
 -- | Allocate a new empty attribute set with the given capacity hint.
 cattrsetNew :: Word32 -> IO CAttrSet
 cattrsetNew = c_nn_attrset_new
-
--- | Free a C-allocated attribute set.  Does NOT free thunk values.
-cattrsetFree :: CAttrSet -> IO ()
-cattrsetFree = c_nn_attrset_free
-
--- | Bracket pattern: allocate, use, free.
-withCAttrSet :: Word32 -> (CAttrSet -> IO a) -> IO a
-withCAttrSet cap action = do
-  set <- cattrsetNew cap
-  result <- action set
-  cattrsetFree set
-  pure result
 
 -- ---------------------------------------------------------------------------
 -- Construction

--- a/src/Nix/Eval/Operator.hs
+++ b/src/Nix/Eval/Operator.hs
@@ -45,14 +45,14 @@ evalBinary forceFn op left right = case op of
   OpDiv -> evalDiv left right
   OpEq -> VBool <$> nixEqual forceFn left right
   OpNeq -> VBool . not <$> nixEqual forceFn left right
-  OpLt -> VBool <$> nixCompare left right
+  OpLt -> VBool <$> nixCompare forceFn left right
   OpLte -> do
-    lt <- nixCompare left right
+    lt <- nixCompare forceFn left right
     eq <- nixEqual forceFn left right
     pure (VBool (lt || eq))
-  OpGt -> VBool <$> nixCompare right left
+  OpGt -> VBool <$> nixCompare forceFn right left
   OpGte -> do
-    gt <- nixCompare right left
+    gt <- nixCompare forceFn right left
     eq <- nixEqual forceFn left right
     pure (VBool (gt || eq))
   OpConcat -> evalConcat left right
@@ -140,20 +140,44 @@ evalDiv left right = case (left, right) of
 -- ---------------------------------------------------------------------------
 
 -- | Ordering comparison for < (reused for >, <=, >= via argument swap).
-nixCompare :: (MonadEval m) => NixValue -> NixValue -> m Bool
-nixCompare (VInt a) (VInt b) = pure (a < b)
-nixCompare (VInt a) (VFloat b) = pure (fromIntegral a < b)
-nixCompare (VFloat a) (VInt b) = pure (a < fromIntegral b)
-nixCompare (VFloat a) (VFloat b) = pure (a < b)
+nixCompare :: (MonadEval m) => Force m -> NixValue -> NixValue -> m Bool
+nixCompare _ (VInt a) (VInt b) = pure (a < b)
+nixCompare _ (VInt a) (VFloat b) = pure (fromIntegral a < b)
+nixCompare _ (VFloat a) (VInt b) = pure (a < fromIntegral b)
+nixCompare _ (VFloat a) (VFloat b) = pure (a < b)
 -- String comparison ignores context (matching real Nix).
-nixCompare (VStr a _) (VStr b _) = pure (a < b)
-nixCompare left right =
+nixCompare _ (VStr a _) (VStr b _) = pure (a < b)
+-- Paths compare as their string representation (Nix semantics).
+nixCompare _ (VPath a) (VPath b) = pure (a < b)
+-- Lists compare lexicographically, element by element (Nix semantics).
+nixCompare forceFn (VList clA) (VList clB) =
+  listCompare forceFn (map Thunk (clistThunks clA)) (map Thunk (clistThunks clB))
+nixCompare _ left right =
   throwEvalError
     ( "cannot compare "
         <> typeName left
         <> " and "
         <> typeName right
     )
+
+-- | Lexicographic comparison of two thunk lists for the @<@ operator: the
+-- first differing element decides; a proper prefix is less than the longer
+-- list.  Mirrors 'listEqual'.
+listCompare :: (MonadEval m) => Force m -> [Thunk] -> [Thunk] -> m Bool
+listCompare _ [] [] = pure False
+listCompare _ [] (_ : _) = pure True
+listCompare _ (_ : _) [] = pure False
+listCompare forceFn (a : as) (b : bs)
+  | thunkSameRef a b = listCompare forceFn as bs
+  | otherwise = do
+      va <- forceFn a
+      vb <- forceFn b
+      ltAB <- nixCompare forceFn va vb
+      if ltAB
+        then pure True
+        else do
+          ltBA <- nixCompare forceFn vb va
+          if ltBA then pure False else listCompare forceFn as bs
 
 -- | Deep structural equality.  Forces thunks inside lists and
 -- attribute sets as needed.

--- a/src/Nix/Parser.hs
+++ b/src/Nix/Parser.hs
@@ -54,6 +54,7 @@ import qualified Data.ByteString as BS
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
+import Data.Text.Encoding.Error (lenientDecode)
 import Nix.Expr.ClosureTrim (trimClosures)
 import Nix.Expr.Resolve (resolveVars)
 import Nix.Expr.Types (Expr)
@@ -110,15 +111,15 @@ decodeAutoEncoding bytes
   | BS.length bytes >= 2,
     BS.index bytes 0 == 0xFF,
     BS.index bytes 1 == 0xFE =
-      TE.decodeUtf16LE (BS.drop 2 bytes)
+      TE.decodeUtf16LEWith lenientDecode (BS.drop 2 bytes)
   | BS.length bytes >= 2,
     BS.index bytes 0 == 0xFE,
     BS.index bytes 1 == 0xFF =
-      TE.decodeUtf16BE (BS.drop 2 bytes)
+      TE.decodeUtf16BEWith lenientDecode (BS.drop 2 bytes)
   | BS.length bytes >= 3,
     BS.index bytes 0 == 0xEF,
     BS.index bytes 1 == 0xBB,
     BS.index bytes 2 == 0xBF =
-      TE.decodeUtf8 (BS.drop 3 bytes)
+      TE.decodeUtf8With lenientDecode (BS.drop 3 bytes)
   | otherwise =
-      TE.decodeUtf8 bytes
+      TE.decodeUtf8With lenientDecode bytes

--- a/src/Nix/Parser/Lexer.hs
+++ b/src/Nix/Parser/Lexer.hs
@@ -224,16 +224,12 @@ lexNormalMode st acc = case T.uncons (lsInput st) of
     '>' -> emit1 st TokGt acc
     '/' | Just '/' <- safeHead rest -> emit2 st TokUpdate acc
     '/'
-      -- After an expression token, / is always division
-      | prevCanEndExpr -> emit1 st TokSlash acc
-      -- Not after expression: / followed by path char starts an absolute path
-      | Just c2 <- safeHead rest, isPathChar c2 -> lexPath st acc
-      -- Otherwise, division
+      -- A '/' that begins a path segment (slash followed by a path char)
+      -- starts a path: /abs/path.  A bare '/' (followed by whitespace) is the
+      -- division operator: a / b.  Relative paths like a/b are caught by the
+      -- path guard further down, before the identifier/number cases.
+      | looksLikePath (lsInput st) -> lexPath st acc
       | otherwise -> emit1 st TokSlash acc
-      where
-        prevCanEndExpr = case acc of
-          (Located _ _ tok : _) -> canFollowWithDivision tok
-          [] -> False
     '$'
       | Just '{' <- safeHead rest ->
           -- Increment brace depth so the closing } is TokRBrace, not
@@ -246,6 +242,9 @@ lexNormalMode st acc = case T.uncons (lsInput st) of
     '~'
       | Just '/' <- safeHead rest ->
           lexPath st acc
+    -- A path-char run that contains a '/' segment is a path, not an
+    -- identifier or number: a/b and 6/2 lex as paths, matching Nix.
+    _ | looksLikePath (lsInput st) -> lexPath st acc
     _ | isDigit c -> lexNumber st acc
     _ | isIdentStart c -> lexIdentOrKeyword st acc
     _ ->
@@ -622,30 +621,23 @@ isIdentChar c = isAlphaNum c || c == '_' || c == '\'' || c == '-'
 isPathChar :: Char -> Bool
 isPathChar c = isAlphaNum c || c `elem` ("/.~_-+" :: [Char])
 
+-- | Does the maximal path-char run at the start of the input contain a
+-- @/@-segment (a slash followed by a non-slash path char)?  If so it lexes
+-- as a path rather than an identifier, number, or division operator —
+-- matching Nix, where @a/b@ and @/abs/path@ are paths, @a / b@ (slash
+-- surrounded by whitespace) is division, and @a // b@ is the update operator.
+looksLikePath :: Text -> Bool
+looksLikePath input =
+  case T.break (== '/') (T.takeWhile isPathChar input) of
+    (_, slashAndRest) -> case T.uncons (T.drop 1 slashAndRest) of
+      Just (afterSlash, _) -> isPathChar afterSlash && afterSlash /= '/'
+      Nothing -> False
+
 isSearchPathChar :: Char -> Bool
 isSearchPathChar c = isAlphaNum c || c `elem` ("/.~_-+" :: [Char])
 
 isUriChar :: Char -> Bool
 isUriChar c = isAlphaNum c || c `elem` ("%/?:@&=+$,#._~!-" :: [Char])
-
--- | Whether a token can be the last token of an expression.
--- Used to decide if @/@ is division or the start of an absolute path.
--- Real Nix uses the same context-dependent rule in its lexer.
-canFollowWithDivision :: Token -> Bool
-canFollowWithDivision (TokIdent _) = True
-canFollowWithDivision (TokInt _) = True
-canFollowWithDivision (TokFloat _) = True
-canFollowWithDivision (TokPath _) = True
-canFollowWithDivision TokRParen = True
-canFollowWithDivision TokRBracket = True
-canFollowWithDivision TokRBrace = True
-canFollowWithDivision TokInterpClose = True
-canFollowWithDivision TokStringClose = True
-canFollowWithDivision TokIndStringClose = True
-canFollowWithDivision TokTrue = True
-canFollowWithDivision TokFalse = True
-canFollowWithDivision TokNull = True
-canFollowWithDivision _ = False
 
 -- ---------------------------------------------------------------------------
 -- Emit helpers

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -276,7 +276,13 @@ testEvalArithmetic = do
       runTest "negate int" $
         assertEval "negate" "- 5" (VInt (-5)),
       runTest "division by zero" $
-        assertEvalFail "div0" "1 / 0"
+        assertEvalFail "div0" "1 / 0",
+      runTest "absolute path lexes as path, not division" $
+        assertEval "path-abs" "builtins.typeOf /abs/path" (mkStr "path"),
+      runTest "bareword relative path lexes as path" $
+        assertEval "path-rel" "builtins.typeOf foo/bar" (mkStr "path"),
+      runTest "function applied to an absolute path argument" $
+        assertEval "app-abs-path" "(p: builtins.typeOf p) /abs/path" (mkStr "path")
     ]
 
 -- ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes from the 2026-06-07 code audit — the bounded correctness/safety set.

**Evaluator correctness**
- `compareVersions`: pre-release ordering now matches Nix (`1.0` > `1.0pre`), fixing `lib.versionOlder`/`versionAtLeast` for any version with `pre`.
- `+`: strict coercion in the string-concat fallback — `null`/`bool`/numbers no longer coerce to strings (type error, as in Nix).
- `nixCompare`: lexicographic list comparison and path comparison, so `<` / `sort` / `min` / `max` / `lessThan` work on lists.

**Lexer**
- A `/` that begins a path segment lexes as a path regardless of the preceding token (`import /abs/path` works; `a/b` and `6/2` are paths, as in Nix), replacing the `canFollowWithDivision` look-behind table.
- Source is decoded leniently, so a malformed-encoding `.nix` file fails at parse rather than throwing.

**C boundary**
- `nn_env_lookup_resolved`: always-on bounds guards (the asserts were stripped under `NDEBUG`, so a bad index read past the slot array in release builds).
- Removed the unused attrset individual-free path that could double-free against the arena teardown.

Builds `-Werror` clean; tests, ormolu, and hlint all green.
