### PR TITLE
Bytecode opcodes as shared pattern synonyms

### DIFF
--- a/src/Nix/Eval.hs
+++ b/src/Nix/Eval.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE PatternSynonyms #-}
 
 -- | Nix expression evaluator.
 --
@@ -88,7 +89,7 @@ import Data.Word (Word32, Word8)
 import Foreign.Ptr (Ptr, castPtr, nullPtr, ptrToWordPtr, wordPtrToPtr)
 import Foreign.Storable (peekElemOff, pokeElemOff)
 import Nix.Derivation (Derivation (..), DerivationOutput (..), textToPlatform, toATerm, toATermForHash)
-import Nix.Eval.CBytecode (cbcArg1, cbcArg2, cbcArg3, cbcData, cbcFlags, cbcOpcode, cbcShortArg)
+import Nix.Eval.CBytecode (cbcArg1, cbcArg2, cbcArg3, cbcData, cbcFlags, cbcOpcode, cbcShortArg, pattern OpApp, pattern OpAssert, pattern OpAttrs, pattern OpBinary, pattern OpHasAttr, pattern OpIf, pattern OpIndStr, pattern OpLambda, pattern OpLet, pattern OpList, pattern OpLitBool, pattern OpLitFloat, pattern OpLitInt, pattern OpLitNull, pattern OpLitPath, pattern OpLitUri, pattern OpResolvedVar, pattern OpSearchPath, pattern OpSelect, pattern OpStr, pattern OpUnary, pattern OpVar, pattern OpWith, pattern OpWithVar)
 import Nix.Eval.CEnv (cenvPushWith)
 import Nix.Eval.CList (CList (..), clistGet)
 import Nix.Eval.CThunk (CThunkPtr)
@@ -190,45 +191,45 @@ evalBytecode :: (MonadEval m) => Env -> Word32 -> m NixValue
 evalBytecode env bcIdx =
   let opcode = unsafePerformIO (cbcOpcode bcIdx)
    in case opcode of
-        0 {- LIT_INT -} ->
+        OpLitInt ->
           let lo = unsafePerformIO (cbcArg1 bcIdx)
               hi = unsafePerformIO (cbcArg2 bcIdx)
            in pure (VInt (reassembleInt64 lo hi))
-        1 {- LIT_FLOAT -} ->
+        OpLitFloat ->
           let lo = unsafePerformIO (cbcArg1 bcIdx)
               hi = unsafePerformIO (cbcArg2 bcIdx)
            in pure (VFloat (reassembleDouble lo hi))
-        2 {- LIT_BOOL -} ->
+        OpLitBool ->
           let flag = unsafePerformIO (cbcShortArg bcIdx)
            in pure (VBool (flag /= 0))
-        3 {- LIT_NULL -} -> pure VNull
-        4 {- LIT_URI -} ->
+        OpLitNull -> pure VNull
+        OpLitUri ->
           let sym = unsafePerformIO (cbcArg1 bcIdx)
            in pure (mkStr (symbolText (Symbol sym)))
-        5 {- LIT_PATH -} ->
+        OpLitPath ->
           let sym = unsafePerformIO (cbcArg1 bcIdx)
            in VPath <$> resolvePathLiteral (symbolText (Symbol sym))
-        6 {- STR -} -> evalBcStr env bcIdx
-        7 {- IND_STR -} -> evalBcIndStr env bcIdx
-        8 {- VAR -} ->
+        OpStr -> evalBcStr env bcIdx
+        OpIndStr -> evalBcIndStr env bcIdx
+        OpVar ->
           let sym = unsafePerformIO (cbcArg1 bcIdx)
            in evalVar env (symbolText (Symbol sym))
-        9 {- WITH_VAR -} ->
+        OpWithVar ->
           let sym = unsafePerformIO (cbcArg1 bcIdx)
               name = symbolText (Symbol sym)
            in evalWithVar env name
-        10 {- RESOLVED_VAR -} ->
+        OpResolvedVar ->
           let level = fromIntegral (unsafePerformIO (cbcArg1 bcIdx))
               idx = fromIntegral (unsafePerformIO (cbcArg2 bcIdx))
            in force (envLookupResolved level idx env)
