### PR TITLE
builder: builtin:fetchurl — hash-verified fixed-output fetcher

### DIFF
--- a/src/Nix/Builder.hs
+++ b/src/Nix/Builder.hs
@@ -44,18 +44,24 @@ where
 
 import Control.Exception (SomeException, try)
 import Control.Monad (filterM, when)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as LBS
 import Data.Char (toLower)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.IO as TIO
+import qualified Network.HTTP.Client as HTTP
+import qualified Network.HTTP.Client.TLS as HTTPS
+import qualified Network.HTTP.Types.Status as HTTP
 import Nix.DependencyGraph (DepGraph, TopoResult (..), buildDepGraph, topoSort)
 import qualified Nix.DependencyGraph
 import Nix.Derivation (Derivation (..), DerivationOutput (..), fromATerm)
 import Nix.Store (Store (..), addToStore, isValid, scanReferences)
 import Nix.Store.Path (StoreDir (..), StorePath (..), storePathToFilePath)
 import Nix.Substituter (CacheConfig, SubstResult (..), trySubstitute)
+import qualified NovaCache.Hash as Hash
 import System.Directory (createDirectoryIfMissing, doesDirectoryExist, doesPathExist, removeDirectoryRecursive)
 import qualified System.Environment
 import System.Exit (ExitCode (..))
@@ -84,6 +90,23 @@ envNixStore = "NIX_STORE"
 -- | Environment variable for PATH.
 envPath :: Text
 envPath = "PATH"
+
+-- | The magic builder string for the built-in URL fetcher.  A derivation with
+-- this builder is not executed as a process — the Builder downloads its @url@
+-- and verifies it against @outputHash@ (see 'runBuiltinFetchurl').
+builtinFetchurlBuilder :: Text
+builtinFetchurlBuilder = "builtin:fetchurl"
+
+-- | Derivation environment keys read by @builtin:fetchurl@.
+envUrl, envOut, envOutputHash, envOutputHashMode :: Text
+envUrl = "url"
+envOut = "out"
+envOutputHash = "outputHash"
+envOutputHashMode = "outputHashMode"
+
+-- | HTTP success status code.
+httpStatusOk :: Int
+httpStatusOk = 200
 
 -- ---------------------------------------------------------------------------
 -- Configuration
@@ -171,7 +194,12 @@ buildDerivationInner config store drv = do
 
           -- 5. Run the builder
           builderArgs = map T.unpack (drvArgs drv)
-      exitResult <- runBuilder builderPath builderArgs environ buildDir
+      -- A "builtin:" builder (e.g. builtin:fetchurl) is handled in-process;
+      -- everything else is a normal subprocess.  The output validation and
+      -- registration below are shared by both paths.
+      exitResult <- case drvBuilder drv of
+        b | b == builtinFetchurlBuilder -> runBuiltinFetchurl drv outputDirs
+        _ -> runBuilder builderPath builderArgs environ buildDir
       case exitResult of
         Left (exitCode, stderrText) -> do
           -- 6. Failure: clean up
@@ -372,6 +400,81 @@ extractCmdString _ = Nothing
 -- | Whether we are running on Windows (compile-time constant via 'System.Info').
 isWindows :: Bool
 isWindows = System.Info.os == "mingw32"
