### PR TITLE
Apply the design and correctness audit fixes

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -17,6 +17,7 @@
 module Main (main) where
 
 import Control.Monad (void, (>=>))
+import Data.IORef (readIORef)
 import qualified Data.Map.Strict as Map
 import qualified Data.Text as T
 import qualified Data.Text.IO as TIO
@@ -28,7 +29,7 @@ import Nix.Eval.Arena (arenaInit)
 import Nix.Eval.IO (EvalState (..), newEvalState, runEvalIO)
 import Nix.Eval.Types (clistFromThunks, clistThunks, thunkToCPtr)
 import Nix.Parser (parseNix, readFileAutoEncoding)
-import Nix.Store (Store, closeStore, openStore, writeDrv)
+import Nix.Store (Store, closeStore, openStore, writeDrv, writeDrvAterm)
 import Nix.Store.Path (StorePath, defaultStoreDir, parseStorePath, platformStoreDir, storePathToFilePath)
 import Paths_nova_nix (getDataDir)
 import System.Directory (getCurrentDirectory, getTemporaryDirectory)
@@ -219,8 +220,11 @@ buildFile extraPaths dataDir filePath = do
           exitFailure
         Right val -> do
           (drv, drvSP) <- extractDerivation val
+          -- The full .drv closure (root + every transitive input) recorded
+          -- during evaluation; written to the store before building.
+          drvClosure <- readIORef (esDrvClosure st)
           store <- openStore platformStoreDir
-          buildResult <- buildAndRegister store drv drvSP
+          buildResult <- buildAndRegister store drvClosure drv drvSP
           closeStore store
           case buildResult of
             BuildSuccess sp ->
@@ -266,9 +270,14 @@ extractDerivation _ = do
 -- | Write the .drv file to the store and build with dependency resolution.
 -- The drvPath is the store path of the .drv file itself, extracted from
 -- the evaluation result alongside the Derivation struct.
-buildAndRegister :: Store -> Derivation -> StorePath -> IO BuildResult
-buildAndRegister store drv drvSP = do
-  -- Write the .drv file to store at its content-addressed path
+buildAndRegister :: Store -> Map.Map T.Text T.Text -> Derivation -> StorePath -> IO BuildResult
+buildAndRegister store drvClosure drv drvSP = do
+  -- Materialize the full input-.drv closure (every transitive dependency's
+  -- recipe) to the store.  buildWithDeps reads these back to construct the
+  -- dependency graph; without them it cannot realize any non-leaf derivation.
+  writeDrvClosure store drvClosure
+  -- Write the root .drv too (idempotent — it is also in the closure) so a build
+  -- still works if the closure was not captured (e.g. a pre-built store drv).
   writeDrv store drv drvSP
   -- Build with dependency resolution
   tmpDir <- getTemporaryDirectory
@@ -277,6 +286,17 @@ buildAndRegister store drv drvSP = do
           { bcTmpDir = tmpDir
           }
   buildWithDeps config store drv drvSP
+
+-- | Write every recorded @.drv@ ATerm (keyed by its store-path text) to the
+-- store.  Keys come from evaluation via 'storePathToText' so they always parse;
+-- an unparseable key is skipped defensively.
+writeDrvClosure :: Store -> Map.Map T.Text T.Text -> IO ()
+writeDrvClosure store = mapM_ writeOne . Map.toList
+  where
+    writeOne (pathText, aterm) =
+      case parseStorePath defaultStoreDir pathText of
+        Just sp -> writeDrvAterm store sp aterm
+        Nothing -> pure ()
 
 -- ---------------------------------------------------------------------------
 -- Output formatting

--- a/cbits/nn_arena.c
+++ b/cbits/nn_arena.c
@@ -1,76 +1,29 @@
 /*
  * nn_arena.c — Batch StablePtr collection from the thunk arena.
  *
- * Iterates all thunks via nn_thunk_count/nn_thunk_get and identifies
- * payloads that are Haskell StablePtrs (as opposed to inline scalar
- * values or C pointers).
+ * The Haskell teardown (Nix.Eval.Arena) needs every Haskell StablePtr the C
+ * arena holds so it can free them.  These two entry points delegate to the
+ * single-pass block-list walk in nn_thunk.c (nn_thunk_{count,collect}_
+ * stableptrs), which is O(total) — index-based iteration via nn_thunk_get
+ * would be O(total * blocks), since each get re-walks the block list.
  *
- * After M6 bytecode integration, PENDING thunks store (bc_idx,
- * StablePtr Env) — the bc_idx replaces the Expr, but the Env stays
- * as a StablePtr for knot-tying laziness.
- *
- * StablePtr sources:
- *   1. PENDING/BLACKHOLE: payload = StablePtr Env (all pending thunks)
+ * StablePtr sources (see nn_thunk.c):
+ *   1. PENDING/BLACKHOLE: payload = StablePtr Env (knot-tying laziness)
  *   2. COMPUTED with val_tag == NN_VALUE_PTR: StablePtr NixValue
- *
- * All other COMPUTED payloads (inline scalars, C pointers) are NOT
- * StablePtrs and must NOT be freed.
+ * All other COMPUTED payloads (inline scalars, C pointers) are NOT freed.
  */
 
 #include "nn_arena.h"
-#include "nn_attrset.h"
 #include "nn_thunk.h"
-
-#include <stddef.h>
 
 uint32_t
 nn_arena_stableptr_count(void)
 {
-    uint32_t total = nn_thunk_count();
-    uint32_t count = 0;
-    uint32_t i;
-
-    for (i = 0; i < total; i++) {
-        nn_thunk_t *t = nn_thunk_get(i);
-        if (!t) continue;
-
-        uint8_t state = nn_thunk_state(t);
-        if (state == NN_THUNK_PENDING || state == NN_THUNK_BLACKHOLE) {
-            void *p = nn_thunk_payload(t);
-            if (p) count++;
-        } else if (state == NN_THUNK_COMPUTED) {
-            uint8_t vtag = nn_thunk_value_tag(t);
-            if (vtag == NN_VALUE_PTR) {
-                void *p = nn_thunk_payload(t);
-                if (p) count++;
-            }
-        }
-    }
-    return count;
+    return nn_thunk_count_stableptrs();
 }
 
 uint32_t
 nn_arena_collect_stableptrs(void **output, uint32_t max_count)
 {
-    uint32_t total = nn_thunk_count();
-    uint32_t written = 0;
-    uint32_t i;
-
-    for (i = 0; i < total && written < max_count; i++) {
-        nn_thunk_t *t = nn_thunk_get(i);
-        if (!t) continue;
-
-        uint8_t state = nn_thunk_state(t);
-        if (state == NN_THUNK_PENDING || state == NN_THUNK_BLACKHOLE) {
-            void *p = nn_thunk_payload(t);
-            if (p) output[written++] = p;
-        } else if (state == NN_THUNK_COMPUTED) {
-            uint8_t vtag = nn_thunk_value_tag(t);
-            if (vtag == NN_VALUE_PTR) {
-                void *p = nn_thunk_payload(t);
-                if (p) output[written++] = p;
-            }
-        }
-    }
-    return written;
+    return nn_thunk_collect_stableptrs(output, max_count);
 }