-        11 {- ATTRS -} -> evalBcAttrs env bcIdx
-        12 {- LIST -} -> evalBcList env bcIdx
-        13 {- SELECT -} -> evalBcSelect env bcIdx
-        14 {- HAS_ATTR -} -> evalBcHasAttr env bcIdx
-        15 {- APP -} -> evalBcApp env bcIdx
-        16 {- LAMBDA -} -> evalBcLambda env bcIdx
-        17 {- LET -} -> evalBcLet env bcIdx
-        18 {- IF -} ->
+        OpAttrs -> evalBcAttrs env bcIdx
+        OpList -> evalBcList env bcIdx
+        OpSelect -> evalBcSelect env bcIdx
+        OpHasAttr -> evalBcHasAttr env bcIdx
+        OpApp -> evalBcApp env bcIdx
+        OpLambda -> evalBcLambda env bcIdx
+        OpLet -> evalBcLet env bcIdx
+        OpIf ->
           let condIdx = unsafePerformIO (cbcArg1 bcIdx)
               thenIdx = unsafePerformIO (cbcArg2 bcIdx)
               elseIdx = unsafePerformIO (cbcArg3 bcIdx)
@@ -238,7 +239,7 @@ evalBytecode env bcIdx =
                   VBool True -> evalBytecode env thenIdx
                   VBool False -> evalBytecode env elseIdx
                   _ -> throwEvalError ("'if' condition must be a Boolean, got " <> typeName condVal)
-        19 {- WITH -} ->
+        OpWith ->
           let scopeIdx = unsafePerformIO (cbcArg1 bcIdx)
               bodyIdx = unsafePerformIO (cbcArg2 bcIdx)
               -- Lazy with: defer forcing the scope until a WITH_VAR lookup
@@ -247,7 +248,7 @@ evalBytecode env bcIdx =
               -- eagerly forcing the scope would blackhole.
               scopeThunk = cheapThunkBc env scopeIdx
            in evalBytecode (pushLazyWithScope scopeThunk env) bodyIdx
-        20 {- ASSERT -} ->
+        OpAssert ->
           let condIdx = unsafePerformIO (cbcArg1 bcIdx)
               bodyIdx = unsafePerformIO (cbcArg2 bcIdx)
            in do
@@ -256,14 +257,14 @@ evalBytecode env bcIdx =
                   VBool True -> evalBytecode env bodyIdx
                   VBool False -> throwEvalError "assertion failed"
                   _ -> throwEvalError ("assertion condition must be a Boolean, got " <> typeName condVal)
-        21 {- UNARY -} ->
+        OpUnary ->
           let flags_ = unsafePerformIO (cbcFlags bcIdx)
               operandIdx = unsafePerformIO (cbcArg1 bcIdx)
            in do
                 val <- evalBytecode env operandIdx
                 evalUnary (decodeUnaryOp flags_) val
-        22 {- BINARY -} -> evalBcBinary env bcIdx
-        23 {- SEARCH_PATH -} ->
+        OpBinary -> evalBcBinary env bcIdx
+        OpSearchPath ->
           let sym = unsafePerformIO (cbcArg1 bcIdx)
            in evalSearchPath env (symbolText (Symbol sym))
         _ -> throwEvalError "evalBytecode: unknown opcode"

--- a/src/Nix/Eval/CBytecode.hs
+++ b/src/Nix/Eval/CBytecode.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE PatternSynonyms #-}
+
 -- | C-backed bytecode storage via FFI.
 --
 -- Wraps @cbits/nn_bytecode.c@ — two growable arrays storing flat Nix
@@ -6,7 +8,7 @@
 --
 -- @
 -- cbcInit 0 0
--- idx <- cbcEmit opLitInt 0 0 42 0 0
+-- idx <- cbcEmit OpLitInt 0 0 42 0 0
 -- cbcOpcode idx   -- NN_OP_LIT_INT (0)
 -- cbcArg1 idx     -- 42
 -- cbcDestroy
@@ -36,30 +38,30 @@ module Nix.Eval.CBytecode
     cbcDataCount,
 
     -- * Opcodes
-    opLitInt,
-    opLitFloat,
-    opLitBool,
-    opLitNull,
-    opLitUri,
-    opLitPath,
-    opStr,
-    opIndStr,
-    opVar,
-    opWithVar,
-    opResolvedVar,
-    opAttrs,
-    opList,
-    opSelect,
-    opHasAttr,
-    opApp,
-    opLambda,
-    opLet,
-    opIf,
-    opWith,
-    opAssert,
-    opUnary,
-    opBinary,
-    opSearchPath,
+    pattern OpLitInt,
+    pattern OpLitFloat,
+    pattern OpLitBool,
+    pattern OpLitNull,
+    pattern OpLitUri,
+    pattern OpLitPath,
+    pattern OpStr,
+    pattern OpIndStr,
+    pattern OpVar,
+    pattern OpWithVar,
+    pattern OpResolvedVar,
+    pattern OpAttrs,
+    pattern OpList,
+    pattern OpSelect,
+    pattern OpHasAttr,
+    pattern OpApp,
+    pattern OpLambda,
+    pattern OpLet,
+    pattern OpIf,
+    pattern OpWith,
+    pattern OpAssert,
+    pattern OpUnary,
+    pattern OpBinary,
+    pattern OpSearchPath,
 
     -- * UnaryOp flags
     unaryNot,