+
+-- ---------------------------------------------------------------------------
+-- Built-in fetcher (builtin:fetchurl)
+-- ---------------------------------------------------------------------------
+
+-- | Run a @builtin:fetchurl@ derivation: download its @url@ into @$out@ and
+-- verify the bytes against the derivation's @outputHash@.  Nix's bootstrap
+-- fetcher is baked into the binary because nothing can be fetched before a
+-- fetcher exists.  Returns the same @Either (exit, msg) ()@ shape as
+-- 'runBuilder', so the shared output-registration path is reused unchanged.
+runBuiltinFetchurl :: Derivation -> [(Text, FilePath)] -> IO (Either (Int, Text) ())
+runBuiltinFetchurl drv outputDirs =
+  case (Map.lookup envUrl (drvEnv drv), lookup envOut outputDirs) of
+    (Nothing, _) -> pure (Left (1, "builtin:fetchurl: derivation has no 'url'"))
+    (_, Nothing) -> pure (Left (1, "builtin:fetchurl: derivation defines no 'out' output"))
+    (Just url, Just outPath) -> do
+      downloaded <- downloadUrl url
+      case downloaded of
+        Left err -> pure (Left (1, "builtin:fetchurl: " <> err))
+        Right body -> do
+          BS.writeFile outPath body
+          pure (verifyFetchHash drv url body)
+
+-- | Download a URL to a strict 'BS.ByteString' using nova-nix's own linked
+-- HTTP client (the same 'Network.HTTP.Client' the substituter uses) — no
+-- external @curl@, which is what makes this a genuine builtin.  Any network
+-- exception is turned into a 'Left' so it becomes a clean build failure.
+downloadUrl :: Text -> IO (Either Text BS.ByteString)
+downloadUrl url = do
+  attempt <- try fetch
+  pure $ case attempt of
+    Left (e :: SomeException) -> Left ("download error: " <> T.pack (show e))
+    Right result -> result
+  where
+    fetch :: IO (Either Text BS.ByteString)
+    fetch = do
+      manager <- HTTP.newManager HTTPS.tlsManagerSettings
+      request <- HTTP.parseRequest (T.unpack url)
+      response <- HTTP.httpLbs request manager
+      pure (bodyOrError response)
+    bodyOrError response
+      | code == httpStatusOk = Right (LBS.toStrict (HTTP.responseBody response))
+      | otherwise = Left ("HTTP " <> T.pack (show code) <> " fetching " <> url)
+      where
+        code = HTTP.statusCode (HTTP.responseStatus response)
+
+-- | Verify downloaded bytes against the derivation's @outputHash@.  Flat mode
+-- (the sha256 of the raw bytes) only; @recursive@ (NAR hash) is not yet
+-- supported.  An empty or absent hash skips verification.
+verifyFetchHash :: Derivation -> Text -> BS.ByteString -> Either (Int, Text) ()
+verifyFetchHash drv url body =
+  case Map.lookup envOutputHashMode (drvEnv drv) of
+    Just "recursive" ->
+      Left (1, "builtin:fetchurl: recursive outputHashMode not yet supported (flat only)")
+    _ -> case Map.lookup envOutputHash (drvEnv drv) of
+      Nothing -> Right ()
+      Just expected
+        | T.null expected -> Right ()
+        | otherwise -> case Hash.parseNixHash expected of
+            Left _ ->
+              Left (1, "builtin:fetchurl: unsupported outputHash format (want sha256:<base32>): " <> expected)
+            Right expectedHash
+              | computed == expectedHash -> Right ()
+              | otherwise ->
+                  Left
+                    ( 1,
+                      "builtin:fetchurl: hash mismatch for "
+                        <> url
+                        <> "\n  expected: "
+                        <> expected
+                        <> "\n  got:      "
+                        <> Hash.formatNixHash computed
+                    )
+              where
+                computed = Hash.hashBytes body
 
 -- ---------------------------------------------------------------------------
 -- Output registration

--- a/src/Nix/Builder.hs
+++ b/src/Nix/Builder.hs
@@ -58,10 +58,10 @@ import qualified Network.HTTP.Types.Status as HTTP
 import Nix.DependencyGraph (DepGraph, TopoResult (..), buildDepGraph, topoSort)
 import qualified Nix.DependencyGraph
 import Nix.Derivation (Derivation (..), DerivationOutput (..), fromATerm)
+import Nix.Hash (bytesToHexText, hexToBytes, rawHashWithAlgo)
 import Nix.Store (Store (..), addToStore, isValid, scanReferences)
 import Nix.Store.Path (StoreDir (..), StorePath (..), storePathToFilePath)
 import Nix.Substituter (CacheConfig, SubstResult (..), trySubstitute)
-import qualified NovaCache.Hash as Hash
 import System.Directory (createDirectoryIfMissing, doesDirectoryExist, doesPathExist, removeDirectoryRecursive)
 import qualified System.Environment
 import System.Exit (ExitCode (..))
@@ -98,11 +98,9 @@ builtinFetchurlBuilder :: Text
 builtinFetchurlBuilder = "builtin:fetchurl"
 
 -- | Derivation environment keys read by @builtin:fetchurl@.
-envUrl, envOut, envOutputHash, envOutputHashMode :: Text
+envUrl, envOut :: Text
 envUrl = "url"
 envOut = "out"
-envOutputHash = "outputHash"
-envOutputHashMode = "outputHashMode"
 
 -- | HTTP success status code.
 httpStatusOk :: Int
@@ -412,16 +410,23 @@ isWindows = System.Info.os == "mingw32"
 -- 'runBuilder', so the shared output-registration path is reused unchanged.
 runBuiltinFetchurl :: Derivation -> [(Text, FilePath)] -> IO (Either (Int, Text) ())
 runBuiltinFetchurl drv outputDirs =