--- a/cbits/nn_attrset.c
+++ b/cbits/nn_attrset.c
@@ -307,6 +307,9 @@ const nn_symbol_t *nn_attrset_keys_ptr(const nn_attrset_t *set)
 
 nn_attrset_t *nn_attrset_union(const nn_attrset_t *a, const nn_attrset_t *b)
 {
+    /* The merge-join below assumes both inputs are sorted; every set this
+     * module produces is frozen (hence sorted), so guard it in debug. */
+    NN_ASSERT(a->frozen && b->frozen, "nn_attrset_union: inputs must be frozen");
     /* Merge-join: all keys from both, b wins on conflict. */
     uint32_t cap = a->count + b->count;
     nn_attrset_t *result = nn_attrset_new(cap);
@@ -345,6 +348,7 @@ nn_attrset_t *nn_attrset_remove_keys(
     const nn_symbol_t *keys,
     uint32_t key_count)
 {
+    NN_ASSERT(set->frozen, "nn_attrset_remove_keys: input must be frozen");
     nn_attrset_t *result = nn_attrset_new(set->count);
     if (!result) { fprintf(stderr, "nn_attrset_remove_keys: alloc failed\n"); abort(); }
     uint32_t i;

--- a/cbits/nn_attrset.h
+++ b/cbits/nn_attrset.h
@@ -98,11 +98,13 @@ void nn_attrset_free_all(void);
 
 /* Create a new set that is the right-biased union of `a` and `b`
  * (keys in `b` override `a`).  Both inputs must be frozen.
- * The result is returned frozen.  Caller owns the result. */
+ * The result is returned frozen and is arena-tracked (freed by
+ * nn_attrset_free_all) — do NOT pass it to nn_attrset_free. */
 nn_attrset_t *nn_attrset_union(const nn_attrset_t *a, const nn_attrset_t *b);
 
-/* Create a new set with the given keys removed.
- * Input must be frozen.  Result is returned frozen. */
+/* Create a new set with the given keys removed.  Input must be frozen.
+ * The result is returned frozen and is arena-tracked (freed by
+ * nn_attrset_free_all) — do NOT pass it to nn_attrset_free. */
 nn_attrset_t *nn_attrset_remove_keys(
     const nn_attrset_t *set,
     const nn_symbol_t *keys,

--- a/cbits/nn_thunk.c
+++ b/cbits/nn_thunk.c
@@ -530,3 +530,45 @@ nn_thunk_get(uint32_t index)
     }
     return NULL;  /* unreachable if index < total */
 }
+
+/* --- Bulk StablePtr collection (single block-list pass, O(total)) --- */
+
+uint32_t
+nn_thunk_count_stableptrs(void)
+{
+    uint32_t count = 0;
+    struct nn_thunk_block *block;
+    uint32_t i;
+    if (!g_arena) return 0;
+    for (block = g_arena->head; block; block = block->next) {
+        for (i = 0; i < block->count; i++) {
+            const nn_thunk_t *t = &block->slots[i];
+            if (t->state == NN_THUNK_PENDING || t->state == NN_THUNK_BLACKHOLE) {
+                if (t->payload) count++;
+            } else if (t->state == NN_THUNK_COMPUTED && t->val_tag == NN_VALUE_PTR) {
+                if (t->payload) count++;
+            }
+        }
+    }
+    return count;
+}
+
+uint32_t
+nn_thunk_collect_stableptrs(void **output, uint32_t max_count)
+{
+    uint32_t written = 0;
+    struct nn_thunk_block *block;
+    uint32_t i;
+    if (!g_arena) return 0;
+    for (block = g_arena->head; block && written < max_count; block = block->next) {
+        for (i = 0; i < block->count && written < max_count; i++) {
+            const nn_thunk_t *t = &block->slots[i];
+            if (t->state == NN_THUNK_PENDING || t->state == NN_THUNK_BLACKHOLE) {
+                if (t->payload) output[written++] = t->payload;
+            } else if (t->state == NN_THUNK_COMPUTED && t->val_tag == NN_VALUE_PTR) {
+                if (t->payload) output[written++] = t->payload;
+            }
+        }
+    }
+    return written;
+}

--- a/cbits/nn_thunk.h
+++ b/cbits/nn_thunk.h
@@ -68,7 +68,7 @@ typedef struct nn_thunk {
     uint8_t   state;
     uint8_t   val_tag;
     uint16_t  _pad;
-    uint32_t  bc_idx;    /* PENDING: bytecode index; COMPUTED: 0 */
+    uint32_t  bc_idx;    /* PENDING: bytecode index; otherwise stale (never read) */
     void     *payload;
 } nn_thunk_t;
 
@@ -196,5 +196,14 @@ uint32_t nn_thunk_count(void);
  * Used for StablePtr cleanup iteration before nn_thunk_destroy().
  * Index must be < nn_thunk_count(). */
 nn_thunk_t *nn_thunk_get(uint32_t index);
+
+/* Single-pass (O(total)) collection of Haskell StablePtr payloads across the
+ * whole arena.  Walks the block list directly — nn_thunk_get is O(blocks) per
+ * call, so index-based iteration would be O(total * blocks).  StablePtr
+ * sources: PENDING/BLACKHOLE payload, and COMPUTED + NN_VALUE_PTR payload.
+ * nn_thunk_collect_stableptrs writes up to max_count pointers into `output`
+ * and returns the count written.  These back the nn_arena_* teardown helpers. */
+uint32_t nn_thunk_count_stableptrs(void);
+uint32_t nn_thunk_collect_stableptrs(void **output, uint32_t max_count);
 
 #endif /* NN_THUNK_H */

--- a/nova-nix.cabal
+++ b/nova-nix.cabal
@@ -160,6 +160,7 @@ test-suite nova-nix-test
     , containers          >= 0.6 && < 0.8
     , directory           >= 1.3 && < 1.4
     , filepath            >= 1.4 && < 1.6
+    , nova-cache          >= 0.3.0 && < 0.4
     , nova-nix
     , process             >= 1.6 && < 1.7
     , text                >= 2.0 && < 2.2

--- a/src/Nix/Builder.hs
+++ b/src/Nix/Builder.hs
@@ -47,8 +47,10 @@ import Control.Monad (filterM, when)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LBS
 import Data.Char (toLower)
+import Data.Either (fromRight)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
+import Data.Maybe (catMaybes)
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.IO as TIO
@@ -59,7 +61,7 @@ import Nix.DependencyGraph (DepGraph, TopoResult (..), buildDepGraph, topoSort)
 import qualified Nix.DependencyGraph
 import Nix.Derivation (Derivation (..), DerivationOutput (..), fromATerm)
 import Nix.Hash (bytesToHexText, hexToBytes, rawHashWithAlgo)
-import Nix.Store (Store (..), addToStore, isValid, scanReferences)
+import Nix.Store (PathRegistration, Store (..), isValid, placeInStore, registerPaths, registrationFor, scanReferences, scanTempReferences)
 import Nix.Store.Path (StoreDir (..), StorePath (..), storePathToFilePath)
 import Nix.Substituter (CacheConfig, SubstResult (..), trySubstitute)
 import System.Directory (createDirectoryIfMissing, doesDirectoryExist, doesPathExist, removeDirectoryRecursive)
@@ -173,8 +175,8 @@ buildDerivation config store drv = do
 
 buildDerivationInner :: BuildConfig -> Store -> Derivation -> IO BuildResult
 buildDerivationInner config store drv = do
-  -- 1. Validate input sources exist
-  inputsOk <- validateInputs store drv
+  -- 1. Validate inputs (sources + input-derivation outputs) exist
+  inputsOk <- validateInputs config store drv
   case inputsOk of
     Left errMsg -> pure (BuildFailure errMsg 1)
     Right () -> do
@@ -222,22 +224,46 @@ buildDerivationInner config store drv = do
 -- Input validation
 -- ---------------------------------------------------------------------------
 
--- | Check that all input sources and input derivation outputs are valid.
-validateInputs :: Store -> Derivation -> IO (Either Text ())
-validateInputs store drv = do
+-- | Check that all inputs needed to build a derivation are present in the store.
+--
+-- Input sources must be valid.  For input derivations, the artifacts a build
+-- actually reads are their realized OUTPUT paths, not the @.drv@ recipe files,
+-- so we resolve each requested output (by reading the input @.drv@ the build
+-- driver materialized) and validate those outputs.  Dependencies are realized
+-- in topological order, so a dependency's outputs are present by the time a
+-- dependent is validated.
+validateInputs :: BuildConfig -> Store -> Derivation -> IO (Either Text ())
+validateInputs config store drv = do
   -- Check input sources
   srcResults <- mapM (isValid store) (drvInputSrcs drv)
   let missingSrcs = [sp | (sp, valid) <- zip (drvInputSrcs drv) srcResults, not valid]
   if not (null missingSrcs)
     then pure (Left ("missing input sources: " <> T.intercalate ", " (map formatSP missingSrcs)))
-    else do
-      -- Check input derivation outputs
-      let inputDrvPaths = Map.keys (drvInputDrvs drv)
-      drvResults <- mapM (isValid store) inputDrvPaths
-      let missingDrvs = [sp | (sp, valid) <- zip inputDrvPaths drvResults, not valid]
-      if not (null missingDrvs)
-        then pure (Left ("missing input derivations: " <> T.intercalate ", " (map formatSP missingDrvs)))
-        else pure (Right ())
+    else case resolveInputOutputs config drv of
+      Left err -> pure (Left err)
+      Right requiredOutputs -> do
+        outResults <- mapM (isValid store) requiredOutputs
+        let missingOutputs = [sp | (sp, valid) <- zip requiredOutputs outResults, not valid]
+        if not (null missingOutputs)
+          then pure (Left ("missing input derivation outputs: " <> T.intercalate ", " (map formatSP missingOutputs)))
+          else pure (Right ())
+
+-- | Resolve each input derivation's requested output names to their store
+-- paths by reading the input @.drv@ from the store.  @Left@ if an input @.drv@
+-- cannot be read or names an output the derivation does not define.
+resolveInputOutputs :: BuildConfig -> Derivation -> Either Text [StorePath]
+resolveInputOutputs config drv =
+  concat <$> traverse resolveOne (Map.toList (drvInputDrvs drv))
+  where
+    resolveOne (inputDrvPath, wantedOutputs) = do
+      inputDrv <- readDrvFromStore config inputDrvPath
+      let outputMap = Map.fromList [(doName o, doPath o) | o <- drvOutputs inputDrv]
+      traverse (lookupOutput inputDrvPath outputMap) wantedOutputs
+    lookupOutput inputDrvPath outputMap name =
+      case Map.lookup name outputMap of
+        Just sp -> Right sp
+        Nothing ->
+          Left ("input derivation " <> formatSP inputDrvPath <> " has no output '" <> name <> "'")
 
 -- | Format a StorePath for error messages.
 formatSP :: StorePath -> Text
@@ -490,7 +516,10 @@ verifyFetchHash url out body
 -- Output registration
 -- ---------------------------------------------------------------------------
 
--- | After a successful build, register each output in the store.
+-- | After a successful build, register every output in the store.
+--
+-- Outputs are placed first and registered together (one transaction) so
+-- intra-derivation cross-output references survive (see 'registerPaths').
 registerOutputs ::
   BuildConfig ->
   Store ->
@@ -499,47 +528,71 @@ registerOutputs ::
   [(Text, FilePath)] ->
   IO BuildResult
 registerOutputs config store drv _buildDir outputDirs = do
-  let allCandidates = collectAllCandidates drv
+  let -- Candidates for reference scanning: input sources, the input
+      -- derivations' realized OUTPUT paths, and this derivation's own outputs.
+      inputOutputs = fromRight [] (resolveInputOutputs config drv)
+      allCandidates = collectAllCandidates drv ++ inputOutputs
       -- Deriver path is not available from the Derivation type alone;
       -- the caller (buildWithDeps) would need to pass it through.
       -- Register with no deriver for now — queryDeriver will return Nothing.
       drvPathText = Nothing
-  -- Register each output
-  results <- mapM (registerSingleOutput config store allCandidates drvPathText) (zip (drvOutputs drv) outputDirs)
-  case sequence results of
+      -- (temp output dir, final store path) for every output, used to detect
+      -- self- and cross-output references that appear as build-temp paths.
+      tempPairs = [(outDir, doPath out) | (out, (_, outDir)) <- zip (drvOutputs drv) outputDirs]
+  -- Phase 1: scan references and move each output into the store, collecting a
+  -- PathRegistration (no DB writes yet).  Already-valid outputs are skipped.
+  prepared <- mapM (prepareOutput config store allCandidates tempPairs drvPathText) (zip (drvOutputs drv) outputDirs)
+  case sequence prepared of
     Left errMsg -> pure (BuildFailure errMsg 1)
-    Right _ ->
-      -- Return the first output's store path
+    Right regs -> do
+      -- Phase 2: register ALL outputs in one transaction.
+      registerPaths (stDB store) (catMaybes regs)
       case drvOutputs drv of
         (firstOut : _) -> pure (BuildSuccess (doPath firstOut))
         [] -> pure (BuildFailure "no outputs defined" 1)
 
--- | Register a single output: scan references, move to store, register in DB.
-registerSingleOutput ::
+-- | Prepare a single output for registration: skip if already valid in the DB,
+-- otherwise scan references (input refs plus self/cross-output temp refs) and
+-- place it in the store, returning its 'PathRegistration'.  Returns @Nothing@
+-- for an output already registered as valid.
+prepareOutput ::
   BuildConfig ->
   Store ->
   [StorePath] ->
+  [(FilePath, StorePath)] ->
   Maybe Text ->
   (DerivationOutput, (Text, FilePath)) ->
-  IO (Either Text ())
-registerSingleOutput config store candidates drvPathText (output, (_outName, outDir)) = do
+  IO (Either Text (Maybe PathRegistration))
+prepareOutput config store candidates tempPairs drvPathText (output, (_outName, outDir)) = do
   let targetSP = doPath output
       targetPath = storePathToFilePath (bcStoreDir config) targetSP
-  -- Check if output exists (file or directory — builder creates it)
+  -- Check the build actually produced the output (file or directory).
   exists <- doesPathExist outDir
   if not exists
     then pure (Left ("output missing: " <> T.pack outDir))
     else do
-      -- Scan for references in the output
-      refs <- scanReferences (bcStoreDir config) candidates outDir
-      -- Check if already in store (e.g. from a previous build)
-      alreadyExists <- doesPathExist targetPath
-      if alreadyExists
-        then pure (Right ())
+      -- Validity is a DB fact, not mere disk presence: an output left on disk by
+      -- an interrupted build is NOT valid and must be (re-)registered.
+      valid <- isValid store targetSP
+      if valid
+        then pure (Right Nothing)
         else do
-          -- Move to store and register
-          addToStore store outDir targetSP drvPathText refs
-          pure (Right ())
+          onDisk <- doesPathExist targetPath
+          -- Scan whichever artifact we will register: a leftover store path if
+          -- present, otherwise the fresh build output.
+          let scanPath = if onDisk then targetPath else outDir
+          inputRefs <- scanReferences (bcStoreDir config) candidates scanPath
+          selfRefs <- scanTempReferences tempPairs scanPath
+          let refs = dedupStorePaths (inputRefs ++ selfRefs)
+          reg <-
+            if onDisk
+              then registrationFor store targetSP drvPathText refs
+              else placeInStore store outDir targetSP drvPathText refs
+          pure (Right (Just reg))
+
+-- | Deduplicate store paths by their (unique) hash.
+dedupStorePaths :: [StorePath] -> [StorePath]
+dedupStorePaths = Map.elems . Map.fromList . map (\sp -> (spHash sp, sp))
 
 -- | Collect all candidate store paths from the derivation's inputs.
 -- Used for reference scanning.

--- a/src/Nix/Eval.hs
+++ b/src/Nix/Eval.hs
@@ -42,7 +42,8 @@ module Nix.Eval
 
     -- * Evaluation monad (re-exported from Types)
     MonadEval (..),
-    PureEval (..),
+    PureEval,
+    runPureEval,
 
     -- * Evaluation
     eval,
@@ -105,7 +106,7 @@ import Nix.Eval.Types
     EvalFormals (..),
     MonadEval (..),
     NixValue (..),
-    PureEval (..),
+    PureEval,
     StringContext (..),
     StringContextElement (..),
     Thunk (..),
@@ -144,6 +145,7 @@ import Nix.Eval.Types
     newCEnv,
     newMinimalEnv,
     readThunkValue,
+    runPureEval,
     thunkToCPtr,
     typeName,
     withScopesForCapture,
@@ -156,7 +158,7 @@ import Nix.Expr.Types
     NixAtom (..),
     UnaryOp (..),
   )
-import Nix.Hash (byteToHex, hashPlaceholder, hexToBytes, makeFixedOutputPath, makeOutputPath, makeTextPath, sha256Digest, sha256Hex)
+import Nix.Hash (bytesToHexText, hashPlaceholder, hexToBytes, makeFixedOutputPath, makeOutputPath, makeTextPath, sha256Digest, sha256Hex)
 import Nix.Store.Path (StorePath (..), defaultStoreDir, defaultStoreDirText, parseStorePath, storePathToFilePath, storePathToText)
 import qualified NovaCache.Base32 as Nix32
 import qualified NovaCache.Base64 as B64
@@ -274,6 +276,8 @@ evalBytecode env bcIdx =
 decodeUnaryOp :: Word8 -> UnaryOp
 decodeUnaryOp 0 = OpNot
 decodeUnaryOp 1 = OpNegate
+-- Unreachable: the tag is written by Nix.Eval.Compile's encodeUnaryOp, which
+-- only emits 0 or 1.
 decodeUnaryOp n = error ("decodeUnaryOp: unknown tag " <> show n)
 
 -- | Decode a BinaryOp from bytecode flags.
@@ -293,6 +297,8 @@ decodeBinaryOp 11 = OpGt
 decodeBinaryOp 12 = OpGte
 decodeBinaryOp 13 = OpConcat
 decodeBinaryOp 14 = OpUpdate
+-- Unreachable: the tag is written by Nix.Eval.Compile's encodeBinaryOp, which
+-- only emits 0..14.
 decodeBinaryOp n = error ("decodeBinaryOp: unknown tag " <> show n)
 
 -- | Evaluate a binary operation from bytecode, with short-circuit
@@ -343,8 +349,8 @@ evalAddWithCoercion left right = case (left, right) of
 -- strings, and sets with @__toString@/@outPath@, coerce; numbers, booleans,
 -- null, lists, and functions are type errors.
 coerceAddOperand :: (MonadEval m) => NixValue -> m (Text, StringContext)
-coerceAddOperand v@(VStr {}) = coerceToString force applyValue v
-coerceAddOperand v@(VAttrs {}) = coerceToString force applyValue v
+coerceAddOperand v@(VStr {}) = coerceToString False force applyValue v
+coerceAddOperand v@(VAttrs {}) = coerceToString False force applyValue v
 coerceAddOperand v =
   throwEvalError ("cannot coerce " <> typeName v <> " to a string with the + operator")
 
@@ -1823,8 +1829,9 @@ builtinConcatStringsSep (VStr sep sepCtx) (VList cl) = do
   where
     forceToStrCtx thunk = do
       val <- force thunk
-      -- Nix coerces list elements to strings (paths, derivations, etc.)
-      coerceToString force applyValue val
+      -- Nix coerces list elements to strings (paths, derivations, etc.).
+      -- concatStringsSep is strict (coerceMore=False): non-string scalars error.
+      coerceToString False force applyValue val
 builtinConcatStringsSep (VStr _ _) other =
   throwEvalError ("builtins.concatStringsSep: expected a list, got " <> typeName other)
 builtinConcatStringsSep other _ =
@@ -1851,16 +1858,18 @@ foldlStrict op acc (thunk : rest) = do
   foldlStrict op stepped rest
 
 builtinSubstring :: (MonadEval m) => NixValue -> NixValue -> NixValue -> m NixValue
-builtinSubstring (VInt start) (VInt len) (VStr s ctx) =
-  let clampedStart = max 0 (fromIntegral start)
-      -- Nix clamps len to available length (negative len means rest of string)
-      available = T.length s - clampedStart
-      clampedLen =
-        if len < 0
-          then available
-          else min (fromIntegral len) available
-   in -- Context is preserved through substring (matching real Nix).
-      pure (VStr (T.take clampedLen (T.drop clampedStart s)) ctx)
+builtinSubstring (VInt start) (VInt len) (VStr s ctx)
+  | start < 0 = throwEvalError "builtins.substring: negative start position"
+  | otherwise =
+      let startPos = fromIntegral start
+          -- Nix clamps len to available length (negative len means rest of string)
+          available = T.length s - startPos
+          clampedLen =
+            if len < 0
+              then available
+              else min (fromIntegral len) available
+       in -- Context is preserved through substring (matching real Nix).
+          pure (VStr (T.take clampedLen (T.drop startPos s)) ctx)
 builtinSubstring _ _ (VStr _ _) =
   throwEvalError "builtins.substring: start and length must be integers"
 builtinSubstring _ _ other =