@@ -219,49 +221,49 @@ cbcDataCount = c_nn_bc_data_count
 -- Opcode constants
 -- ---------------------------------------------------------------------------
 
-opLitInt, opLitFloat, opLitBool, opLitNull :: Word8
-opLitInt = 0
-opLitFloat = 1
-opLitBool = 2
-opLitNull = 3
+pattern OpLitInt, OpLitFloat, OpLitBool, OpLitNull :: Word8
+pattern OpLitInt = 0
+pattern OpLitFloat = 1
+pattern OpLitBool = 2
+pattern OpLitNull = 3
 
-opLitUri, opLitPath :: Word8
-opLitUri = 4
-opLitPath = 5
+pattern OpLitUri, OpLitPath :: Word8
+pattern OpLitUri = 4
+pattern OpLitPath = 5
 
-opStr, opIndStr :: Word8
-opStr = 6
-opIndStr = 7
+pattern OpStr, OpIndStr :: Word8
+pattern OpStr = 6
+pattern OpIndStr = 7
 
-opVar, opWithVar, opResolvedVar :: Word8
-opVar = 8
-opWithVar = 9
-opResolvedVar = 10
+pattern OpVar, OpWithVar, OpResolvedVar :: Word8
+pattern OpVar = 8
+pattern OpWithVar = 9
+pattern OpResolvedVar = 10
 
-opAttrs, opList :: Word8
-opAttrs = 11
-opList = 12
+pattern OpAttrs, OpList :: Word8
+pattern OpAttrs = 11
+pattern OpList = 12
 
-opSelect, opHasAttr, opApp :: Word8
-opSelect = 13
-opHasAttr = 14
-opApp = 15
+pattern OpSelect, OpHasAttr, OpApp :: Word8
+pattern OpSelect = 13
+pattern OpHasAttr = 14
+pattern OpApp = 15
 
-opLambda, opLet :: Word8
-opLambda = 16
-opLet = 17
+pattern OpLambda, OpLet :: Word8
+pattern OpLambda = 16
+pattern OpLet = 17
 
-opIf, opWith, opAssert :: Word8
-opIf = 18
-opWith = 19
-opAssert = 20
+pattern OpIf, OpWith, OpAssert :: Word8
+pattern OpIf = 18
+pattern OpWith = 19
+pattern OpAssert = 20
 
-opUnary, opBinary :: Word8
-opUnary = 21
-opBinary = 22
+pattern OpUnary, OpBinary :: Word8
+pattern OpUnary = 21
+pattern OpBinary = 22
 
-opSearchPath :: Word8
-opSearchPath = 23
+pattern OpSearchPath :: Word8
+pattern OpSearchPath = 23
 
 -- ---------------------------------------------------------------------------
 -- Sub-type flags

--- a/src/Nix/Eval/Compile.hs
+++ b/src/Nix/Eval/Compile.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE PatternSynonyms #-}
+
 -- | Compile Nix 'Expr' AST trees to flat C bytecode.
 --
 -- Post-order traversal: children are compiled before parents, so child
@@ -54,34 +56,34 @@ import Nix.Eval.CBytecode
     formalName,
     formalNamedSet,
     formalSet,
-    opApp,
-    opAssert,
-    opAttrs,
-    opBinary,
-    opHasAttr,
-    opIf,
-    opIndStr,
-    opLambda,
-    opLet,
-    opList,
-    opLitBool,
-    opLitFloat,
-    opLitInt,
-    opLitNull,
-    opLitPath,
-    opLitUri,
-    opResolvedVar,
-    opSearchPath,
-    opSelect,
-    opStr,
-    opUnary,
-    opVar,
-    opWith,
-    opWithVar,
     strpartInterp,
     strpartLit,
     unaryNegate,
     unaryNot,
+    pattern OpApp,
+    pattern OpAssert,
+    pattern OpAttrs,
+    pattern OpBinary,
+    pattern OpHasAttr,
+    pattern OpIf,
+    pattern OpIndStr,
+    pattern OpLambda,
+    pattern OpLet,
+    pattern OpList,
+    pattern OpLitBool,
+    pattern OpLitFloat,
+    pattern OpLitInt,
+    pattern OpLitNull,
+    pattern OpLitPath,
+    pattern OpLitUri,
+    pattern OpResolvedVar,
+    pattern OpSearchPath,
+    pattern OpSelect,
+    pattern OpStr,
+    pattern OpUnary,
+    pattern OpVar,
+    pattern OpWith,
+    pattern OpWithVar,
   )
 import Nix.Eval.EvalFormals (EvalFormal (..), EvalFormals (..))
 import Nix.Eval.Symbol (Symbol (..), symbolIntern, symbolText)