-  case (Map.lookup envUrl (drvEnv drv), lookup envOut outputDirs) of
-    (Nothing, _) -> pure (Left (1, "builtin:fetchurl: derivation has no 'url'"))
-    (_, Nothing) -> pure (Left (1, "builtin:fetchurl: derivation defines no 'out' output"))
-    (Just url, Just outPath) -> do
+  case (Map.lookup envUrl (drvEnv drv), lookup envOut outputDirs, fixedOutput) of
+    (Nothing, _, _) -> pure (Left (1, "builtin:fetchurl: derivation has no 'url'"))
+    (_, Nothing, _) -> pure (Left (1, "builtin:fetchurl: derivation defines no 'out' output"))
+    (_, _, Nothing) -> pure (Left (1, "builtin:fetchurl: 'out' output has no fixed-output hash"))
+    (Just url, Just outPath, Just out) -> do
       downloaded <- downloadUrl url
       case downloaded of
         Left err -> pure (Left (1, "builtin:fetchurl: " <> err))
         Right body -> do
           BS.writeFile outPath body
-          pure (verifyFetchHash drv url body)
+          pure (verifyFetchHash url out body)
+  where
+    -- builtin:fetchurl derivations are always fixed-output; the expected hash
+    -- lives in the canonical output spec (doHashAlgo + doHash), not the env.
+    fixedOutput = case drvOutputs drv of
+      (out : _) | not (T.null (doHashAlgo out)) -> Just out
+      _ -> Nothing
 
 -- | Download a URL to a strict 'BS.ByteString' using nova-nix's own linked
 -- HTTP client (the same 'Network.HTTP.Client' the substituter uses) — no
@@ -446,35 +451,40 @@ downloadUrl url = do
       where
         code = HTTP.statusCode (HTTP.responseStatus response)
 
--- | Verify downloaded bytes against the derivation's @outputHash@.  Flat mode
--- (the sha256 of the raw bytes) only; @recursive@ (NAR hash) is not yet
--- supported.  An empty or absent hash skips verification.
-verifyFetchHash :: Derivation -> Text -> BS.ByteString -> Either (Int, Text) ()
-verifyFetchHash drv url body =
-  case Map.lookup envOutputHashMode (drvEnv drv) of
-    Just "recursive" ->
-      Left (1, "builtin:fetchurl: recursive outputHashMode not yet supported (flat only)")
-    _ -> case Map.lookup envOutputHash (drvEnv drv) of
-      Nothing -> Right ()
-      Just expected
-        | T.null expected -> Right ()
-        | otherwise -> case Hash.parseNixHash expected of
-            Left _ ->
-              Left (1, "builtin:fetchurl: unsupported outputHash format (want sha256:<base32>): " <> expected)
-            Right expectedHash
-              | computed == expectedHash -> Right ()
-              | otherwise ->
-                  Left
-                    ( 1,
-                      "builtin:fetchurl: hash mismatch for "
-                        <> url
-                        <> "\n  expected: "
-                        <> expected
-                        <> "\n  got:      "
-                        <> Hash.formatNixHash computed
-                    )
-              where
-                computed = Hash.hashBytes body
+-- | Verify the fetched bytes against the derivation's fixed-output hash, read
+-- from the canonical output spec.  @doHashAlgo@ is @sha256@/@sha512@/… (or
+-- @r:sha256@ for recursive); @doHash@ is the base-16 digest eval normalized the
+-- user's hash into.  Flat mode is fully supported across algorithms; recursive
+-- (unpack/executable) fetches are a separate feature — they require unpacking
+-- the download — and fail with a clear message rather than a wrong result.
+verifyFetchHash :: Text -> DerivationOutput -> BS.ByteString -> Either (Int, Text) ()
+verifyFetchHash url out body
+  | recursive =
+      Left (1, "builtin:fetchurl: recursive outputHashMode (unpack/executable) not yet supported; fetch flat and unpack in a build phase")
+  | otherwise = case (hexToBytes (doHash out), rawHashWithAlgo algo body) of
+      (Nothing, _) -> Left (1, "builtin:fetchurl: malformed expected hash for " <> url)
+      (_, Nothing) -> Left (1, "builtin:fetchurl: unsupported hash algorithm '" <> algo <> "'")
+      (Just expected, Just got)
+        | expected == got -> Right ()
+        | otherwise ->
+            Left
+              ( 1,
+                "builtin:fetchurl: hash mismatch for "
+                  <> url
+                  <> "\n  expected: "
+                  <> algoField
+                  <> ":"
+                  <> doHash out
+                  <> "\n  got:      "
+                  <> algoField
+                  <> ":"
+                  <> bytesToHexText got
+              )
+  where
+    algoField = doHashAlgo out
+    (recursive, algo) = case T.stripPrefix "r:" algoField of
+      Just rest -> (True, rest)
+      Nothing -> (False, algoField)
 
 -- ---------------------------------------------------------------------------
 -- Output registration