@@ -1901,7 +1910,7 @@ coerceToStringPermissive (VList cl) = do
     coerceThunk thunk = do
       val <- force thunk
       coerceToStringPermissive val
-coerceToStringPermissive other = coerceToString force applyValue other
+coerceToStringPermissive other = coerceToString True force applyValue other
 
 -- | Coerce a value to a string for a DERIVATION field (an env value or an
 -- arg).  Like 'coerceToStringPermissive', but a path literal is copied into
@@ -1930,7 +1939,7 @@ coerceToStringInterp (VPath p) = do
   case parseStorePath defaultStoreDir spText of
     Just sp -> pure (spText, StringContext (Set.singleton (SCPlain sp)))
     Nothing -> pure (spText, mempty)
-coerceToStringInterp other = coerceToString force applyValue other
+coerceToStringInterp other = coerceToString False force applyValue other
 
 -- | The current system platform string.
 currentSystemStr :: Text
@@ -2427,7 +2436,10 @@ matchWithCompiled compiled str =
           let groups = Array.elems match
               -- Skip index 0 (full match) — return only capture groups.
               captureGroups = drop 1 groups
-              toThunk (s, _) = evaluated (mkStr (T.pack s))
+              -- A non-participating capture group has offset (-1); C++ Nix
+              -- yields null for it, not the empty string.
+              toThunk (s, (off, _)) =
+                if off < 0 then evaluated VNull else evaluated (mkStr (T.pack s))
            in pure (VList (clistFromThunks (map (thunkToCPtr . toThunk) captureGroups)))
 
 -- | @builtins.split regex str@: split a string by a POSIX ERE.
@@ -2471,7 +2483,9 @@ buildSplitResult remaining pos (match : rest) =
       before = T.pack (take (matchStart - pos) (drop pos remaining))
       -- Capture groups (indices 1..)
       groups = drop 1 (Array.elems match)
-      groupThunks = map (\(s, _) -> evaluated (mkStr (T.pack s))) groups
+      -- A non-participating capture group has offset (-1) → null (as 'match').
+      groupThunks =
+        map (\(s, (off, _)) -> if off < 0 then evaluated VNull else evaluated (mkStr (T.pack s))) groups
       -- Continue after this match
       afterPos = matchStart + matchLen
    in evaluated (mkStr before)
@@ -2625,20 +2639,19 @@ valueToJSON (VList cl) = do
       ctx = mconcat (map snd results)
   pure ("[" <> T.intercalate "," jsonVals <> "]", ctx)
 valueToJSON (VAttrs attrs) =
-  -- Derivation-like attrsets (with outPath) coerce to string in toJSON,
-  -- matching C++ Nix behavior.
-  case attrSetLookup "outPath" attrs of
-    Just outThunk -> do
-      outVal <- force outThunk
-      (s, ctx) <- coerceToString force applyValue outVal
-      pure (jsonEscapeString s, ctx)
-    Nothing -> do
+  -- C++ Nix serializes an attrset via __toString first, then outPath, and only
+  -- falls back to an object when neither is present.
+  case (attrSetLookup "__toString" attrs, attrSetLookup "outPath" attrs) of
+    (Nothing, Nothing) -> do
       let m = attrSetToMap attrs
           sortedKeys = Map.keys m
       results <- mapM (jsonPair m) sortedKeys
       let pairs = map fst results
           ctx = mconcat (map snd results)
       pure ("{" <> T.intercalate "," pairs <> "}", ctx)
+    _ -> do
+      (s, ctx) <- coerceToString True force applyValue (VAttrs attrs)
+      pure (jsonEscapeString s, ctx)
   where
     jsonPair attrMap key = case Map.lookup key attrMap of
       Nothing -> pure ("", emptyContext)
@@ -2813,9 +2826,7 @@ builtinHashString other _ =
   throwEvalError ("builtins.hashString: expected a string, got " <> typeName other)
 
 digestToHex :: (BA.ByteArrayAccess a) => a -> Text
-digestToHex digest =
-  let bytes = BA.unpack digest
-   in T.pack (concatMap byteToHex bytes)
+digestToHex = bytesToHexText . BA.convert
 
 -- ---------------------------------------------------------------------------
 -- Builtin implementations — deep evaluation
@@ -3172,7 +3183,7 @@ forceAttrStr builtin key attrs =
     Nothing -> throwEvalError (builtin <> ": missing required attribute '" <> key <> "'")
     Just thunk -> do
       val <- force thunk
-      result <- catchEvalError (coerceToString force applyValue val)
+      result <- catchEvalError (coerceToString True force applyValue val)
       case result of
         Right (s, _ctx) -> pure s
         Left _ -> throwEvalError (builtin <> ": '" <> key <> "' must be a string")
@@ -3184,7 +3195,7 @@ forceOptionalAttrStr attrs key =
     Nothing -> pure Nothing
     Just thunk -> do
       val <- force thunk
-      result <- catchEvalError (coerceToString force applyValue val)
+      result <- catchEvalError (coerceToString True force applyValue val)
       case result of
         Right (s, _ctx) -> pure (Just s)
         Left _ -> pure Nothing
@@ -3282,7 +3293,7 @@ builtinDerivationStrict (VAttrs attrs) = do
       let foPath = makeFixedOutputPath drvName foAlgo foMode foDigest
           foPathText = storePathToText defaultStoreDir foPath
           algoField = (if foMode == "recursive" then "r:" else "") <> foAlgo
-          foHashHex = bytesToHex foDigest
+          foHashHex = bytesToHexText foDigest
           foModulo =
             sha256Digest
               (TE.encodeUtf8 ("fixed:out:" <> algoField <> ":" <> foHashHex <> ":" <> foPathText))
@@ -3292,7 +3303,7 @@ builtinDerivationStrict (VAttrs attrs) = do
               (Map.insert "out" foPathText baseEnv)
           drvSp = makeTextPath drvFileName (sha256Digest (TE.encodeUtf8 (toATerm contents))) drvRefs
           drvText = storePathToText defaultStoreDir drvSp
-      cacheDrvHash drvText (bytesToHex foModulo)
+      cacheDrvHash drvText (bytesToHexText foModulo)
       pure (drvText, drvSp, [("out", foPathText)], contents)
     Nothing -> do
       inputSubst <- mapM resolveInputModulo (Map.toList inputDrvs)
@@ -3309,8 +3320,14 @@ builtinDerivationStrict (VAttrs attrs) = do
           moduloUnmasked = sha256Digest (TE.encodeUtf8 (toATermForHash False (Just inputSubst) contents))
           drvSp = makeTextPath drvFileName (sha256Digest (TE.encodeUtf8 (toATerm contents))) drvRefs
           drvText = storePathToText defaultStoreDir drvSp
-      cacheDrvHash drvText (bytesToHex moduloUnmasked)
+      cacheDrvHash drvText (bytesToHexText moduloUnmasked)
       pure (drvText, drvSp, outPathTexts, contents)
+
+  -- Record this derivation's full .drv ATerm (the exact bytes whose hash is its
+  -- store path) so the build driver can materialize the entire input-.drv
+  -- closure before building.  Bottom-up eval guarantees every transitive input
+  -- is recorded by the time a dependent is.
+  recordDrvAterm drvPathText (toATerm completeDrv)
 
   let mainOutPath = case outPaths of
         ((_, p) : _) -> p
@@ -3450,7 +3467,7 @@ builtinDerivationLazy other =
 forceToText :: (MonadEval m) => Thunk -> m Text
 forceToText thunk = do
   val <- force thunk
-  (s, _ctx) <- coerceToString force applyValue val
+  (s, _ctx) <- coerceToString True force applyValue val
   pure s
 
 -- | Collect all string-coercible attributes for the derivation environment,
@@ -3524,7 +3541,7 @@ builtinConvertHash (VAttrs attrs) = do
   (algo, rawBytes) <- decodeHashInput attrs hashVal
   -- Encode to target format
   case toFmt of
-    "base16" -> pure (mkStr (bytesToHex rawBytes))
+    "base16" -> pure (mkStr (bytesToHexText rawBytes))
     "nix32" -> pure (mkStr (Nix32.encode rawBytes))
     "base32" -> pure (mkStr (Nix32.encode rawBytes)) -- deprecated alias
     "base64" -> pure (mkStr (bytesToBase64 rawBytes))
@@ -3581,10 +3598,6 @@ requireStrAttr ctx key attrs = case attrSetLookup key attrs of
       VStr s _ -> pure s
       _ -> throwEvalError ("builtins." <> ctx <> ": " <> key <> " must be a string")
   Nothing -> throwEvalError ("builtins." <> ctx <> ": missing required attribute '" <> key <> "'")
-
--- | Encode bytes to base16 hex.
-bytesToHex :: BS.ByteString -> Text
-bytesToHex = T.pack . concatMap byteToHex . BS.unpack
 
 -- ---------------------------------------------------------------------------
 -- Base64 encode/decode — delegates to nova-cache (base64-bytestring under the hood)

--- a/src/Nix/Eval/CEnv.hs
+++ b/src/Nix/Eval/CEnv.hs
@@ -4,7 +4,7 @@
 -- hold slot arrays, lazy scopes, parent pointers, and with-scopes.
 -- All memory is freed in bulk via 'cenvDestroy' at evaluation end.
 --
--- This moves Env records off the GHC heap.  Each @nn_env_t@ is 40
+-- This moves Env records off the GHC heap.  Each @nn_env_t@ is 48
 -- bytes (arena-allocated, zero GC overhead), replacing the former
 -- Haskell record (~80-100 bytes with GHC info pointers, Maybe
 -- constructors, and list cons cells per env).
@@ -44,6 +44,7 @@ module Nix.Eval.CEnv
 where
 
 import Data.Word (Word16, Word32)
+import Foreign.C.Types (CInt (..))
 import Foreign.Ptr (Ptr)
 import Nix.Eval.CThunk (CThunkPtr)
 
@@ -109,7 +110,7 @@ foreign import ccall unsafe "nn_env_with_count"
   c_nn_env_with_count :: Ptr NnEnv -> IO Word16
 
 foreign import ccall unsafe "nn_env_lookup_resolved"
-  c_nn_env_lookup_resolved :: Ptr NnEnv -> Int -> Int -> IO CThunkPtr
+  c_nn_env_lookup_resolved :: Ptr NnEnv -> CInt -> CInt -> IO CThunkPtr
 
 foreign import ccall unsafe "nn_env_root_scope"
   c_nn_env_root_scope :: Ptr NnEnv -> IO (Ptr ())
@@ -205,7 +206,9 @@ cenvWithCount = c_nn_env_with_count
 -- | Resolved variable lookup: walk @level@ parent hops, then read
 -- @slots[idx]@.  Single FFI call — O(level) in C.
 cenvLookupResolved :: Ptr NnEnv -> Int -> Int -> IO CThunkPtr
-cenvLookupResolved = c_nn_env_lookup_resolved
+cenvLookupResolved env level idx =
+  -- C @int@ params: convert at the boundary (CInt), not HsInt (64-bit).
+  c_nn_env_lookup_resolved env (fromIntegral level) (fromIntegral idx)
 
 -- | Walk parent chain to root, return root's lazy scope (NULL if none).
 cenvRootScope :: Ptr NnEnv -> IO (Ptr ())

--- a/src/Nix/Eval/CThunk.hs
+++ b/src/Nix/Eval/CThunk.hs
@@ -81,7 +81,7 @@ where
 
 import Data.Int (Int64)
 import Data.Word (Word32, Word8)
-import Foreign.C.Types (CDouble (..))
+import Foreign.C.Types (CDouble (..), CInt (..))
 import Foreign.Ptr (Ptr, nullPtr)
 
 -- | Phantom type for C-side @nn_thunk_t@.
@@ -182,7 +182,7 @@ foreign import ccall unsafe "nn_thunk_get_lambda"
   c_nn_thunk_get_lambda :: CThunkPtr -> IO (Ptr ())
 
 foreign import ccall unsafe "nn_thunk_mark_blackhole"
-  c_nn_thunk_mark_blackhole :: CThunkPtr -> IO Int
+  c_nn_thunk_mark_blackhole :: CThunkPtr -> IO CInt
 
 foreign import ccall unsafe "nn_thunk_set_computed"
   c_nn_thunk_set_computed :: CThunkPtr -> Ptr () -> IO (Ptr ())

--- a/src/Nix/Eval/Compile.hs
+++ b/src/Nix/Eval/Compile.hs
@@ -456,6 +456,8 @@ decodeBcFormals flags dataOff = case flags of
     ellipsis <- cbcData (dataOff + 2)
     formals <- decodeFormalEntries (fromIntegral count) (dataOff + 3)
     pure (EFNamedSet (symbolText (Symbol nameSym)) formals (ellipsis /= 0))
+  -- Unreachable: the flag is written only by this module's formals compiler,
+  -- which emits 0, 1, or 2 — all matched above.
   _ -> error "decodeBcFormals: invalid formal type flag"
 
 -- | Decode a list of formal entries from the data buffer.
@@ -484,6 +486,8 @@ decodeBcCaptureInfo dataOff = do
       count <- cbcData (dataOff + 1)
       pairs <- decodePairs (fromIntegral count) (dataOff + 2)
       pure (CapturesWithScopes pairs)
+    -- Unreachable: the tag is written only by this module's capture compiler,
+    -- which emits 0, 1, or 2 — all matched above.
     _ -> error "decodeBcCaptureInfo: invalid capture type tag"
 
 -- | Decode (level, idx) pairs from the data buffer.
@@ -546,6 +550,8 @@ decodeOneBinding off = do
       if hasFrom /= 0
         then pure (BcInheritFrom fromBcIdx syms, nextOff)
         else pure (BcInherit syms, nextOff)
+    -- Unreachable: the tag is written only by this module's binding compiler,
+    -- which emits 0 or 1 — both matched above.
     _ -> error "decodeOneBinding: invalid binding type tag"
 
 -- | Decode attr path keys: pairs of (is_expr, key_or_bc_idx).