@@ -105,12 +107,12 @@ compileExpr = go
   where
     go :: Expr -> IO Word32
     go (ELit atom) = compileLit atom
-    go (EStr parts) = compileStringParts opStr parts
-    go (EIndStr parts) = compileStringParts opIndStr parts
-    go (EVar name) = compileSymbolOp opVar name
-    go (EWithVar name) = compileSymbolOp opWithVar name
+    go (EStr parts) = compileStringParts OpStr parts
+    go (EIndStr parts) = compileStringParts OpIndStr parts
+    go (EVar name) = compileSymbolOp OpVar name
+    go (EWithVar name) = compileSymbolOp OpWithVar name
     go (EResolvedVar level idx) =
-      cbcEmit opResolvedVar 0 0 (fi level) (fi idx) 0
+      cbcEmit OpResolvedVar 0 0 (fi level) (fi idx) 0
     go (EAttrs isRec bindings captureInfo) =
       compileAttrs isRec bindings captureInfo
     go (EList exprs) = compileList exprs
@@ -120,7 +122,7 @@ compileExpr = go
     go (EApp func arg) = do
       funcIdx <- go func
       argIdx <- go arg
-      cbcEmit opApp 0 0 funcIdx argIdx 0
+      cbcEmit OpApp 0 0 funcIdx argIdx 0
     go (ELambda formals body captureInfo) =
       compileLambda formals body captureInfo
     go (ELet bindings body captureInfo) =
@@ -129,23 +131,23 @@ compileExpr = go
       condIdx <- go cond
       thenIdx <- go thenExpr
       elseIdx <- go elseExpr
-      cbcEmit opIf 0 0 condIdx thenIdx elseIdx
+      cbcEmit OpIf 0 0 condIdx thenIdx elseIdx
     go (EWith scope body) = do
       scopeIdx <- go scope
       bodyIdx <- go body
-      cbcEmit opWith 0 0 scopeIdx bodyIdx 0
+      cbcEmit OpWith 0 0 scopeIdx bodyIdx 0
     go (EAssert cond body) = do
       condIdx <- go cond
       bodyIdx <- go body
-      cbcEmit opAssert 0 0 condIdx bodyIdx 0
+      cbcEmit OpAssert 0 0 condIdx bodyIdx 0
     go (EUnary op operand) = do
       operandIdx <- go operand
-      cbcEmit opUnary (encodeUnaryOp op) 0 operandIdx 0 0
+      cbcEmit OpUnary (encodeUnaryOp op) 0 operandIdx 0 0
     go (EBinary op left right) = do
       leftIdx <- go left
       rightIdx <- go right
-      cbcEmit opBinary (encodeBinaryOp op) 0 leftIdx rightIdx 0
-    go (ESearchPath name) = compileSymbolOp opSearchPath name
+      cbcEmit OpBinary (encodeBinaryOp op) 0 leftIdx rightIdx 0
+    go (ESearchPath name) = compileSymbolOp OpSearchPath name
 
     -- -----------------------------------------------------------------
     -- Literals
@@ -154,16 +156,16 @@ compileExpr = go
     compileLit :: NixAtom -> IO Word32
     compileLit (NixInt n) =
       let (lo, hi) = splitInt64 n
-       in cbcEmit opLitInt 0 0 lo hi 0
+       in cbcEmit OpLitInt 0 0 lo hi 0
     compileLit (NixFloat d) =
       let (lo, hi) = splitDouble d
-       in cbcEmit opLitFloat 0 0 lo hi 0
+       in cbcEmit OpLitFloat 0 0 lo hi 0
     compileLit (NixBool b) =
-      cbcEmit opLitBool 0 (if b then 1 else 0) 0 0 0
+      cbcEmit OpLitBool 0 (if b then 1 else 0) 0 0 0
     compileLit NixNull =
-      cbcEmit opLitNull 0 0 0 0 0
-    compileLit (NixUri u) = compileSymbolOp opLitUri u
-    compileLit (NixPath p) = compileSymbolOp opLitPath p
+      cbcEmit OpLitNull 0 0 0 0 0
+    compileLit (NixUri u) = compileSymbolOp OpLitUri u
+    compileLit (NixPath p) = compileSymbolOp OpLitPath p
 
     -- \| Emit an instruction whose only operand is an interned symbol.
     compileSymbolOp :: Word8 -> Text -> IO Word32