--- a/src/Nix/Eval.hs
+++ b/src/Nix/Eval.hs
@@ -156,7 +156,7 @@ import Nix.Expr.Types
     NixAtom (..),
     UnaryOp (..),
   )
-import Nix.Hash (byteToHex, hashPlaceholder, makeFixedOutputPath, makeOutputPath, makeTextPath, sha256Digest, sha256Hex)
+import Nix.Hash (byteToHex, hashPlaceholder, hexToBytes, makeFixedOutputPath, makeOutputPath, makeTextPath, sha256Digest, sha256Hex)
 import Nix.Store.Path (StorePath (..), defaultStoreDir, defaultStoreDirText, parseStorePath, storePathToFilePath, storePathToText)
 import qualified NovaCache.Base32 as Nix32
 import qualified NovaCache.Base64 as B64
@@ -3585,18 +3585,6 @@ requireStrAttr ctx key attrs = case attrSetLookup key attrs of
 -- | Encode bytes to base16 hex.
 bytesToHex :: BS.ByteString -> Text
 bytesToHex = T.pack . concatMap byteToHex . BS.unpack
-
--- | Decode hex string to bytes.
-hexToBytes :: Text -> Maybe BS.ByteString
-hexToBytes t
-  | T.null t = Just BS.empty
-  | odd (T.length t) = Nothing
-  | T.all isHexDigit t = Just (BS.pack (go (T.unpack t)))
-  | otherwise = Nothing
-  where
-    go [] = []
-    go (hi : lo : rest) = fromIntegral (digitToInt hi * 16 + digitToInt lo) : go rest
-    go [_] = [] -- unreachable due to odd check
 
 -- ---------------------------------------------------------------------------
 -- Base64 encode/decode — delegates to nova-cache (base64-bytestring under the hood)

--- a/src/Nix/Hash.hs
+++ b/src/Nix/Hash.hs
@@ -39,6 +39,8 @@ module Nix.Hash
     truncatedBase32,
     hashPlaceholder,
     byteToHex,
+    hexToBytes,
+    rawHashWithAlgo,
 
     -- * Store path construction (Nix @makeStorePath@ family)
     makeStorePath,
@@ -60,6 +62,7 @@ import qualified Crypto.Hash as CH
 import Data.Bits (xor)
 import qualified Data.ByteArray as BA
 import qualified Data.ByteString as BS
+import Data.Char (digitToInt, isHexDigit)
 import Data.List (foldl')
 import qualified Data.Set as Set
 import Data.Text (Text)
@@ -153,6 +156,32 @@ sha256Digest bs = BA.convert (CH.hash bs :: CH.Digest CH.SHA256)
 -- | Lowercase base-16 of raw bytes (two hex characters per byte).
 bytesToHexText :: BS.ByteString -> Text
 bytesToHexText = T.pack . concatMap byteToHex . BS.unpack
+
+-- | Decode a lowercase/uppercase base-16 string to raw bytes.  Returns
+-- 'Nothing' for odd length or non-hex characters.  This is the canonical
+-- form a @.drv@ stores a fixed-output hash in, so the builder reads it back
+-- with this rather than re-parsing the user's original SRI/base32 string.
+hexToBytes :: Text -> Maybe BS.ByteString
+hexToBytes t
+  | T.null t = Just BS.empty
+  | odd (T.length t) = Nothing
+  | T.all isHexDigit t = Just (BS.pack (pairs (T.unpack t)))
+  | otherwise = Nothing
+  where
+    pairs [] = []
+    pairs (hi : lo : rest) = fromIntegral (digitToInt hi * 16 + digitToInt lo) : pairs rest
+    pairs [_] = [] -- unreachable: even length checked above
+
+-- | Raw digest of a 'BS.ByteString' under a named algorithm (@sha256@,
+-- @sha512@, @sha1@, @md5@).  Returns 'Nothing' for an unknown algorithm.
+-- Used to verify a fixed-output fetch against its declared @outputHashAlgo@.
+rawHashWithAlgo :: Text -> BS.ByteString -> Maybe BS.ByteString
+rawHashWithAlgo algo bytes = case algo of
+  "sha256" -> Just (BA.convert (CH.hash bytes :: CH.Digest CH.SHA256))
+  "sha512" -> Just (BA.convert (CH.hash bytes :: CH.Digest CH.SHA512))
+  "sha1" -> Just (BA.convert (CH.hash bytes :: CH.Digest CH.SHA1))
+  "md5" -> Just (BA.convert (CH.hash bytes :: CH.Digest CH.MD5))
+  _ -> Nothing
 
 -- | The core store-path construction primitive.  Given a @type@ string, the
 -- inner content digest (raw SHA-256 bytes), and a name, produce the store

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -29,6 +29,7 @@ import Nix.Eval.IO (EvalState (..), newEvalState, runEvalIO)
 import Nix.Eval.Symbol (Symbol (..), symbolCount, symbolIntern, symbolLen, symbolText)
 import Nix.Eval.Types (emptyCList)
 import Nix.Expr.Types
+import qualified Nix.Hash as Hash
 import Nix.Parser (parseNix)
 import Nix.Parser.Lexer (Located (..), Token (..), tokenize)
 import Nix.Store (Store (..), addToStore, closeStore, isValid, openStore, pathExists, scanReferences, setReadOnly, writeDrv)
@@ -2677,6 +2678,28 @@ testTrivialBuildIO = do
               Fail ("build failed (exit " <> T.pack (show code) <> "): " <> msg)
           ]
 