--- a/src/Nix/Eval/IO.hs
+++ b/src/Nix/Eval/IO.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 -- | IO-based Nix evaluator.
@@ -48,7 +49,7 @@ import Nix.Eval (eval)
 import Nix.Eval.CList (CList (..))
 import Nix.Eval.CThunk (CThunkPtr, cthunkGetAttrs, cthunkGetBcIdx, cthunkGetBool, cthunkGetCtxStr, cthunkGetFloat, cthunkGetInt, cthunkGetLambda, cthunkGetList, cthunkGetPath, cthunkGetStr, cthunkMarkBlackhole, cthunkPayload, cthunkSetComputed, cthunkSetComputedAttrs, cthunkSetComputedBool, cthunkSetComputedCtxStr, cthunkSetComputedFloat, cthunkSetComputedInt, cthunkSetComputedLambda, cthunkSetComputedList, cthunkSetComputedNull, cthunkSetComputedPath, cthunkSetComputedStr, cthunkState, cthunkValueTag)
 import Nix.Eval.Symbol (Symbol (..), symbolIntern, symbolText)
-import Nix.Eval.Types (AttrSet (..), Env (..), MonadEval (..), NixValue (..), Thunk (..), attrSetSize, emptyContext, marshalLambda, marshalStringContext, unmarshalLambdaValue, unmarshalStringContext)
+import Nix.Eval.Types (AttrSet (..), Env (..), MonadEval (..), NixValue (..), Thunk (..), attrSetSize, emptyContext, marshalLambda, marshalStringContext, unmarshalLambdaValue, unmarshalStringContext, pattern ValueAttrs, pattern ValueBool, pattern ValueCtxStr, pattern ValueFloat, pattern ValueInt, pattern ValueLambda, pattern ValueList, pattern ValueNull, pattern ValuePath, pattern ValueStr)
 import Nix.Expr.Types (AttrKey (..), Binding (..), Expr (..), Formal (..), Formals (..), NixAtom (..), StringPart (..))
 import Nix.Hash (makeFixedOutputPath, sha256Digest, sha256Hex, truncatedBase32)
 import Nix.Parser (parseNix, readFileAutoEncoding)
@@ -98,6 +99,10 @@ data EvalState = EvalState
     -- bottom-up by 'builtinDerivationStrict' so input derivations can be
     -- substituted by their content hashes when computing output paths.
     esDrvModuloCache :: !(IORef (Map Text Text)),
+    -- | Accumulated @.drv@ closure (drv store path text → its ATerm), recorded
+    -- bottom-up by 'builtinDerivationStrict'.  The build driver reads this after
+    -- evaluation to write every input @.drv@ to the store before building.
+    esDrvClosure :: !(IORef (Map Text Text)),
     -- | Cache of source path → its store path (recursive NAR hash), so a path
     -- literal used across many derivations is hashed only once.
     esSourcePathCache :: !(IORef (Map Text Text)),
@@ -113,6 +118,7 @@ newEvalState :: FilePath -> IO EvalState
 newEvalState baseDir = do
   cache <- newIORef Map.empty
   drvCache <- newIORef Map.empty
+  drvClosure <- newIORef Map.empty
   srcCache <- newIORef Map.empty
   now <- floor <$> getPOSIXTime :: IO Int64
   nixPathStr <- lookupEnvText "NIX_PATH"