@@ -197,7 +199,7 @@ compileExpr = go
     compileAttrs isRec bindings captureInfo = do
       dataOff <- compileBindings bindings
       capOff <- compileCaptureInfo captureInfo
-      cbcEmit opAttrs (if isRec then 1 else 0) (fi (length bindings)) dataOff capOff 0
+      cbcEmit OpAttrs (if isRec then 1 else 0) (fi (length bindings)) dataOff capOff 0
 
     -- -----------------------------------------------------------------
     -- Lists (EList)
@@ -207,7 +209,7 @@ compileExpr = go
     compileList exprs = do
       childIndices <- mapM go exprs
       dataOff <- emitWordList childIndices
-      cbcEmit opList 0 (fi (length exprs)) dataOff 0 0
+      cbcEmit OpList 0 (fi (length exprs)) dataOff 0 0
 
     -- -----------------------------------------------------------------
     -- Select / HasAttr
@@ -221,13 +223,13 @@ compileExpr = go
         Just d -> go d
       (pathOff, pathLen) <- compileAttrPath path
       let hasDef = case defExpr of Nothing -> 0; Just _ -> 1
-      cbcEmit opSelect hasDef pathLen targetIdx pathOff defIdx
+      cbcEmit OpSelect hasDef pathLen targetIdx pathOff defIdx
 
     compileHasAttr :: Expr -> [AttrKey] -> IO Word32
     compileHasAttr target path = do
       targetIdx <- go target
       (pathOff, pathLen) <- compileAttrPath path
-      cbcEmit opHasAttr 0 pathLen targetIdx pathOff 0
+      cbcEmit OpHasAttr 0 pathLen targetIdx pathOff 0
 
     compileAttrPath :: [AttrKey] -> IO (Word32, Word16)
     compileAttrPath path = do
@@ -252,7 +254,7 @@ compileExpr = go
       bodyIdx <- go body
       formalsOff <- compileFormals formals
       capOff <- compileCaptureInfo captureInfo
-      cbcEmit opLambda (encodeFormalType formals) 0 formalsOff bodyIdx capOff
+      cbcEmit OpLambda (encodeFormalType formals) 0 formalsOff bodyIdx capOff
 
     compileFormals :: Formals -> IO Word32
     compileFormals (FormalName name) = do
@@ -291,7 +293,7 @@ compileExpr = go
       bodyIdx <- go body
       dataOff <- compileBindings bindings
       capOff <- compileCaptureInfo captureInfo
-      cbcEmit opLet 0 (fi (length bindings)) dataOff bodyIdx capOff
+      cbcEmit OpLet 0 (fi (length bindings)) dataOff bodyIdx capOff
 
     -- -----------------------------------------------------------------
     -- Bindings (shared by EAttrs and ELet)

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE PatternSynonyms #-}
 
 module Main (main) where
 