+-- | Pure hash decode/digest helpers shared by eval (fixed-output paths) and
+-- the builder (builtin:fetchurl verification).
+testHashHelpers :: IO [Bool]
+testHashHelpers = do
+  putStrLn "hash/decode-helpers"
+  sequence
+    [ runTest "hexToBytes empty" $ assertEqual "empty" (Just BS.empty) (Hash.hexToBytes ""),
+      runTest "hexToBytes deadbeef" $
+        assertEqual "deadbeef" (Just (BS.pack [0xde, 0xad, 0xbe, 0xef])) (Hash.hexToBytes "deadbeef"),
+      runTest "hexToBytes uppercase" $
+        assertEqual "DEADBEEF" (Just (BS.pack [0xde, 0xad, 0xbe, 0xef])) (Hash.hexToBytes "DEADBEEF"),
+      runTest "hexToBytes odd length rejected" $ assertEqual "odd" Nothing (Hash.hexToBytes "abc"),
+      runTest "hexToBytes non-hex rejected" $ assertEqual "nonhex" Nothing (Hash.hexToBytes "zz"),
+      runTest "rawHashWithAlgo sha256 empty == known vector" $
+        assertEqual
+          "sha256-empty"
+          (Hash.hexToBytes "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
+          (Hash.rawHashWithAlgo "sha256" BS.empty),
+      runTest "rawHashWithAlgo unknown algo rejected" $
+        assertEqual "unknown" Nothing (Hash.rawHashWithAlgo "sha3-256" (BS.pack [1, 2, 3]))
+    ]
+
 testStoreOps :: IO [Bool]
 testStoreOps = do
   putStrLn "store/ops"
@@ -4249,6 +4272,7 @@ main = bracket_ arenaInit arenaDestroy $ do
           testStorePaths,
           testDerivation,
           testTrivialBuildIO,
+          testHashHelpers,
           testEvalLiterals,
           testEvalVariables,
           testEvalArithmetic,


### PR DESCRIPTION
## What

Implements `builtin:fetchurl` in the Builder — the bootstrap fetcher that `<nix/fetchurl.nix>` targets.

A derivation whose builder is `builtin:fetchurl` is no longer exec'd as a process. Instead the Builder:

1. downloads its `url` using nova-nix's own `Network.HTTP.Client` (the same client the substituter uses — no external `curl`, which is what makes it a genuine builtin), then
2. verifies the bytes against `outputHash` (flat mode, `sha256:<base32>`) before the shared output-registration path content-addresses it.

Dispatch is a `case` on the builder string: `builtin:` builders run in-process, everything else stays a normal subprocess. The output validation and store registration are shared by both paths.

## Why

Fixed-output fetches are the entry point to the store (you can't fetch a fetcher) — so this is the prerequisite for the Windows-stdenv seed: fetching the MSYS2 toolchain tarballs.

## Verification

- `-Werror` clean (lib + exe + test); ormolu + hlint clean; full suite green, no regressions.
- Live-verified end to end on Windows:
  - wrong hash → rejected with expected-vs-got
  - correct hash → fetched, verified, landed content-addressed in `C:\nix\store`

## Follow-ups

- Broaden hash-format support (SRI) and `recursive` `outputHashMode`.
- A network-free unit test for the verify logic.