@@ -123,6 +129,7 @@ newEvalState baseDir = do
     EvalState
       { esImportCache = cache,
         esDrvModuloCache = drvCache,
+        esDrvClosure = drvClosure,
         esSourcePathCache = srcCache,
         esBaseDir = baseDir,
         esStoreDir = T.unpack SP.platformStoreDirText,
@@ -219,6 +226,10 @@ instance MonadEval EvalIO where
     ref <- asks esDrvModuloCache
     liftIO (modifyIORef' ref (Map.insert key val))
 
+  recordDrvAterm key aterm = EvalIO $ do
+    ref <- asks esDrvClosure
+    liftIO (modifyIORef' ref (Map.insert key aterm))
+
   storeSourcePath rawPath = do
     ref <- EvalIO (asks esSourcePathCache)
     cached <- EvalIO (liftIO (Map.lookup rawPath <$> readIORef ref))
@@ -246,6 +257,11 @@ instance MonadEval EvalIO where
     when (T.any (== '\0') name) $
       throwEvalError ("writeToStore: name must not contain null bytes: " <> name)
     storeDir <- EvalIO (asks esStoreDir)
+    -- The preimage is built inline against the LIVE storeDir (esStoreDir), not
+    -- via Nix.Hash.makeStorePath which pins the canonical defaultStoreDir for
+    -- cross-platform .drv-hash parity.  toFile outputs are host-local, so they
+    -- must use the running store dir — keep this format in sync with
+    -- makeStorePath's preimage (type:sha256:hex:storeDir:name).
     let contentHash = sha256Hex (encodeUtf8 contents)
         inner = "nix-store:sha256:" <> contentHash <> ":" <> T.pack storeDir <> ":" <> name
         pathHash = truncatedBase32 (encodeUtf8 inner)
@@ -315,6 +331,8 @@ instance MonadEval EvalIO where
     when (T.any (== '\0') name) $
       throwEvalError ("copyPathToStore: name must not contain null bytes: " <> name)
     storeDir <- EvalIO (asks esStoreDir)
+    -- Inline host-local store-path preimage (see writeToStore's note): uses the
+    -- live esStoreDir, not makeStorePath's pinned defaultStoreDir.
     let contentHash = sha256Hex (encodeUtf8 ("source:" <> srcPath <> ":" <> name))
         inner = "nix-store:sha256:" <> contentHash <> ":" <> T.pack storeDir <> ":" <> name
         pathHash = truncatedBase32 (encodeUtf8 inner)
@@ -407,22 +425,22 @@ readComputed :: CThunkPtr -> IO NixValue
 readComputed ptr = do
   tag <- cthunkValueTag ptr
   case tag of
-    0 {- INT -} -> VInt <$> cthunkGetInt ptr
-    1 {- FLOAT -} -> VFloat <$> cthunkGetFloat ptr
-    2 {- BOOL -} -> (\b -> VBool (b /= 0)) <$> cthunkGetBool ptr
-    3 {- NULL -} -> pure VNull
-    4 {- STR -} -> do
+    ValueInt -> VInt <$> cthunkGetInt ptr
+    ValueFloat -> VFloat <$> cthunkGetFloat ptr
+    ValueBool -> (\b -> VBool (b /= 0)) <$> cthunkGetBool ptr
+    ValueNull -> pure VNull
+    ValueStr -> do
       sym <- cthunkGetStr ptr
       pure (VStr (symbolText (Symbol sym)) emptyContext)
-    5 {- PATH -} -> VPath . symbolText . Symbol <$> cthunkGetPath ptr
-    6 {- LIST -} -> do
+    ValuePath -> VPath . symbolText . Symbol <$> cthunkGetPath ptr
+    ValueList -> do
       listPtr <- cthunkGetList ptr
       pure (VList (CList (castPtr listPtr)))
-    7 {- ATTRS -} -> VAttrs . AttrSet . castPtr <$> cthunkGetAttrs ptr
-    8 {- CTXSTR -} -> do
+    ValueAttrs -> VAttrs . AttrSet . castPtr <$> cthunkGetAttrs ptr
+    ValueCtxStr -> do
       csptr <- cthunkGetCtxStr ptr
       uncurry VStr <$> unmarshalStringContext (castPtr csptr)
-    9 {- LAMBDA -} -> do
+    ValueLambda -> do
       lamPtr <- cthunkGetLambda ptr
       unmarshalLambdaValue lamPtr
     _ {- PTR -} -> do

--- a/src/Nix/Eval/StringInterp.hs
+++ b/src/Nix/Eval/StringInterp.hs
@@ -76,34 +76,36 @@ chunksStrip n = go True 0
       | c == '\n' = ('\n' : acc, True, 0)
       | otherwise = (c : acc, False, dropped)
 
--- | Coerce a Nix value to a string for interpolation.
+-- | Coerce a Nix value to a string.
 --
--- Strict coercion: strings, ints, floats, paths, null, bools, and
--- attribute sets with @__toString@ or @outPath@.
--- Lists and functions without coercion metadata are errors.
--- Used by string interpolation (@"${...}"@) and @builtins.toString@.
-coerceToString :: (MonadEval m) => Force m -> Apply m -> NixValue -> m (Text, StringContext)
-coerceToString _ _ (VStr s ctx) = pure (s, ctx)
-coerceToString _ _ (VInt n) = pure (T.pack (show n), emptyContext)
-coerceToString _ _ (VFloat n) = pure (formatNixFloat n, emptyContext)
-coerceToString _ _ (VPath p) = pure (p, emptyContext)
-coerceToString _ _ VNull = pure ("", emptyContext)
-coerceToString _ _ (VBool True) = pure ("1", emptyContext)
-coerceToString _ _ (VBool False) = pure ("", emptyContext)
--- Attribute sets: try __toString first, then outPath
-coerceToString forceFn applyFn (VAttrs attrs) =
+-- The @coerceMore@ flag mirrors C++ Nix's @coerceToString@ argument: when
+-- 'True' (e.g. @builtins.toString@, derivation-env values) ints, floats, bools
+-- and null coerce permissively; when 'False' (string interpolation,
+-- @builtins.concatStringsSep@) those are type errors, matching C++ Nix.
+-- Strings, paths, and attribute sets with @__toString@/@outPath@ coerce in
+-- both modes; lists and bare functions are always errors.
+coerceToString :: (MonadEval m) => Bool -> Force m -> Apply m -> NixValue -> m (Text, StringContext)
+coerceToString _ _ _ (VStr s ctx) = pure (s, ctx)
+coerceToString _ _ _ (VPath p) = pure (p, emptyContext)
+coerceToString True _ _ (VInt n) = pure (T.pack (show n), emptyContext)
+coerceToString True _ _ (VFloat n) = pure (formatNixFloat n, emptyContext)
+coerceToString True _ _ VNull = pure ("", emptyContext)
+coerceToString True _ _ (VBool True) = pure ("1", emptyContext)
+coerceToString True _ _ (VBool False) = pure ("", emptyContext)
+-- Attribute sets: try __toString first, then outPath (both modes).
+coerceToString coerceMore forceFn applyFn (VAttrs attrs) =
   case attrSetLookup "__toString" attrs of
     Just toStrThunk -> do
       toStrFn <- forceFn toStrThunk
       result <- applyFn toStrFn (VAttrs attrs)
-      coerceToString forceFn applyFn result
+      coerceToString coerceMore forceFn applyFn result
     Nothing -> case attrSetLookup "outPath" attrs of
       Just outPathThunk -> do
         outPathVal <- forceFn outPathThunk
-        coerceToString forceFn applyFn outPathVal
+        coerceToString coerceMore forceFn applyFn outPathVal
       Nothing ->
         throwEvalError "cannot coerce a set to a string (missing __toString or outPath)"
-coerceToString _ _ other =
+coerceToString _ _ _ other =
   throwEvalError ("cannot coerce " <> typeName other <> " to a string")
 
 -- | Format a float the way C++ Nix does: 6 fixed decimal places

--- a/src/Nix/Eval/Types.hs
+++ b/src/Nix/Eval/Types.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE PatternSynonyms #-}
 
 -- | Shared types for the Nix evaluator.
 --
@@ -83,9 +84,25 @@ module Nix.Eval.Types
     -- * Display
     typeName,
 
+    -- * C thunk-state and value tags (mirror cbits/nn_thunk.h)
+    pattern ThunkPending,
+    pattern ThunkComputed,
+    pattern ThunkBlackhole,
+    pattern ValueInt,
+    pattern ValueFloat,
+    pattern ValueBool,
+    pattern ValueNull,
+    pattern ValueStr,
+    pattern ValuePath,
+    pattern ValueList,
+    pattern ValueAttrs,
+    pattern ValueCtxStr,
+    pattern ValueLambda,
+
     -- * Evaluation monad
     MonadEval (..),
-    PureEval (..),
+    PureEval,
+    runPureEval,
   )
 where
 
@@ -181,11 +198,11 @@ newtype Thunk = Thunk {unThunk :: CThunkPtr}
 instance Show Thunk where
   show (Thunk ptr) =
     case unsafePerformIO (cthunkState ptr) of
-      1 {- COMPUTED -} -> case readThunkValue (Thunk ptr) of
+      ThunkComputed -> case readThunkValue (Thunk ptr) of
         Just val -> "Thunk (" ++ show val ++ ")"
         Nothing -> "Thunk <computed?>"
-      0 -> "Thunk <pending>"
-      2 -> "Thunk <blackhole>"
+      ThunkPending -> "Thunk <pending>"
+      ThunkBlackhole -> "Thunk <blackhole>"
       _ -> "Thunk <unknown>"
 
 -- | Equality: pointer identity fast path, then value comparison for
@@ -197,6 +214,31 @@ instance Eq Thunk where
         (Just v1, Just v2) -> v1 == v2
         _ -> False
 
+-- | Named constants for the C thunk-state byte and value-tag byte, mirroring
+-- the @NN_THUNK_*@ / @NN_VALUE_*@ macros in @cbits\/nn_thunk.h@.  Bidirectional
+-- pattern synonyms over literals, so a @case@ on a tag keeps the jump-table
+-- compilation a bare-literal @case@ gets, while the three thunk-dispatch sites
+-- ('readThunkValue', @PureEval@'s 'forceThunk', and @Nix.Eval.IO@'s
+-- @readComputed@) share one source of truth instead of triplicating literals.
+-- These MUST stay in lockstep with @cbits\/nn_thunk.h@.  The remaining value
+-- tag (PTR, a StablePtr payload) is the wildcard at each dispatch site.
+pattern ThunkPending, ThunkComputed, ThunkBlackhole :: Word8
+pattern ThunkPending = 0
+pattern ThunkComputed = 1
+pattern ThunkBlackhole = 2
+
+pattern ValueInt, ValueFloat, ValueBool, ValueNull, ValueStr, ValuePath, ValueList, ValueAttrs, ValueCtxStr, ValueLambda :: Word8
+pattern ValueInt = 0
+pattern ValueFloat = 1
+pattern ValueBool = 2
+pattern ValueNull = 3
+pattern ValueStr = 4
+pattern ValuePath = 5
+pattern ValueList = 6
+pattern ValueAttrs = 7
+pattern ValueCtxStr = 8
+pattern ValueLambda = 9
+
 -- | Read a COMPUTED thunk's value without forcing.
 -- Returns 'Nothing' for PENDING or BLACKHOLE thunks.
 -- Uses 'unsafePerformIO' — safe because C reads are idempotent.
@@ -204,25 +246,25 @@ readThunkValue :: Thunk -> Maybe NixValue
 readThunkValue (Thunk ptr) =
   unsafePerformIO $ do
     state <- cthunkState ptr
-    if state /= 1
+    if state /= ThunkComputed
       then pure Nothing
       else do
         tag <- cthunkValueTag ptr
         fmap Just $ case tag of
-          0 {- INT -} -> VInt <$> cthunkGetInt ptr
-          1 {- FLOAT -} -> VFloat <$> cthunkGetFloat ptr
-          2 {- BOOL -} -> (\b -> VBool (b /= 0)) <$> cthunkGetBool ptr
-          3 {- NULL -} -> pure VNull
-          4 {- STR -} -> (\sym -> VStr (symbolText (Symbol sym)) emptyContext) <$> cthunkGetStr ptr
-          5 {- PATH -} -> VPath . symbolText . Symbol <$> cthunkGetPath ptr
-          6 {- LIST -} -> do
+          ValueInt -> VInt <$> cthunkGetInt ptr
+          ValueFloat -> VFloat <$> cthunkGetFloat ptr
+          ValueBool -> (\b -> VBool (b /= 0)) <$> cthunkGetBool ptr
+          ValueNull -> pure VNull
+          ValueStr -> (\sym -> VStr (symbolText (Symbol sym)) emptyContext) <$> cthunkGetStr ptr
+          ValuePath -> VPath . symbolText . Symbol <$> cthunkGetPath ptr
+          ValueList -> do
             listPtr <- cthunkGetList ptr
             pure (VList (CList (castPtr listPtr)))
-          7 {- ATTRS -} -> VAttrs . AttrSet . castPtr <$> cthunkGetAttrs ptr
-          8 {- CTXSTR -} -> do
+          ValueAttrs -> VAttrs . AttrSet . castPtr <$> cthunkGetAttrs ptr
+          ValueCtxStr -> do
             csptr <- cthunkGetCtxStr ptr
             uncurry VStr <$> unmarshalStringContext (castPtr csptr)
-          9 {- LAMBDA -} -> do
+          ValueLambda -> do
             lamRaw <- cthunkPayload ptr
             unmarshalLambdaValue (castPtr lamRaw)
           _ {- PTR -} -> do
@@ -407,7 +449,7 @@ fillCAttrSetValues cset thunkMap = unsafePerformIO $
 
 -- | Evaluation environment — C-backed scope chain.
 --
--- Arena-allocated @nn_env_t@ struct (40 bytes, zero GC overhead).
+-- Arena-allocated @nn_env_t@ struct (48 bytes, zero GC overhead).
 -- All env data (slots, lazy scope, parent, with-scopes) lives in C.
 -- Haskell holds only the pointer.  Variable lookup has two paths:
 --
@@ -1059,22 +1101,47 @@ class (Monad m) => MonadEval m where
   -- A no-op in pure evaluators (no memoization).
   cacheDrvHash :: Text -> Text -> m ()
 
+  -- | Record a derivation's serialized @.drv@ ATerm under its @.drv@ store
+  -- path, as each derivation is computed (bottom-up).  Unlike 'cacheDrvHash'
+  -- (which stores only the modulo hash), this retains the full ATerm so the
+  -- build driver can materialize the entire input-@.drv@ closure to the store
+  -- before a dependency-aware build.  A no-op in pure evaluators.
+  recordDrvAterm :: Text -> Text -> m ()
+
   -- | Compute the store path a source file/directory gets when copied into
   -- the store (recursive NAR sha256 → @source@ fixed-output path), WITHOUT
   -- performing the copy.  Used when a path literal is coerced in a derivation
   -- argument or environment value.  Unavailable in pure evaluation.
   storeSourcePath :: Text -> m Text
 
--- | Pure evaluation monad — wraps 'Either Text'.
+-- | Error raised during pure evaluation.  'PAbort' (from @abort@ and infinite
+-- recursion) must escape 'tryEval' exactly as in C++ Nix; 'PThrow' is catchable.
+data PureError = PThrow !Text | PAbort !Text
+
+-- | Pure evaluation monad — wraps @Either PureError@.
 -- IO builtins ('readFile', 'import') are unavailable;
 -- everything else evaluates identically to the IO version.
-newtype PureEval a = PureEval {runPureEval :: Either Text a}
+newtype PureEval a = PureEval (Either PureError a)
   deriving (Functor, Applicative, Monad)
 
+-- | Run a pure evaluation, flattening the internal error into 'Text'.  An abort
+-- is prefixed @\"evaluation aborted: \"@, matching 'EvalIO'.
+runPureEval :: PureEval a -> Either Text a
+runPureEval (PureEval (Right a)) = Right a
+runPureEval (PureEval (Left (PThrow t))) = Left t
+runPureEval (PureEval (Left (PAbort t))) = Left ("evaluation aborted: " <> t)
+
 instance MonadEval PureEval where
-  throwEvalError msg = PureEval (Left msg)
-  abortEvaluation msg = PureEval (Left ("evaluation aborted: " <> msg))
-  catchEvalError (PureEval action) = PureEval (Right action)
+  throwEvalError msg = PureEval (Left (PThrow msg))
+  abortEvaluation msg = PureEval (Left (PAbort msg))
+
+  -- Catch a throw (tryEval sees the error), but let an abort / infinite
+  -- recursion propagate past tryEval, matching EvalIO and C++ Nix.
+  catchEvalError (PureEval action) =
+    PureEval $ case action of
+      Left (PThrow t) -> Right (Left t)
+      Left (PAbort t) -> Left (PAbort t)
+      Right a -> Right (Right a)
   readFileText _ = throwEvalError "readFile: not available in pure evaluation"
   doesPathExist _ = pure False
   listDirectory _ = throwEvalError "builtins.readDir: not available in pure evaluation"
@@ -1090,6 +1157,7 @@ instance MonadEval PureEval where
   traceMessage _ = pure ()
   lookupDrvHash _ = pure Nothing
   cacheDrvHash _ _ = pure ()
+  recordDrvAterm _ _ = pure ()
 
   -- Pure eval cannot read files: a path coerces to itself (no store copy);
   -- the real copy-to-store happens only under 'EvalIO'.
@@ -1101,30 +1169,30 @@ instance MonadEval PureEval where
     -- Does NOT mark blackholes — PureEval may re-force the same thunk.
     -- Dispatches on val_tag for computed scalars (no StablePtr deref).
     case unsafePerformIO (cthunkState ptr) of
-      1 {- COMPUTED -} ->
+      ThunkComputed ->
         let tag = unsafePerformIO (cthunkValueTag ptr)
          in case tag of
-              0 {- INT -} -> pure (VInt (unsafePerformIO (cthunkGetInt ptr)))
-              1 {- FLOAT -} -> pure (VFloat (unsafePerformIO (cthunkGetFloat ptr)))
-              2 {- BOOL -} -> pure (VBool (unsafePerformIO (cthunkGetBool ptr) /= 0))
-              3 {- NULL -} -> pure VNull
-              4 {- STR -} ->
+              ValueInt -> pure (VInt (unsafePerformIO (cthunkGetInt ptr)))
+              ValueFloat -> pure (VFloat (unsafePerformIO (cthunkGetFloat ptr)))
+              ValueBool -> pure (VBool (unsafePerformIO (cthunkGetBool ptr) /= 0))
+              ValueNull -> pure VNull
+              ValueStr ->
                 let sym = unsafePerformIO (cthunkGetStr ptr)
                  in pure (VStr (symbolText (Symbol sym)) emptyContext)
-              5 {- PATH -} ->
+              ValuePath ->
                 let sym = unsafePerformIO (cthunkGetPath ptr)
                  in pure (VPath (symbolText (Symbol sym)))
-              6 {- LIST -} ->
+              ValueList ->
                 let listPtr = unsafePerformIO (cthunkGetList ptr)
                  in pure (VList (CList (castPtr listPtr)))
-              7 {- ATTRS -} ->
+              ValueAttrs ->
                 let p = unsafePerformIO (cthunkGetAttrs ptr)
                  in pure (VAttrs (AttrSet (castPtr p)))
-              8 {- CTXSTR -} ->
+              ValueCtxStr ->
                 let csptr = unsafePerformIO (cthunkGetCtxStr ptr)
                     (t, ctx) = unsafePerformIO (unmarshalStringContext (castPtr csptr))
                  in pure (VStr t ctx)
-              9 {- LAMBDA -} ->
+              ValueLambda ->
                 let lamRaw = unsafePerformIO (cthunkPayload ptr)
                     val = unsafePerformIO (unmarshalLambdaValue lamRaw)
                  in pure val
@@ -1132,7 +1200,7 @@ instance MonadEval PureEval where
                 let payload = unsafePerformIO (cthunkPayload ptr)
                     val = unsafePerformIO (deRefStablePtr (castPtrToStablePtr payload))
                  in pure val
-      2 {- BLACKHOLE -} ->
+      ThunkBlackhole ->
         -- Non-catchable: must escape tryEval like in C++ Nix
         abortEvaluation "infinite recursion encountered"
       _ {- PENDING -} ->

--- a/src/Nix/Hash.hs
+++ b/src/Nix/Hash.hs
@@ -26,15 +26,10 @@
 --   network transfer integrity.
 --
 -- nova-cache already handles output hashes and file hashes.  This module
--- adds input hash (derivation hash) computation for the evaluator, plus
--- the @makeStorePath@ family that constructs content-addressed store paths
--- exactly as C++ Nix does.
+-- provides the shared hashing utilities and the @makeStorePath@ family that
+-- constructs content-addressed store paths exactly as C++ Nix does.
 module Nix.Hash
-  ( -- * Derivation hashing
-    DrvHash (..),
-    hashDerivation,
-
-    -- * Shared hashing utilities
+  ( -- * Shared hashing utilities
     sha256Hex,
     truncatedBase32,
     hashPlaceholder,
@@ -72,24 +67,6 @@ import Data.Word (Word8)
 import Nix.Store.Path (StoreDir (..), StorePath (..), defaultStoreDir, storePathToText)
 import NovaCache.Base32 (encode)
 import NovaCache.Hash (formatNixHash, hashBytes, parseNixHash)
-
--- | A derivation hash — the input hash that determines the store path.
--- This is computed from the derivation's inputs, NOT from the build output.
--- Stored as the Nix-formatted hash string (e.g. "sha256:0abc...").
-newtype DrvHash = DrvHash {unDrvHash :: Text}
-  deriving (Eq, Show)
-
--- | Hash a serialized derivation (.drv file contents) to produce the
--- input hash used in store path computation.
---
--- The derivation is first converted to ATerm format, then SHA-256 hashed,
--- then truncated to 160 bits (20 bytes) and encoded in Nix base-32.
--- This produces the 32-character hash in the store path.
-hashDerivation :: Text -> DrvHash
-hashDerivation drvText =
-  let drvBytes = encodeUtf8 drvText
-      nixHash = hashBytes drvBytes
-   in DrvHash (formatNixHash nixHash)
 
 -- | SHA-256 hex digest of a ByteString.
 sha256Hex :: BS.ByteString -> Text

--- a/src/Nix/Parser/Expr.hs
+++ b/src/Nix/Parser/Expr.hs
@@ -7,7 +7,11 @@
 -- ! / + - / * \\/ / ++ / ? / negate / application / selection
 -- @
 --
--- Matches the C++ Nix parser (parser.y) precedence exactly.
+-- Close to the C++ Nix parser (parser.y), with two inert deviations: here
+-- @++@ binds looser than multiplication\/addition (parser.y binds it tighter)
+-- and unary negate binds looser than @?@ (parser.y makes negate tightest).
+-- Both only affect mixed expressions that are type errors regardless, so no
+-- program that type-checks parses differently.
 -- Entirely pure. No IO, no Megaparsec, no Parsec.
 module Nix.Parser.Expr
   ( -- * Entry point

--- a/src/Nix/Parser/Lexer.hs
+++ b/src/Nix/Parser/Lexer.hs
@@ -175,6 +175,9 @@ lexNormalMode st acc = case T.uncons (lsInput st) of
         Just c2 <- safeHead (T.drop 1 rest),
         c2 == '/' ->
           lexPath st acc
+      | Just d <- safeHead rest,
+        isDigit d ->
+          lexLeadingDotFloat st acc
     '.' -> emit1 st TokDot acc
     ',' -> emit1 st TokComma acc
     ';' -> emit1 st TokSemicolon acc
@@ -474,16 +477,28 @@ lexNumber st acc =
           | Just (d, _) <- T.uncons after2,
             isDigit d ->
               let (decimals, after3) = T.span isDigit after2
-                  fullLen = T.length digits + 1 + T.length decimals
-                  val = readDouble digits decimals
+                  (expVal, after4, expLen) = lexExponent after3
+                  fullLen = T.length digits + 1 + T.length decimals + expLen
+                  val = applyExponent (readDouble digits decimals) expVal
                   tok = Located (lsLine st) (lsCol st) (TokFloat val)
-                  newSt = advanceCol fullLen st {lsInput = after3}
+                  newSt = advanceCol fullLen st {lsInput = after4}
                in lexNormalMode newSt (tok : acc)
-        _ ->
-          let val = fromIntegral (readInteger digits) :: Int64
-              tok = Located (lsLine st) (lsCol st) (TokInt val)
-              newSt = advanceCol len st {lsInput = after}
-           in lexNormalMode newSt (tok : acc)
+        _
+          -- C++ Nix rejects out-of-range integer literals rather than
+          -- silently wrapping modulo 2^64.
+          | readInteger digits > toInteger (maxBound :: Int64) ->
+              Left
+                ParseError
+                  { peFile = lsFile st,
+                    peLine = lsLine st,
+                    peCol = lsCol st,
+                    peMessage = "integer literal out of range: " <> digits
+                  }
+          | otherwise ->
+              let val = fromIntegral (readInteger digits) :: Int64
+                  tok = Located (lsLine st) (lsCol st) (TokInt val)
+                  newSt = advanceCol len st {lsInput = after}
+               in lexNormalMode newSt (tok : acc)
 
 -- | Read an integer from text without using the partial 'read'.
 readInteger :: Text -> Integer
@@ -497,6 +512,42 @@ readDouble intPart decPart =
       fracDigits = T.length decPart
       frac = fromIntegral (readInteger decPart) / (decimalBase' ^ fracDigits)
    in whole + frac
+
+-- | Consume an optional exponent @[eE][+-]?[0-9]+@ after a float's digits.
+-- Returns the signed exponent, the remaining input, and the characters
+-- consumed.  An @e@ not followed by digits is not an exponent (consumes 0), so
+-- e.g. @1.5e@ lexes as the float @1.5@ followed by the identifier @e@.
+lexExponent :: Text -> (Integer, Text, Int)
+lexExponent input =
+  case T.uncons input of
+    Just (e, afterE)
+      | e == 'e' || e == 'E' ->
+          let (sign, afterSign, signLen) = case T.uncons afterE of
+                Just ('+', rest) -> (1, rest, 1)
+                Just ('-', rest) -> (-1, rest, 1)
+                _ -> (1, afterE, 0)
+              (expDigits, afterExp) = T.span isDigit afterSign
+           in if T.null expDigits
+                then (0, input, 0)
+                else (sign * readInteger expDigits, afterExp, 1 + signLen + T.length expDigits)
+    _ -> (0, input, 0)
+
+-- | Scale a float mantissa by @10 ^^ exp@ (exp may be negative).
+applyExponent :: Double -> Integer -> Double
+applyExponent mantissa expVal = mantissa * (10 ^^ expVal)
+
+-- | Lex a leading-dot float like @.5@ or @.5e3@ (Nix's @0?\\.[0-9]+@ form).
+-- The current input begins with the @.@.
+lexLeadingDotFloat :: LexState -> [Located] -> Either ParseError [Located]
+lexLeadingDotFloat st acc =
+  let afterDot = T.drop 1 (lsInput st)
+      (decimals, after3) = T.span isDigit afterDot
+      (expVal, after4, expLen) = lexExponent after3
+      fullLen = 1 + T.length decimals + expLen
+      val = applyExponent (readDouble "" decimals) expVal
+      tok = Located (lsLine st) (lsCol st) (TokFloat val)
+      newSt = advanceCol fullLen st {lsInput = after4}
+   in lexNormalMode newSt (tok : acc)
 
 -- | Base for decimal digit accumulation.
 decimalBase :: Integer

--- a/src/Nix/Store.hs
+++ b/src/Nix/Store.hs
@@ -42,9 +42,13 @@ module Nix.Store
 
     -- * Store operations
     addToStore,
+    placeInStore,
+    registrationFor,
     scanReferences,
+    scanTempReferences,
     setReadOnly,
     writeDrv,
+    writeDrvAterm,
 
     -- * Re-exports
     module Nix.Store.Path,
@@ -123,25 +127,46 @@ addToStore ::
   [StorePath] ->
   IO ()
 addToStore store srcPath sp deriver refs = do
+  reg <- placeInStore store srcPath sp deriver refs
+  registerPath (stDB store) reg
+
+-- | Move a build output into the store (read-only) and compute its
+-- registration (NAR hash, size, references) WITHOUT writing to the database.
+--
+-- Splitting placement from registration lets a multi-output build place every
+-- output first and then register them together, so intra-derivation
+-- cross-output references are preserved (see 'registerPaths').
+placeInStore ::
+  Store ->
+  FilePath ->
+  StorePath ->
+  Maybe Text ->
+  [StorePath] ->
+  IO PathRegistration
+placeInStore store srcPath sp deriver refs = do
   let destPath = storePathToFilePath (stDir store) sp
   -- Move (or copy) source to store
   moveOutput srcPath destPath
   -- Set read-only permissions
   setReadOnly destPath
+  registrationFor store sp deriver refs
+
+-- | Compute the registration metadata for a store path already present on
+-- disk, without moving anything.  Used to (re-)register an output that an
+-- interrupted build left in place but never recorded in the database.
+registrationFor :: Store -> StorePath -> Maybe Text -> [StorePath] -> IO PathRegistration
+registrationFor store sp deriver refs = do
+  let destPath = storePathToFilePath (stDir store) sp
   -- Compute the NAR hash and size of the final store contents.  The NAR
-  -- serialization is canonical (entries sorted, 8-byte padding), so this
-  -- is exactly the NarHash/NarSize a binary cache reports for the path.
+  -- serialization is canonical (entries sorted, 8-byte padding), so this is
+  -- exactly the NarHash/NarSize a binary cache reports for the path.
   narEntry <- NAR.serialiseFromPath destPath
   let narBytes = NAR.serialise narEntry
-      narHashText = Hash.formatNixHash (Hash.hashBytes narBytes)
-      narSize = BS.length narBytes
-  -- Register in database
-  registerPath
-    (stDB store)
+  pure
     PathRegistration
       { prPath = sp,
-        prNarHash = narHashText,
-        prNarSize = narSize,
+        prNarHash = Hash.formatNixHash (Hash.hashBytes narBytes),
+        prNarSize = BS.length narBytes,
         prDeriver = deriver,
         prReferences = refs
       }
@@ -185,20 +210,38 @@ scanReferences :: StoreDir -> [StorePath] -> FilePath -> IO [StorePath]
 scanReferences storeDir candidates dir = do
   let candidateSet = Set.fromList [(spHash sp, sp) | sp <- candidates]
       storeDirStr = unStoreDir storeDir
-      -- Scan for both forward-slash and backslash store prefixes.
-      -- On Windows, binaries may contain either separator style.
+      -- Scan for both forward-slash and backslash store prefixes.  On Windows,
+      -- binaries may contain either separator style.  Both separators are a
+      -- single ASCII byte, so the two prefixes share a length.
       prefixFwd = TE.encodeUtf8 (T.pack (storeDirStr <> "/"))
       prefixBwd = TE.encodeUtf8 (T.pack (storeDirStr <> "\\"))
-      prefixBytes = prefixFwd
-      prefixLen = BS.length prefixBytes
-      hashLen = 32
+      prefixLen = BS.length prefixFwd
   files <- collectRegularFiles dir
   foundHashes <- foldlIO Set.empty files $ \acc filePath -> do
     contents <- BS.readFile filePath
     -- Scan with forward-slash prefix, then backslash (for Windows)
-    let acc1 = scanBytes prefixFwd prefixLen hashLen contents acc
-    pure (scanBytes prefixBwd prefixLen hashLen contents acc1)
+    let acc1 = scanBytes prefixFwd prefixLen storePathHashLen contents acc
+    pure (scanBytes prefixBwd prefixLen storePathHashLen contents acc1)
   pure [sp | (h, sp) <- Set.toList candidateSet, Set.member h foundHashes]
+
+-- | Scan an output for references to build-temp output locations.
+--
+-- The builder runs under a temp directory, so an output that embeds its own or
+-- a sibling output's path embeds the TEMP path — which 'scanReferences' (store
+-- prefix only) cannot see.  Given @(tempDir, storePath)@ for every output of
+-- the derivation, returns the store paths whose temp location is referenced
+-- from the scanned output, capturing self- and cross-output references.
+--
+-- This records the dependency edge; it does not rewrite the embedded bytes
+-- (self-reference hash rewriting is a separate, future concern).
+scanTempReferences :: [(FilePath, StorePath)] -> FilePath -> IO [StorePath]
+scanTempReferences tempPairs dir = do
+  let needles = [(TE.encodeUtf8 (T.pack tempDir), sp) | (tempDir, sp) <- tempPairs]
+  files <- collectRegularFiles dir
+  foundHashes <- foldlIO Set.empty files $ \acc filePath -> do
+    contents <- BS.readFile filePath
+    pure (Set.union acc (Set.fromList [spHash sp | (needle, sp) <- needles, needle `BS.isInfixOf` contents]))
+  pure [sp | (_, sp) <- tempPairs, Set.member (spHash sp) foundHashes]
 
 -- | Collect all regular files under a path, recursively.
 -- If the path is itself a regular file, returns it directly.
@@ -244,7 +287,13 @@ foldlIO z (x : xs) f = do
   acc <- f z x
   foldlIO acc xs f
 
--- | Recursively set a directory and all its contents to read-only.
+-- | Recursively mark a store path and its contents read-only after a build.
+--
+-- On Windows the directory read-only attribute does not prevent adding or
+-- removing entries — only the per-file read-only attribute protects a file.
+-- Immutability here is therefore enforced at FILE granularity (every file is
+-- made read-only); hardening the directory itself against entry changes would
+-- require ACLs and is deferred.
 setReadOnly :: FilePath -> IO ()
 setReadOnly path = do
   isDir <- doesDirectoryExist path
@@ -260,10 +309,16 @@ setReadOnly path = do
         perms <- Dir.getPermissions path
         setPermissions path (Dir.setOwnerWritable False perms)
 
--- | Serialize a derivation to ATerm and write it to the store at the given path.
-writeDrv :: Store -> Derivation -> StorePath -> IO ()
-writeDrv store drv sp = do
+-- | Write an already-serialized derivation ATerm to its store path.  Used to
+-- materialize the input @.drv@ closure (root plus every transitive input)
+-- before a dependency-aware build: evaluation computes these ATerms but does
+-- no store IO, so the build driver writes them here.
+writeDrvAterm :: Store -> StorePath -> Text -> IO ()
+writeDrvAterm store sp aterm = do
   let destPath = storePathToFilePath (stDir store) sp
-      aterm = toATerm drv
   createDirectoryIfMissing True (unStoreDir (stDir store))
   TIO.writeFile destPath aterm
+
+-- | Serialize a derivation to ATerm and write it to the store at the given path.
+writeDrv :: Store -> Derivation -> StorePath -> IO ()
+writeDrv store drv sp = writeDrvAterm store sp (toATerm drv)

--- a/src/Nix/Store/DB.hs
+++ b/src/Nix/Store/DB.hs
@@ -22,7 +22,7 @@
 -- @\/nix\/store\/.nova-nix\/db.sqlite@ (or @C:\\nix\\store\\.nova-nix\\db.sqlite@).
 module Nix.Store.DB
   ( -- * Database handle
-    StoreDB (..),
+    StoreDB,
 
     -- * Types
     PathRegistration (..),
@@ -34,6 +34,7 @@ module Nix.Store.DB
 
     -- * Registration
     registerPath,
+    registerPaths,
     isValidPath,
     queryReferences,
     queryDeriver,
@@ -159,26 +160,46 @@ closeStoreDB db = close (sdbConn db)
 -- Registration
 -- ---------------------------------------------------------------------------
 
--- | Register a store path as valid with its metadata and references.
--- Uses a transaction for atomicity.  Idempotent — re-registering an
--- existing path is a no-op (INSERT OR IGNORE).
+-- | Register a single store path as valid with its metadata and references.
+-- A convenience wrapper over 'registerPaths' for one path.
 registerPath :: StoreDB -> PathRegistration -> IO ()
-registerPath db reg = withTransaction (sdbConn db) $ do
+registerPath db reg = registerPaths db [reg]
+
+-- | Register several store paths as valid in one transaction.
+--
+-- ALL path rows are inserted BEFORE any reference edge, so references among the
+-- paths in this batch — e.g. intra-derivation cross-output references — are
+-- never dropped.  (Registering one path at a time loses an edge whenever a
+-- referrer is registered before its referent.)
+--
+-- Re-registering an existing path refreshes its metadata (NAR hash, size,
+-- deriver) via @ON CONFLICT DO UPDATE@, so a path first registered with a
+-- placeholder hash is corrected on a later real registration.
+registerPaths :: StoreDB -> [PathRegistration] -> IO ()
+registerPaths db regs = withTransaction (sdbConn db) $ do
+  mapM_ (insertPathRow db) regs
+  mapM_ (insertPathRefs db) regs
+
+-- | Insert (or refresh) a single ValidPaths row.
+insertPathRow :: StoreDB -> PathRegistration -> IO ()
+insertPathRow db reg = do
+  let pathText = T.pack (storePathToFilePath (sdbDir db) (prPath reg))
+  execute
+    (sdbConn db)
+    "INSERT INTO ValidPaths (path, hash, registrationTime, deriver, narSize) \
+    \VALUES (?, ?, strftime('%s','now'), ?, ?) \
+    \ON CONFLICT(path) DO UPDATE SET hash = excluded.hash, narSize = excluded.narSize, deriver = excluded.deriver"
+    (pathText, prNarHash reg, prDeriver reg, prNarSize reg)
+
+-- | Insert the reference edges for a path whose row already exists.
+insertPathRefs :: StoreDB -> PathRegistration -> IO ()
+insertPathRefs db reg = do
   let conn = sdbConn db
       pathText = T.pack (storePathToFilePath (sdbDir db) (prPath reg))
-  -- Insert the path (skip if already present)
-  execute
-    conn
-    "INSERT OR IGNORE INTO ValidPaths (path, hash, registrationTime, deriver, narSize) \
-    \VALUES (?, ?, strftime('%s','now'), ?, ?)"
-    (pathText, prNarHash reg, prDeriver reg, prNarSize reg)
-  -- Lookup the referrer's id
   referrerRows <- query conn "SELECT id FROM ValidPaths WHERE path = ?" (Only pathText) :: IO [Only Int]
   case referrerRows of
-    (Only referrerId : _) -> do
-      -- Insert references
-      mapM_ (insertRef conn referrerId) (prReferences reg)
-    [] -> pure () -- Should not happen after INSERT OR IGNORE
+    (Only referrerId : _) -> mapM_ (insertRef conn referrerId) (prReferences reg)
+    [] -> pure () -- Should not happen: the row was just inserted above.
   where
     insertRef conn referrerId refPath = do
       let refPathText = T.pack (storePathToFilePath (sdbDir db) refPath)
@@ -186,7 +207,7 @@ registerPath db reg = withTransaction (sdbConn db) $ do
       case refRows of
         (Only refId : _) ->
           execute conn "INSERT OR IGNORE INTO Refs (referrer, reference) VALUES (?, ?)" (referrerId, refId)
-        [] -> pure () -- Reference not yet registered — skip
+        [] -> pure () -- Reference not in this batch or the store yet — skip.
 
 -- ---------------------------------------------------------------------------
 -- Queries

--- a/src/Nix/Substituter.hs
+++ b/src/Nix/Substituter.hs
@@ -42,6 +42,8 @@ module Nix.Substituter
     -- * Pure helpers (exported for testing)
     sortCaches,
     verifySigs,
+    verifyNarHash,
+    narInfoMatchesPath,
     decompressNar,
     unpackNarEntry,
     parseReferences,
@@ -62,7 +64,8 @@ import qualified Network.HTTP.Client.TLS as HTTPS
 import qualified Network.HTTP.Types.Status as HTTP
 import Nix.Store (Store (..), setReadOnly)
 import Nix.Store.DB (PathRegistration (..), registerPath)
-import Nix.Store.Path (StoreDir, StorePath (..), parseStorePath, storePathToFilePath)
+import Nix.Store.Path (StoreDir, StorePath (..), parseStorePath, storePathHashLen, storePathToFilePath)
+import qualified NovaCache.Hash as Hash
 import qualified NovaCache.NAR as NAR
 import qualified NovaCache.NarInfo as NarInfo
 import qualified NovaCache.Signing as Signing
@@ -116,7 +119,9 @@ data SubstResult
 trySubstitute :: Store -> [CacheConfig] -> StorePath -> IO SubstResult
 trySubstitute _ [] _ = pure SubstNotFound
 trySubstitute store caches sp = do
-  manager <- HTTPS.newTlsManager
+  -- Reuse the process-global TLS manager (connection pooling / keep-alive)
+  -- rather than creating a fresh one per call and per output.
+  manager <- HTTPS.getGlobalManager
   tryCaches manager (sortCaches caches) sp
   where
     tryCaches _ [] _ = pure SubstNotFound
@@ -145,15 +150,28 @@ substituteFromCache mgr store cache sp = do
   narInfoResult <- fetchNarInfo mgr cache sp
   case narInfoResult of
     Left notFoundOrErr -> pure notFoundOrErr
-    Right narInfo -> do
-      -- 2–4. Verify, download, decompress (pure pipeline after fetch)
-      case verifyAndDecompress cache mgr narInfo of
-        Left err -> pure (SubstError err)
-        Right fetchDecompress -> do
-          narBytes <- fetchDecompress
-          case narBytes of
+    Right narInfo
+      -- 1b. The served narinfo must describe the requested path.  A
+      -- misconfigured or hostile cache could return a validly-signed narinfo
+      -- for a DIFFERENT path under this hash's URL.
+      | not (narInfoMatchesPath sp narInfo) ->
+          pure
+            ( SubstError
+                ( "narinfo identity mismatch: requested "
+                    <> spHash sp
+                    <> ", narinfo names "
+                    <> NarInfo.niStorePath narInfo
+                )
+            )
+      | otherwise ->
+          -- 2–4. Verify, download, decompress (pure pipeline after fetch)
+          case verifyAndDecompress cache mgr narInfo of
             Left err -> pure (SubstError err)
-            Right rawNar -> unpackAndRegister store sp narInfo rawNar
+            Right fetchDecompress -> do
+              narBytes <- fetchDecompress
+              case narBytes of
+                Left err -> pure (SubstError err)
+                Right rawNar -> unpackAndRegister store sp narInfo rawNar
 
 -- | Pure pipeline: verify signature, then produce an IO action
 -- that downloads and decompresses.
@@ -169,28 +187,72 @@ verifyAndDecompress cache mgr narInfo = do
     downloaded <- downloadNar mgr cache narInfo
     pure $ downloaded >>= decompressNar compression
 
--- | Deserialize a NAR, unpack to the store, set permissions, and register.
+-- | Verify the NAR hash, deserialize, unpack to the store, set permissions,
+-- and register.
 unpackAndRegister :: Store -> StorePath -> NarInfo.NarInfo -> BS.ByteString -> IO SubstResult
 unpackAndRegister store sp narInfo rawNar =
-  case NAR.deserialise rawNar of
-    Left err -> pure (SubstError ("NAR deserialisation failed: " <> T.pack err))
-    Right narEntry -> do
-      let destPath = storePathToFilePath (stDir store) sp
-      unpackResult <- try (unpackNarEntry destPath narEntry)
-      case (unpackResult :: Either SomeException ()) of
-        Left err -> pure (SubstError ("unpack failed: " <> T.pack (show err)))
-        Right () -> do
-          setReadOnly destPath
-          registerPath
-            (stDB store)
-            PathRegistration
-              { prPath = sp,
-                prNarHash = NarInfo.niNarHash narInfo,
-                prNarSize = fromInteger (NarInfo.niNarSize narInfo),
-                prDeriver = NarInfo.niDeriver narInfo,
-                prReferences = parseReferences (stDir store) (NarInfo.niReferences narInfo)
-              }
-          pure (SubstSuccess sp)
+  -- Verify the downloaded NAR's hash matches the (signed) narinfo BEFORE
+  -- trusting its bytes.  The NAR hash is the content-addressed integrity
+  -- contract; the signature only attests to the narinfo, not the body, so
+  -- network corruption or a compromised cache must be caught here.
+  case verifyNarHash narInfo rawNar of
+    Left err -> pure (SubstError err)
+    Right () -> case NAR.deserialise rawNar of
+      Left err -> pure (SubstError ("NAR deserialisation failed: " <> T.pack err))
+      Right narEntry -> do
+        let destPath = storePathToFilePath (stDir store) sp
+        unpackResult <- try (unpackNarEntry destPath narEntry)
+        case (unpackResult :: Either SomeException (Either Text ())) of
+          Left err -> pure (SubstError ("unpack failed: " <> T.pack (show err)))
+          Right (Left err) -> pure (SubstError ("unpack failed: " <> err))
+          Right (Right ()) -> do
+            setReadOnly destPath
+            registerPath
+              (stDB store)
+              PathRegistration
+                { prPath = sp,
+                  prNarHash = NarInfo.niNarHash narInfo,
+                  prNarSize = fromInteger (NarInfo.niNarSize narInfo),
+                  prDeriver = NarInfo.niDeriver narInfo,
+                  prReferences = parseReferences (stDir store) (NarInfo.niReferences narInfo)
+                }
+            pure (SubstSuccess sp)
+
+-- | Verify that the downloaded NAR bytes hash to the narinfo's declared
+-- NarHash.  Compares decoded hash bytes, so any valid encoding of the digest
+-- validates; @prNarHash@ stays sourced from the (now-verified) narinfo.
+verifyNarHash :: NarInfo.NarInfo -> BS.ByteString -> Either Text ()
+verifyNarHash narInfo rawNar =
+  case Hash.parseNixHash (NarInfo.niNarHash narInfo) of
+    Left err -> Left ("invalid narinfo NarHash: " <> T.pack err)
+    Right declared
+      | declared == actual -> Right ()
+      | otherwise ->
+          Left
+            ( "NAR hash mismatch: narinfo declares "
+                <> NarInfo.niNarHash narInfo
+                <> " but downloaded bytes hash to "
+                <> Hash.formatNixHash actual
+            )
+  where
+    actual = Hash.hashBytes rawNar
+
+-- | Whether a served narinfo describes the requested path: the hash component
+-- of its declared StorePath must equal the requested path's hash.  Only the
+-- hash is compared, since the cache may use a different store directory.
+narInfoMatchesPath :: StorePath -> NarInfo.NarInfo -> Bool
+narInfoMatchesPath sp narInfo =
+  storePathHashOf (NarInfo.niStorePath narInfo) == Just (spHash sp)
+
+-- | Extract the leading hash from a full store path's basename, if well-formed
+-- (@\<hash\>-\<name\>@ with a hash of the expected length).
+storePathHashOf :: Text -> Maybe Text
+storePathHashOf path =
+  let base = T.takeWhileEnd (\c -> c /= '/' && c /= '\\') path
+      (hashPart, rest) = T.splitAt storePathHashLen base
+   in if T.length hashPart == storePathHashLen && T.isPrefixOf "-" rest
+        then Just hashPart
+        else Nothing
 
 -- ---------------------------------------------------------------------------
 -- HTTP fetching
@@ -221,6 +283,10 @@ fetchNarInfo mgr cache sp = do
         else pure (Left (SubstError ("narinfo fetch failed: HTTP " <> T.pack (show code))))
 
 -- | Download the NAR file referenced by a narinfo.
+--
+-- The whole NAR is realized in memory (nova-cache's 'NAR.deserialise' consumes
+-- a strict 'BS.ByteString'), so a very large path briefly spikes RSS.  Streaming
+-- would need a streaming NAR parser that nova-cache does not yet provide.
 downloadNar :: HTTP.Manager -> CacheConfig -> NarInfo.NarInfo -> IO (Either Text BS.ByteString)
 downloadNar mgr cache narInfo = do
   let narUrl = T.unpack (ccUrl cache) <> "/" <> T.unpack (NarInfo.niUrl narInfo)
@@ -273,8 +339,10 @@ parseReferences storeDir refs =
 -- NAR unpacking
 -- ---------------------------------------------------------------------------
 
--- | Unpack a NarEntry tree to a filesystem destination.
-unpackNarEntry :: FilePath -> NAR.NarEntry -> IO ()
+-- | Unpack a NarEntry tree to a filesystem destination.  Returns @Left@ on an
+-- unsafe entry name (path traversal); these come from untrusted cache data, so
+-- a typed failure is used instead of a partial 'error'.
+unpackNarEntry :: FilePath -> NAR.NarEntry -> IO (Either Text ())
 unpackNarEntry path entry = case entry of
   NAR.NarRegular isExec contents -> do
     createDirectoryIfMissing True (takeDirectory path)
@@ -282,24 +350,33 @@ unpackNarEntry path entry = case entry of
     when isExec $ do
       perms <- Dir.getPermissions path
       setPermissions path (Dir.setOwnerExecutable True perms)
+    pure (Right ())
   NAR.NarSymlink target -> do
     createDirectoryIfMissing True (takeDirectory path)
     -- On Windows, symlinks require elevated permissions.
     -- Fall back to writing the target as a text file.
     result <- try (Dir.createFileLink (T.unpack target) path)
     case result of
-      Right () -> pure ()
-      Left (_ :: SomeException) ->
+      Right () -> pure (Right ())
+      Left (_ :: SomeException) -> do
         writeFile path (T.unpack target)
+        pure (Right ())
   NAR.NarDirectory entries -> do
     createDirectoryIfMissing True path
-    mapM_
-      ( \(name, child) ->
-          if isSafeNarName name
-            then unpackNarEntry (path </> T.unpack name) child
-            else error ("unpackNarEntry: unsafe directory entry name: " <> T.unpack name)
-      )
-      entries
+    unpackChildren path entries
+
+-- | Unpack directory children, short-circuiting with a typed failure on the
+-- first unsafe entry name rather than crashing on untrusted input.
+unpackChildren :: FilePath -> [(Text, NAR.NarEntry)] -> IO (Either Text ())
+unpackChildren _ [] = pure (Right ())
+unpackChildren path ((name, child) : rest)
+  | not (isSafeNarName name) =
+      pure (Left ("unsafe NAR directory entry name: " <> name))
+  | otherwise = do
+      result <- unpackNarEntry (path </> T.unpack name) child
+      case result of
+        Left err -> pure (Left err)
+        Right () -> unpackChildren path rest
 
 -- | Validate that a NAR entry name is safe (no path traversal).
 isSafeNarName :: Text -> Bool

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -18,7 +18,7 @@ import Nix.Builder (BuildConfig (..), BuildResult (..), buildDerivation, buildWi
 import Nix.Builtins (builtinEnv, parseNixPath)
 import qualified Nix.DependencyGraph as DepGraph
 import Nix.Derivation (Derivation (..), DerivationOutput (..), Platform (..), currentPlatform, fromATerm, platformToText, toATerm)
-import Nix.Eval (NixValue (..), StringContext (..), StringContextElement (..), attrSetFromMap, attrSetLookup, attrSetNull, attrSetSize, emptyContext, emptyEnv, eval, force, mkStr, readThunkValue, runPureEval)
+import Nix.Eval (NixValue (..), StringContext (..), StringContextElement (..), attrSetFromMap, attrSetLookup, attrSetNull, attrSetSize, builtinNames, emptyContext, emptyEnv, eval, force, mkStr, readThunkValue, runPureEval)
 import Nix.Eval.Arena (arenaDestroy, arenaInit)
 import Nix.Eval.CAttrSet (cattrsetFreeze, cattrsetInsert, cattrsetKeys, cattrsetLookup, cattrsetNew, cattrsetSize, cattrsetUnion)
 import Nix.Eval.CBytecode (binaryAdd, captureSlots, captureWithScopes, cbcArg1, cbcArg2, cbcArg3, cbcData, cbcFlags, cbcOpCount, cbcOpcode, cbcShortArg, formalName, formalNamedSet, formalSet, opApp, opAssert, opAttrs, opBinary, opHasAttr, opIf, opIndStr, opLambda, opLet, opList, opLitBool, opLitFloat, opLitInt, opLitNull, opLitPath, opLitUri, opResolvedVar, opSelect, opStr, opUnary, opVar, opWith, opWithVar, strpartInterp, strpartLit, unaryNegate)
@@ -36,6 +36,8 @@ import Nix.Store (Store (..), addToStore, closeStore, isValid, openStore, pathEx
 import Nix.Store.DB (PathInfo (..), PathRegistration (..), closeStoreDB, isValidPath, openStoreDB, queryDeriver, queryPathInfo, queryReferences, registerPath)
 import Nix.Store.Path (StoreDir (..), StorePath (..), defaultStoreDir, parseStorePath, platformStoreDirText, storePathToFilePath, storePathToText, windowsStoreDir)
 import qualified Nix.Substituter as Subst
+import qualified NovaCache.Hash as CHash
+import qualified NovaCache.NarInfo as NarInfo
 import System.Directory (createDirectoryIfMissing, doesDirectoryExist, getPermissions, getTemporaryDirectory, removeDirectoryRecursive, writable)
 import qualified System.Directory as Dir
 import System.Exit (ExitCode (..), exitFailure, exitSuccess)
@@ -2293,8 +2295,51 @@ testSubstituter = do
         assertEqual "default-url" "https://cache.nixos.org" (Subst.ccUrl Subst.defaultCacheConfig),
       -- defaultCacheConfig has priority 40
       runTest "defaultCacheConfig priority" $
-        assertEqual "default-prio" 40 (Subst.ccPriority Subst.defaultCacheConfig)
+        assertEqual "default-prio" 40 (Subst.ccPriority Subst.defaultCacheConfig),
+      -- verifyNarHash: matching NAR hash accepted (HIGH#2 integrity gate)
+      runTest "verifyNarHash accepts matching hash" $
+        assertEqual "narhash-match" (Right ()) (Subst.verifyNarHash (sampleNarInfo sampleNarHash) sampleNarBytes),
+      -- verifyNarHash: mismatched NAR hash rejected
+      runTest "verifyNarHash rejects mismatched hash" $
+        case Subst.verifyNarHash (sampleNarInfo wrongNarHash) sampleNarBytes of
+          Left _ -> Pass
+          Right () -> Fail "expected mismatch rejection",
+      -- verifyNarHash: malformed NAR hash rejected
+      runTest "verifyNarHash rejects malformed hash" $
+        case Subst.verifyNarHash (sampleNarInfo "not-a-hash") sampleNarBytes of
+          Left _ -> Pass
+          Right () -> Fail "expected malformed-hash rejection",
+      -- narInfoMatchesPath: identity match accepted
+      runTest "narInfoMatchesPath accepts matching identity" $
+        if Subst.narInfoMatchesPath (StorePath sampleHash "hello") (sampleNarInfo sampleNarHash)
+          then Pass
+          else Fail "expected identity match",
+      -- narInfoMatchesPath: identity mismatch rejected
+      runTest "narInfoMatchesPath rejects mismatched identity" $
+        if Subst.narInfoMatchesPath (StorePath (T.replicate 32 "b") "hello") (sampleNarInfo sampleNarHash)
+          then Fail "expected identity mismatch"
+          else Pass
     ]
+  where
+    sampleNarBytes = "nova-nix nar sample bytes" :: BS.ByteString
+    sampleNarHash = CHash.formatNixHash (CHash.hashBytes sampleNarBytes)
+    wrongNarHash = CHash.formatNixHash (CHash.hashBytes ("different bytes" :: BS.ByteString))
+    sampleHash = T.replicate 32 "a"
+    sampleNarInfo narHash =
+      NarInfo.NarInfo
+        { NarInfo.niStorePath = "/nix/store/" <> sampleHash <> "-hello",
+          NarInfo.niUrl = "nar/sample.nar",
+          NarInfo.niCompression = "none",
+          NarInfo.niFileHash = sampleNarHash,
+          NarInfo.niFileSize = 0,
+          NarInfo.niNarHash = narHash,
+          NarInfo.niNarSize = fromIntegral (BS.length sampleNarBytes),
+          NarInfo.niReferences = [],
+          NarInfo.niDeriver = Nothing,
+          NarInfo.niSigs = [],
+          NarInfo.niCA = Nothing,
+          NarInfo.niSystem = Nothing
+        }
 
 -- ---------------------------------------------------------------------------
 -- Tests: Build orchestrator (Phase 3, Batch 7)
@@ -2677,6 +2722,140 @@ testTrivialBuildIO = do
           [ runTest "trivial build succeeds" $
               Fail ("build failed (exit " <> T.pack (show code) <> "): " <> msg)
           ]
+
+-- | Step 2 of the ladder: a dependency-aware build end-to-end.  A root
+-- derivation depends on a leaf; both @.drv@ files are pre-written to the store
+-- (as the build driver's closure-writing does), and 'buildWithDeps' must read
+-- the closure, topologically order it, build the leaf first, then the root —
+-- whose 'validateInputs' requires the leaf's realized output to be valid.
+--
+-- This is the regression guard for the input-@.drv@-closure fix: before it, no
+-- derivation with a non-empty @drvInputDrvs@ could be realized (the closure was
+-- never on disk, so the dependency graph could not be read).
+testDependentBuildIO :: IO [Bool]
+testDependentBuildIO = do
+  putStrLn "builder/dependent-native-build"
+  withTempStore $ \store -> do
+    let storeDir = stDir store
+        depOut = StorePath (T.replicate 31 "c" <> "0") "dep"
+        depDrvSP = StorePath (T.replicate 31 "c" <> "1") "dep.drv"
+        rootOut = StorePath (T.replicate 31 "a" <> "0") "root"
+        rootDrvSP = StorePath (T.replicate 31 "a" <> "1") "root.drv"
+        mkBuilder word
+          | SI.os == "mingw32" = ("cmd.exe", ["/c", "echo " <> word <> ">%out%"])
+          | otherwise = ("/bin/sh", ["-c", "echo " <> word <> " > $out"])
+        (depBuilder, depArgs) = mkBuilder "leaf"
+        (rootBuilder, rootArgs) = mkBuilder "root"
+        depDrv =
+          Derivation
+            { drvOutputs = [DerivationOutput {doName = "out", doPath = depOut, doHashAlgo = "", doHash = ""}],
+              drvInputDrvs = Map.empty,
+              drvInputSrcs = [],
+              drvPlatform = currentPlatform,
+              drvBuilder = depBuilder,
+              drvArgs = depArgs,
+              drvEnv = Map.singleton "name" "dep"
+            }
+        rootDrv =
+          Derivation
+            { drvOutputs = [DerivationOutput {doName = "out", doPath = rootOut, doHashAlgo = "", doHash = ""}],
+              drvInputDrvs = Map.singleton depDrvSP ["out"],
+              drvInputSrcs = [],
+              drvPlatform = currentPlatform,
+              drvBuilder = rootBuilder,
+              drvArgs = rootArgs,
+              drvEnv = Map.singleton "name" "root"
+            }
+    -- The build driver writes the full .drv closure before building; emulate
+    -- that here by writing both recipes to the store.
+    writeDrv store depDrv depDrvSP
+    writeDrv store rootDrv rootDrvSP
+    buildTmp <- (</> "nova-nix-test-dep-build-tmp") <$> getTemporaryDirectory
+    forceRemoveIfExists buildTmp
+    createDirectoryIfMissing True buildTmp
+    let config = (defaultBuildConfig storeDir) {bcTmpDir = buildTmp}
+    result <- buildWithDeps config store rootDrv rootDrvSP
+    depValid <- isValid store depOut
+    rootValid <- isValid store rootOut
+    forceRemoveIfExists buildTmp
+    case result of
+      BuildSuccess sp ->
+        sequence
+          [ runTest "dependent build succeeds with root output" $
+              assertEqual "root output path" rootOut sp,
+            runTest "leaf dependency built and registered first" $
+              if depValid then Pass else Fail "leaf output not valid after build",
+            runTest "root output built and registered" $
+              if rootValid then Pass else Fail "root output not valid after build"
+          ]
+      BuildFailure msg code ->
+        sequence
+          [ runTest "dependent build succeeds with root output" $
+              Fail ("dependency-aware build failed (exit " <> T.pack (show code) <> "): " <> msg)
+          ]
+
+-- | Regression tests for the 2026-06-09 audit eval-fidelity fixes.  All are
+-- parity-safe — none affects a derivation or store-path hash.
+testEvalFidelity :: IO [Bool]
+testEvalFidelity = do
+  putStrLn "eval/audit-fidelity"
+  sequence
+    [ -- builtins.match: a non-participating capture group is null, not ""
+      runTest "match null capture group" $
+        assertEval "match-null" "builtins.isNull (builtins.elemAt (builtins.match \"(a)(b)?\" \"a\") 1)" (VBool True),
+      runTest "match participating group value" $
+        assertEval "match-val" "builtins.elemAt (builtins.match \"(a)(b)\" \"ab\") 1" (mkStr "b"),
+      -- builtins.split: a non-participating group is null too
+      runTest "split null capture group" $
+        assertEval "split-null" "builtins.isNull (builtins.elemAt (builtins.elemAt (builtins.split \"(a)|(b)\" \"a\") 1) 1)" (VBool True),
+      -- builtins.toJSON honors __toString, preferring it over outPath
+      runTest "toJSON __toString" $
+        assertEval "tojson-tostr" "builtins.toJSON { __toString = self: \"x\"; }" (mkStr "\"x\""),
+      runTest "toJSON __toString beats outPath" $
+        assertEval "tojson-tostr-out" "builtins.toJSON { __toString = self: \"a\"; outPath = \"/b\"; }" (mkStr "\"a\""),
+      runTest "toJSON outPath still works" $
+        assertEval "tojson-out" "builtins.toJSON { outPath = \"/b\"; }" (mkStr "\"/b\""),
+      -- String interpolation is strict (coerceMore = False): scalars error
+      runTest "interp rejects int" $
+        assertEvalFail "interp-int" "\"v${1}\"",
+      runTest "interp rejects bool" $
+        assertEvalFail "interp-bool" "\"${true}\"",
+      runTest "interp rejects null" $
+        assertEvalFail "interp-null" "\"${null}\"",
+      runTest "concatStringsSep rejects int" $
+        assertEvalFail "ccs-int" "builtins.concatStringsSep \",\" [ 1 2 ]",
+      -- builtins.toString stays permissive
+      runTest "toString still coerces int" $
+        assertEval "tostr-int" "builtins.toString 1" (mkStr "1"),
+      runTest "interp via toString works" $
+        assertEval "interp-tostr" "\"v${builtins.toString 1}\"" (mkStr "v1"),
+      -- builtins.substring rejects a negative start position
+      runTest "substring negative start errors" $
+        assertEvalFail "substr-neg" "builtins.substring (0 - 1) 3 \"hello\"",
+      -- an integer literal that overflows Int64 is a parse error, not a wrap
+      runTest "integer literal overflow errors" $
+        assertEvalFail "int-overflow" "99999999999999999999",
+      -- float exponents and leading-dot floats lex per the Nix grammar
+      runTest "float exponent lexes as float" $
+        assertEval "float-exp-type" "builtins.typeOf 6.022e23" (mkStr "float"),
+      runTest "float negative exponent lexes" $
+        assertEval "float-negexp-type" "builtins.typeOf 1.0e-3" (mkStr "float"),
+      runTest "float exponent value" $
+        assertEval "float-exp-val" "1.5e1 == 15.0" (VBool True),
+      runTest "leading-dot float lexes as float" $
+        assertEval "leading-dot-type" "builtins.typeOf .5" (mkStr "float"),
+      runTest "leading-dot float value" $
+        assertEval "leading-dot-val" ".5 == 0.5" (VBool True),
+      -- PureEval tryEval must NOT catch abort — it propagates (matches C++ Nix)
+      runTest "tryEval does not catch abort" $
+        assertEvalFail "tryeval-abort" "(builtins.tryEval (builtins.abort \"x\")).success",
+      -- every builtin in the registry (the source of builtinNames/builtinArity)
+      -- is actually exposed in the builtins set — guards against builtinRegistry
+      -- drifting from the exposed builtins
+      runTest "every registered builtin is exposed" $
+        let missing = [n | n <- builtinNames, evalNix ("builtins ? \"" <> n <> "\"") /= Right (VBool True)]
+         in if null missing then Pass else Fail ("not exposed: " <> T.intercalate ", " missing)
+    ]
 
 -- | Pure hash decode/digest helpers shared by eval (fixed-output paths) and
 -- the builder (builtin:fetchurl verification).
@@ -4272,6 +4451,8 @@ main = bracket_ arenaInit arenaDestroy $ do
           testStorePaths,
           testDerivation,
           testTrivialBuildIO,
+          testDependentBuildIO,
+          testEvalFidelity,
           testHashHelpers,
           testEvalLiterals,
           testEvalVariables,


### PR DESCRIPTION
Applies the 2026-06-09 design and correctness audit to nova-nix: two HIGH findings plus a batch of medium and low correctness, idiom, and structure fixes.

## Builder and store (HIGH)
Derivations with dependencies now build. The evaluator records each derivation's `.drv` ATerm and the CLI writes the full input-`.drv` closure to the store before `buildWithDeps`, which reads it back to build the dependency graph; previously only leaf derivations (empty `inputDrvs`) could be realized. `validateInputs` now checks input derivations' realized output paths rather than the `.drv` recipe paths. Multi-output registration inserts all paths before any reference edge, so intra-derivation cross-output references survive, and re-registration refreshes a stale NAR hash via `ON CONFLICT`. References to sibling outputs that appear as build-temp paths are detected. A new `builder/dependent-native-build` test realizes a two-node chain end to end.

## Substituter (HIGH)
The downloaded NAR's hash is verified against the narinfo before unpacking and registering, and the served narinfo's `StorePath` is checked against the requested path. Unsafe NAR directory entry names are a typed failure instead of `error`, and the global TLS manager is reused across requests.

## Eval fidelity (parity-safe — none change a derivation or store-path hash)
- `builtins.match` / `split` return `null` for non-participating capture groups
- `builtins.toJSON` honors `__toString` before `outPath`
- string interpolation and `concatStringsSep` reject non-string scalars (`coerceMore = false`), matching C++ Nix; `toString` stays permissive
- `builtins.substring` rejects a negative start position
- under `PureEval`, `abort` and infinite recursion escape `tryEval`

## Idiom and structure
- arena StablePtr teardown walks the block list once (O(n) instead of O(n×blocks))
- value and thunk tags are bidirectional pattern synonyms shared by the three dispatch sites (jump-table dispatch preserved)
- the lexer handles float exponents and leading-dot floats and rejects out-of-range integer literals
- `CInt` for C `int` parameters across the FFI boundary; deduplicated hex encoding; removed dead `DrvHash`; C frozen-input assertions

## Verification
`cabal test`, `cabal build --ghc-options=-Werror`, C under `-Wall -Wextra -pedantic -Werror`, ormolu, and hlint are all clean. The parity workflow runs on this branch to confirm the eval changes leave `hello.drvPath` and its closure byte-matching `nix-instantiate`.