@@ -21,7 +22,7 @@ import Nix.Derivation (Derivation (..), DerivationOutput (..), Platform (..), cu
 import Nix.Eval (NixValue (..), StringContext (..), StringContextElement (..), attrSetFromMap, attrSetLookup, attrSetNull, attrSetSize, builtinNames, emptyContext, emptyEnv, eval, force, mkStr, readThunkValue, runPureEval)
 import Nix.Eval.Arena (arenaDestroy, arenaInit)
 import Nix.Eval.CAttrSet (cattrsetFreeze, cattrsetInsert, cattrsetKeys, cattrsetLookup, cattrsetNew, cattrsetSize, cattrsetUnion)
-import Nix.Eval.CBytecode (binaryAdd, captureSlots, captureWithScopes, cbcArg1, cbcArg2, cbcArg3, cbcData, cbcFlags, cbcOpCount, cbcOpcode, cbcShortArg, formalName, formalNamedSet, formalSet, opApp, opAssert, opAttrs, opBinary, opHasAttr, opIf, opIndStr, opLambda, opLet, opList, opLitBool, opLitFloat, opLitInt, opLitNull, opLitPath, opLitUri, opResolvedVar, opSelect, opStr, opUnary, opVar, opWith, opWithVar, strpartInterp, strpartLit, unaryNegate)
+import Nix.Eval.CBytecode (binaryAdd, captureSlots, captureWithScopes, cbcArg1, cbcArg2, cbcArg3, cbcData, cbcFlags, cbcOpCount, cbcOpcode, cbcShortArg, formalName, formalNamedSet, formalSet, strpartInterp, strpartLit, unaryNegate, pattern OpApp, pattern OpAssert, pattern OpAttrs, pattern OpBinary, pattern OpHasAttr, pattern OpIf, pattern OpIndStr, pattern OpLambda, pattern OpLet, pattern OpList, pattern OpLitBool, pattern OpLitFloat, pattern OpLitInt, pattern OpLitNull, pattern OpLitPath, pattern OpLitUri, pattern OpResolvedVar, pattern OpSelect, pattern OpStr, pattern OpUnary, pattern OpVar, pattern OpWith, pattern OpWithVar)
 import Nix.Eval.CThunk (CThunkPtr, cthunkCount, cthunkGet, cthunkMarkBlackhole, cthunkNew, cthunkNewComputed, cthunkPayload, cthunkSetComputed, cthunkState)
 import Nix.Eval.Compile (compileExpr)
 import qualified Nix.Eval.Context as Context
@@ -3946,7 +3947,7 @@ testBytecodeCompile = do
         a1 <- cbcArg1 idx
         a2 <- cbcArg2 idx
         pure
-          ( if op == opLitInt && a1 == 42 && a2 == 0
+          ( if op == OpLitInt && a1 == 42 && a2 == 0
               then Pass
               else Fail ("op=" <> T.pack (show op) <> " a1=" <> T.pack (show a1))
           ),
@@ -3957,7 +3958,7 @@ testBytecodeCompile = do
         a2 <- cbcArg2 idx
         -- -1 as uint64 = 0xFFFFFFFFFFFFFFFF, lo=0xFFFFFFFF, hi=0xFFFFFFFF
         pure
-          ( if op == opLitInt && a1 == 0xFFFFFFFF && a2 == 0xFFFFFFFF
+          ( if op == OpLitInt && a1 == 0xFFFFFFFF && a2 == 0xFFFFFFFF
               then Pass
               else
                 Fail
@@ -3975,21 +3976,21 @@ testBytecodeCompile = do
         saT <- cbcShortArg idxT
         saF <- cbcShortArg idxF
         pure
-          ( if opT == opLitBool && saT == 1 && opF == opLitBool && saF == 0
+          ( if opT == OpLitBool && saT == 1 && opF == OpLitBool && saF == 0
               then Pass
               else Fail "bool encoding mismatch"
           ),
       runTestM "compile ELit NixNull" $ do
         idx <- compileExpr (ELit NixNull)
         op <- cbcOpcode idx
-        pure (assertEqual "opcode" opLitNull op),
+        pure (assertEqual "opcode" OpLitNull op),
       runTestM "compile EResolvedVar" $ do
         idx <- compileExpr (EResolvedVar 3 7)
         op <- cbcOpcode idx
         a1 <- cbcArg1 idx
         a2 <- cbcArg2 idx
         pure
-          ( if op == opResolvedVar && a1 == 3 && a2 == 7
+          ( if op == OpResolvedVar && a1 == 3 && a2 == 7
               then Pass
               else
                 Fail
@@ -4007,7 +4008,7 @@ testBytecodeCompile = do
         sym <- cbcArg1 idx
         let symText = symbolText (Symbol sym)
         pure
-          ( if op == opVar && symText == "hello"
+          ( if op == OpVar && symText == "hello"
               then Pass
               else Fail ("op=" <> T.pack (show op) <> " sym=" <> symText)
           ),
@@ -4019,7 +4020,7 @@ testBytecodeCompile = do
         funcOp <- cbcOpcode funcIdx
         argOp <- cbcOpcode argIdx
         pure
-          ( if op == opApp && funcOp == opVar && argOp == opLitInt
+          ( if op == OpApp && funcOp == OpVar && argOp == OpLitInt
               then Pass
               else
                 Fail
@@ -4043,7 +4044,7 @@ testBytecodeCompile = do
         thenA1 <- cbcArg1 thenIdx
         elseA1 <- cbcArg1 elseIdx
         pure
-          ( if op == opIf && condOp == opLitBool && thenA1 == 1 && elseA1 == 2
+          ( if op == OpIf && condOp == OpLitBool && thenA1 == 1 && elseA1 == 2
               then Pass
               else Fail "if structure mismatch"
           ),
@@ -4058,7 +4059,7 @@ testBytecodeCompile = do
         leftA1 <- cbcArg1 leftIdx
         rightA1 <- cbcArg1 rightIdx
         pure
-          ( if op == opBinary && fl == binaryAdd && leftA1 == 10 && rightA1 == 20
+          ( if op == OpBinary && fl == binaryAdd && leftA1 == 10 && rightA1 == 20
               then Pass
               else Fail "binary structure mismatch"
           ),
@@ -4069,7 +4070,7 @@ testBytecodeCompile = do
         operandIdx <- cbcArg1 idx
         operandA1 <- cbcArg1 operandIdx
         pure
-          ( if op == opUnary && fl == unaryNegate && operandA1 == 5
+          ( if op == OpUnary && fl == unaryNegate && operandA1 == 5
               then Pass
               else Fail "unary structure mismatch"
           ),
@@ -4087,7 +4088,7 @@ testBytecodeCompile = do
         c1a1 <- cbcArg1 c1
         c2a1 <- cbcArg1 c2
         pure
-          ( if op == opList && count == 3 && c0a1 == 1 && c1a1 == 2 && c2a1 == 3
+          ( if op == OpList && count == 3 && c0a1 == 1 && c1a1 == 2 && c2a1 == 3
               then Pass
               else
                 Fail
@@ -4113,12 +4114,12 @@ testBytecodeCompile = do
         -- tag0=0(lit), tag1=1(interp), tag2=0(lit)
         interpOp <- cbcOpcode val1
         pure
-          ( if op == opStr
+          ( if op == OpStr
               && count == 3
               && tag0 == strpartLit
               && tag1 == strpartInterp
               && tag2 == strpartLit
-              && interpOp == opVar
+              && interpOp == OpVar
               then Pass
               else
                 Fail
@@ -4140,7 +4141,7 @@ testBytecodeCompile = do
         scopeOp <- cbcOpcode scopeIdx
         bodyOp <- cbcOpcode bodyIdx
         pure
-          ( if op == opWith && scopeOp == opVar && bodyOp == opVar
+          ( if op == OpWith && scopeOp == OpVar && bodyOp == OpVar
               then Pass
               else Fail "with structure mismatch"
           ),
@@ -4152,7 +4153,7 @@ testBytecodeCompile = do
         condOp <- cbcOpcode condIdx
         bodyOp <- cbcOpcode bodyIdx
         pure
-          ( if op == opAssert && condOp == opLitBool && bodyOp == opLitInt
+          ( if op == OpAssert && condOp == OpLitBool && bodyOp == OpLitInt
               then Pass
               else Fail "assert structure mismatch"
           ),
@@ -4165,7 +4166,7 @@ testBytecodeCompile = do
         bodyIdx <- cbcArg2 idx
         bodyOp <- cbcOpcode bodyIdx
         pure
-          ( if op == opLambda && fl == formalName && bodyOp == opResolvedVar
+          ( if op == OpLambda && fl == formalName && bodyOp == OpResolvedVar
               then Pass
               else
                 Fail
@@ -4188,7 +4189,7 @@ testBytecodeCompile = do
         bodyIdx <- cbcArg2 idx
         bodyOp <- cbcOpcode bodyIdx
         pure
-          ( if op == opLet && count == 1 && bodyOp == opResolvedVar
+          ( if op == OpLet && count == 1 && bodyOp == OpResolvedVar
               then Pass
               else
                 Fail
@@ -4210,7 +4211,7 @@ testBytecodeCompile = do
         fl <- cbcFlags idx
         count <- cbcShortArg idx
         pure
-          ( if op == opAttrs && fl == 0 && count == 1
+          ( if op == OpAttrs && fl == 0 && count == 1
               then Pass
               else Fail "attrs structure mismatch"
           ),
@@ -4228,7 +4229,7 @@ testBytecodeCompile = do
         fl <- cbcFlags idx
         count <- cbcShortArg idx
         pure
-          ( if op == opAttrs && fl == 1 && count == 2
+          ( if op == OpAttrs && fl == 1 && count == 2
               then Pass
               else
                 Fail
@@ -4245,7 +4246,7 @@ testBytecodeCompile = do
         op <- cbcOpcode idx
         fl <- cbcFlags idx
         pure
-          ( if op == opSelect && fl == 0
+          ( if op == OpSelect && fl == 0
               then Pass
               else Fail ("flags=" <> T.pack (show fl))
           ),
@@ -4258,7 +4259,7 @@ testBytecodeCompile = do
         defIdx <- cbcArg3 idx
         defOp <- cbcOpcode defIdx
         pure
-          ( if op == opSelect && fl == 1 && defOp == opLitNull
+          ( if op == OpSelect && fl == 1 && defOp == OpLitNull
               then Pass
               else Fail ("flags=" <> T.pack (show fl))
           ),
@@ -4269,7 +4270,7 @@ testBytecodeCompile = do
         op <- cbcOpcode idx
         pathLen <- cbcShortArg idx
         pure
-          ( if op == opHasAttr && pathLen == 2
+          ( if op == OpHasAttr && pathLen == 2
               then Pass
               else
                 Fail
@@ -4285,9 +4286,9 @@ testBytecodeCompile = do
         idx <- compileExpr (EApp (EApp (EVar "__findFile") (EVar "__nixPath")) (EStr [StrLit "nixpkgs"]))
         op <- cbcOpcode idx
         pure
-          ( if op == opApp
+          ( if op == OpApp
               then Pass
-              else Fail ("expected opApp, got op=" <> T.pack (show op))
+              else Fail ("expected OpApp, got op=" <> T.pack (show op))
           ),
       runTestM "op_count grows after compilation" $ do
         before <- cbcOpCount
@@ -4307,13 +4308,13 @@ testBytecodeCompile = do
       runTestM "compile ELit NixFloat" $ do
         idx <- compileExpr (ELit (NixFloat 3.14))
         op <- cbcOpcode idx
-        pure (assertEqual "opcode" opLitFloat op),
+        pure (assertEqual "opcode" OpLitFloat op),
       runTestM "compile ELit NixUri" $ do
         idx <- compileExpr (ELit (NixUri "https://example.com"))
         op <- cbcOpcode idx
         sym <- cbcArg1 idx
         pure
-          ( if op == opLitUri && symbolText (Symbol sym) == "https://example.com"
+          ( if op == OpLitUri && symbolText (Symbol sym) == "https://example.com"
               then Pass
               else Fail "uri mismatch"
           ),
@@ -4322,7 +4323,7 @@ testBytecodeCompile = do
         op <- cbcOpcode idx
         sym <- cbcArg1 idx
         pure
-          ( if op == opLitPath && symbolText (Symbol sym) == "/nix/store/foo"
+          ( if op == OpLitPath && symbolText (Symbol sym) == "/nix/store/foo"
               then Pass
               else Fail "path mismatch"
           ),
@@ -4337,7 +4338,7 @@ testBytecodeCompile = do
         op <- cbcOpcode idx
         count <- cbcShortArg idx
         pure
-          ( if op == opAttrs && count == 1
+          ( if op == OpAttrs && count == 1
               then Pass
               else Fail "inherit binding mismatch"
           ),
@@ -4352,7 +4353,7 @@ testBytecodeCompile = do
         op <- cbcOpcode idx
         fl <- cbcFlags idx
         pure
-          ( if op == opLambda && fl == formalSet
+          ( if op == OpLambda && fl == formalSet
               then Pass
               else Fail ("flags=" <> T.pack (show fl))
           ),
@@ -4367,7 +4368,7 @@ testBytecodeCompile = do
         op <- cbcOpcode idx
         fl <- cbcFlags idx
         pure
-          ( if op == opLambda && fl == formalNamedSet
+          ( if op == OpLambda && fl == formalNamedSet
               then Pass
               else Fail ("flags=" <> T.pack (show fl))
           ),
@@ -4388,7 +4389,7 @@ testBytecodeCompile = do
         capL1 <- cbcData (capOff + 4)
         capI1 <- cbcData (capOff + 5)
         pure
-          ( if op == opLambda
+          ( if op == OpLambda
               && capTag == captureSlots
               && capCount == 2
               && capL0 == 1
@@ -4420,7 +4421,7 @@ testBytecodeCompile = do
         op <- cbcOpcode idx
         sym <- cbcArg1 idx
         pure
-          ( if op == opWithVar && symbolText (Symbol sym) == "dynamic"
+          ( if op == OpWithVar && symbolText (Symbol sym) == "dynamic"
               then Pass
               else Fail "withvar mismatch"
           ),
@@ -4429,7 +4430,7 @@ testBytecodeCompile = do
         op <- cbcOpcode idx
         count <- cbcShortArg idx
         pure
-          ( if op == opIndStr && count == 1
+          ( if op == OpIndStr && count == 1
               then Pass
               else Fail "indstr mismatch"
           )


### PR DESCRIPTION
Finishes the audit's named-constants item for the bytecode opcodes.

The 24 `op*` constants in `Nix.Eval.CBytecode` were plain `Word8` values used by the encoder (`Nix.Eval.Compile`), while the decoder (`Nix.Eval.evalBytecode`) re-hardcoded the same tag literals (`15 {- APP -} -> …`). A renumbering would have silently desynced them.

This converts them to **bidirectional pattern synonyms** (`pattern OpApp = 15`, …), so the encoder and decoder reference one definition. Because they're literal-pattern synonyms, the decoder's `case` still compiles to the same jump table — the interpreter's hot path is unchanged.

636 tests pass (including every `compile E*` bytecode test); `-Werror`, C strict, ormolu, and hlint clean.