### PR TITLE
builder: builtin:unpack — the stage-0 Windows seed extractor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.4.0.0 — 2026-06-10
+
+### Milestone: The First Native Windows Build
+
+`nova-nix build pkgs/windows/hello.nix` compiles and runs a C program through a Nix derivation, natively on Windows: evaluation records the derivation closure, the builder realizes 17 fixed-output fetches and a toolchain unpack in dependency order, and a compiler that is itself a store path produces `C:\nix\store\…-hello\hello.exe`. The first package built natively on Windows by a Nix implementation.
+
+- **New: `builtin:unpack`** — an in-process archive extractor, the counterpart to `builtin:fetchurl`: the unpacker is the thing being bootstrapped, so it cannot be a store tool, and ambient `tar` is unpinned. Extracts `.tar.zst`/`.tar` archives listed in `srcs` into the single `out` output, in order. MSYS2 packages share the `mingw64/` prefix, so a package set merges into one working toolchain root. Symlink and hardlink entries are materialized as copies (store outputs must not require Developer Mode), pacman per-package metadata is skipped, and cross-archive file collisions and path traversal fail the build loudly. MSYS2's zstd frames carry no pledged content size, so decompression is streaming. New dependencies: `tar >= 0.7.1`, `zstd`.
+- **New: `pkgs/windows/seed.nix`** — stage 0 of the native Windows stdenv: the 17-package runtime closure of `mingw-w64-x86_64-gcc`, sha256-pinned against `repo.msys2.org`, fetched and merged into a single toolchain root. `pkgs/windows/hello.nix` is the proof build; its recipe also documents the Windows DLL rule (a subprocess resolves DLLs via `PATH`, not RPATH, so dependencies' `bin` dirs go on the build `PATH`).
+- **Fix: the build driver materializes eval-coerced source paths** — `src = ./file` produced only the source store path *text* during evaluation (eval performs no store writes — the parity runner's store is not writable), so input validation failed on the missing path. The driver now copies each coerced source into the store, marks it read-only, and registers it with its real NAR hash before building.
+- **`data/nix/fetchurl.nix` documentation rewritten as original prose** — the functional content is fixed byte-for-byte by derivation-hash parity and is unchanged (CI-verified).
+
 ## 0.3.0.0 — 2026-06-06
 
 ### Milestone: Derivation-Hash Parity with Upstream Nix

--- a/README.md
+++ b/README.md
@@ -14,7 +14,23 @@
 
 ## Status
 
-nova-nix evaluates real nixpkgs. `import <nixpkgs> {}` resolves the top-level package set (~23,000 attributes) to weak head normal form, and a package evaluates through the stdenv bootstrap down to a derivation:
+nova-nix builds natively on Windows. The toolchain is itself a store path — fetched, hash-verified, and unpacked through derivations — and the builder runs it directly:
+
+```console
+$ nova-nix build pkgs\windows\hello.nix
+  [build]  mingw-w64-x86_64-gcc-16.1.0-5-any.pkg.tar.zst
+  ...      (17 fixed-output fetches, one per MSYS2 package)
+  [build]  mingw-w64-seed
+  [build]  hello
+C:\nix\store\4lv3zydln7y7wg0znf56dfmzf5s59h9g-hello
+
+$ C:\nix\store\4lv3zydln7y7wg0znf56dfmzf5s59h9g-hello\hello.exe
+Hello from the first native Windows Nix build.
+```
+
+The seed (`pkgs/windows/seed.nix`) is stage 0 of a native Windows stdenv: the sha256-pinned runtime closure of MinGW-w64 GCC, merged into one toolchain root by in-process fetch and unpack builtins.
+
+It also evaluates real nixpkgs. `import <nixpkgs> {}` resolves the top-level package set (~23,000 attributes) to weak head normal form, and a package evaluates through the stdenv bootstrap down to a derivation:
 
 ```console
 $ NIX_PATH=nixpkgs=/path/to/nixpkgs \
@@ -22,7 +38,7 @@ $ NIX_PATH=nixpkgs=/path/to/nixpkgs \
 "/nix/store/gciipqhqkdlqqn803zd4a389v86ran45-hello-2.12.1.drv"
 ```
 
-That `drvPath`, and the 253-derivation closure behind it, byte-matches upstream `nix-instantiate` — verified in CI on the same nixpkgs tree. It targets the Nix 2.24 language. Evaluation and derivation-hash parity are done; *building* on Windows is the work ahead.
+That `drvPath`, and the 253-derivation closure behind it, byte-matches upstream `nix-instantiate` — verified in CI on the same nixpkgs tree. It targets the Nix 2.24 language.
 
 ## Quickstart
 
@@ -69,13 +85,13 @@ Two decisions shape the rest. **Haskell owns evaluation, C owns data layout** �
 
 ## Roadmap
 
-**Done** — parser, lazy bytecode evaluator, the Nix `builtins` set, the C99 data layer, content-addressed store, derivation builder, binary-cache substituter, `import <nixpkgs> {}` evaluation, and derivation-hash parity with upstream Nix (`hello`'s 253-derivation closure byte-matches `nix-instantiate`).
+**Done** — parser, lazy bytecode evaluator, the Nix `builtins` set, the C99 data layer, content-addressed store, derivation builder, binary-cache substituter, `import <nixpkgs> {}` evaluation, derivation-hash parity with upstream Nix (`hello`'s 253-derivation closure byte-matches `nix-instantiate`), and native Windows builds from a store-pinned MinGW-w64 toolchain (stage 0).
 
 **Next**
 
-- Windows stdenv — MinGW GCC + MSYS2 coreutils bootstrap for native builds.
+- Windows stdenv stage 1 — a setup script and compiler wrappers over the seed; rebuild coreutils and bash from source.
 - Parity across more of nixpkgs — extend the byte-match check beyond `hello`'s closure.
-- Substituter — XZ decompression and real NAR hashing (currently uncompressed-only, with a placeholder hash).
+- Substituter — XZ decompression.
 
 ## Library usage
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -19,6 +19,7 @@ module Main (main) where
 import Control.Monad (void, (>=>))
 import Data.IORef (readIORef)
 import qualified Data.Map.Strict as Map
+import Data.Maybe (catMaybes)
 import qualified Data.Text as T
 import qualified Data.Text.IO as TIO
 import Nix.Builder (BuildConfig (..), BuildResult (..), buildWithDeps, defaultBuildConfig)
@@ -29,13 +30,14 @@ import Nix.Eval.Arena (arenaInit)
 import Nix.Eval.IO (EvalState (..), newEvalState, runEvalIO)
 import Nix.Eval.Types (clistFromThunks, clistThunks, thunkToCPtr)
 import Nix.Parser (parseNix, readFileAutoEncoding)
-import Nix.Store (Store, closeStore, openStore, writeDrv, writeDrvAterm)
+import Nix.Store (Store (..), closeStore, isValid, openStore, registerPaths, registrationFor, setReadOnly, writeDrv, writeDrvAterm)
 import Nix.Store.Path (StorePath, defaultStoreDir, parseStorePath, platformStoreDir, storePathToFilePath)
 import Paths_nova_nix (getDataDir)
-import System.Directory (getCurrentDirectory, getTemporaryDirectory)
+import System.Directory (copyFile, createDirectoryIfMissing, doesDirectoryExist, getCurrentDirectory, getTemporaryDirectory, listDirectory)
 import System.Environment (getArgs)
 import System.Exit (exitFailure)
 import System.FilePath (takeDirectory)
+import qualified System.FilePath as FP
 import System.IO (BufferMode (..), hPutStrLn, hSetBuffering, stderr, stdout)
 
 -- ---------------------------------------------------------------------------
@@ -223,7 +225,13 @@ buildFile extraPaths dataDir filePath = do
           -- The full .drv closure (root + every transitive input) recorded
           -- during evaluation; written to the store before building.
           drvClosure <- readIORef (esDrvClosure st)
+          sourceCache <- readIORef (esSourcePathCache st)
           store <- openStore platformStoreDir
+          -- Materialize eval-coerced source paths (src = ./file, path
+          -- interpolation): evaluation computes their store paths as text
+          -- only — the parity runner's store is not writable — so the build
+          -- driver performs the copy and registration.
+          materializeEvalSources store sourceCache
           buildResult <- buildAndRegister store drvClosure drv drvSP
           closeStore store
           case buildResult of
@@ -286,6 +294,40 @@ buildAndRegister store drvClosure drv drvSP = do
           { bcTmpDir = tmpDir
           }
   buildWithDeps config store drv drvSP
+
+-- | Copy eval-coerced source paths into the store and register them.  The
+-- evaluator's source-path cache maps each coerced filesystem path to its
+-- @source@ fixed-output store path (text only — eval performs no store
+-- writes).  Each entry not already valid is copied in, made read-only, and
+-- registered with its real NAR hash.  A copied source carries no references.
+materializeEvalSources :: Store -> Map.Map T.Text T.Text -> IO ()
+materializeEvalSources store sourceCache = do
+  regs <- catMaybes <$> mapM adopt (Map.toList sourceCache)
+  registerPaths (stDB store) regs
+  where
+    adopt (rawPath, spText) =
+      case parseStorePath defaultStoreDir spText of
+        Nothing -> pure Nothing
+        Just sp -> do
+          valid <- isValid store sp
+          if valid
+            then pure Nothing
+            else do
+              let dest = storePathToFilePath platformStoreDir sp
+              copyPathInto (T.unpack rawPath) dest
+              setReadOnly dest
+              Just <$> registrationFor store sp Nothing []
+
+-- | Recursively copy a file or directory tree to a destination path.
+copyPathInto :: FilePath -> FilePath -> IO ()
+copyPathInto src dest = do
+  isDir <- doesDirectoryExist src
+  if isDir
+    then do
+      createDirectoryIfMissing True dest
+      names <- listDirectory src
+      mapM_ (\name -> copyPathInto (src FP.</> name) (dest FP.</> name)) names
+    else copyFile src dest
 
 -- | Write every recorded @.drv@ ATerm (keyed by its store-path text) to the
 -- store.  Keys come from evaluation via 'storePathToText' so they always parse;

--- a/data/nix/fetchurl.nix
+++ b/data/nix/fetchurl.nix
@@ -1,12 +1,19 @@
-# Nix built-in fetchurl — creates a fixed-output derivation that downloads a URL.
-# This file is normally shipped with the Nix daemon as <nix/fetchurl.nix>.
-# nova-nix bundles it so that nixpkgs bootstrap works without a system Nix install.
+# nova-nix's implementation of the <nix/fetchurl.nix> interface.
+#
+# Nix exposes a built-in fetcher expression under the search-path entry
+# <nix/fetchurl.nix>; nixpkgs' bootstrap imports it directly, so nova-nix
+# must provide one with the exact same interface and derivation output.
+# Every attribute below feeds the .drv ATerm, so the produced derivation
+# (and therefore its store path) byte-matches upstream Nix — this is
+# enforced by the parity CI job.  The argument names, default chains, and
+# derivation attributes are all fixed by that contract; only fetch one
+# thing at a time and let the fixed-output hash do the verifying.
 {
-  system ? "", # obsolete
+  system ? "", # ignored; kept for interface compatibility
   url,
   hash ? "", # an SRI hash
 
-  # Legacy hash specification
+  # Pre-SRI hash arguments, still accepted everywhere in nixpkgs.
   md5 ? "",
   sha1 ? "",
   sha256 ? "",
@@ -42,9 +49,13 @@
 
 derivation (
   {
+    # Handled in-process by the Builder, not spawned as a subprocess
+    # (see Nix.Builder.runBuiltinFetchurl).
     builder = "builtin:fetchurl";
 
-    # New-style output content requirements.
+    # An unpacked or executable output is a tree, so its fixed-output
+    # hash must be taken over the NAR serialisation rather than the
+    # flat file bytes.
     outputHashMode = if unpack || executable then "recursive" else "flat";
 
     inherit
@@ -56,9 +67,11 @@ derivation (
 
     system = "builtin";
 
-    # No need to double the amount of network traffic
+    # The fetch is cheaper than copying the result between machines.
     preferLocalBuild = true;
 
+    # Proxy configuration may legitimately vary between hosts without
+    # changing what gets fetched, so it is allowed through the env.
     impureEnvVars = [
       "http_proxy"
       "https_proxy"
@@ -67,7 +80,8 @@ derivation (
       "no_proxy"
     ];
 
-    # To make "nix-prefetch-url" work.
+    # Tooling that prefetches (nix-prefetch-url and friends) reads the
+    # candidate URLs from this attribute.
     urls = [ url ];
   }
   // (if impure then { __impure = true; } else { inherit outputHashAlgo outputHash; })

--- a/nova-nix.cabal
+++ b/nova-nix.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               nova-nix
-version:            0.3.0.0
+version:            0.4.0.0
 synopsis:           Windows-native Nix implementation in Haskell and C99
 description:
   A from-scratch implementation of the Nix package manager that runs

--- a/nova-nix.cabal
+++ b/nova-nix.cabal
@@ -74,6 +74,7 @@ library
     Nix.DependencyGraph
     Nix.Derivation
     Nix.Builder
+    Nix.Builder.Unpack
     Nix.Substituter
     Nix.Builtins
     Nix.Hash
@@ -95,8 +96,10 @@ library
     , process             >= 1.6 && < 1.7
     , regex-tdfa          >= 1.3 && < 1.4
     , sqlite-simple       >= 0.4 && < 0.5
+    , tar                 >= 0.7.1 && < 0.8
     , text                >= 2.0 && < 2.2
     , time                >= 1.9 && < 1.15
+    , zstd                >= 0.1 && < 0.2
 
   c-sources:
     cbits/nn_symbol.c
@@ -163,7 +166,9 @@ test-suite nova-nix-test
     , nova-cache          >= 0.3.0 && < 0.4
     , nova-nix
     , process             >= 1.6 && < 1.7
+    , tar                 >= 0.7.1 && < 0.8
     , text                >= 2.0 && < 2.2
+    , zstd                >= 0.1 && < 0.2
 
 source-repository head
   type:     git

--- a/pkgs/windows/hello.c
+++ b/pkgs/windows/hello.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+
+int main(void) {
+    printf("Hello from the first native Windows Nix build.\n");
+    return 0;
+}

--- a/pkgs/windows/hello.nix
+++ b/pkgs/windows/hello.nix
@@ -1,0 +1,26 @@
+# Step 4 of the stdenv plan: the first package built natively on Windows
+# through a Nix derivation.  The compiler comes from the stage-0 seed (a
+# store path), the source is copied into the store, and the output lands in
+# the store with scanned references and a real NAR hash.
+#
+# cmd.exe is the one ambient tool here — the OS-guaranteed bootstrap shell,
+# used only until stage 1 rebuilds bash from source.  It expands %out% and
+# %src% from the build environment, the same role /bin/sh plays on Linux.
+let
+  seed = import ./seed.nix;
+in
+derivation {
+  name = "hello";
+  system = "x86_64-windows";
+  builder = "cmd.exe";
+  args = [
+    "/c"
+    "mkdir %out% && ${seed}/mingw64/bin/gcc.exe %src% -o %out%/hello.exe"
+  ];
+  src = ./hello.c;
+  # Windows resolves a subprocess's DLLs via PATH (no RPATH): gcc.exe spawns
+  # cc1.exe from lib/gcc/, whose gmp/mpfr/isl/zstd DLLs live in the seed's
+  # bin.  Dependencies' bin dirs on the build PATH is the Windows analogue of
+  # Linux stdenv's PATH setup — stage 1 will automate this.
+  PATH = "${seed}/mingw64/bin";
+}

--- a/pkgs/windows/seed.nix
+++ b/pkgs/windows/seed.nix
@@ -1,0 +1,105 @@
+# Stage 0 of the native Windows stdenv: the MinGW-w64 toolchain seed.
+#
+# The bootstrap trust anchor — pre-built MSYS2 packages, pinned by sha256,
+# fetched with builtin:fetchurl and extracted with builtin:unpack into one
+# merged toolchain root (MSYS2 packages share the mingw64/ prefix).  This is
+# the Windows equivalent of nixpkgs' bootstrapTools tarball: everything past
+# this point is built from source by tools that live in the store.
+#
+# The pin set is the runtime closure of mingw-w64-x86_64-gcc, resolved and
+# hash-verified against repo.msys2.org on 2026-06-10.  MSYS2 prunes old
+# package versions from its repo, so these URLs rot upstream; the durable
+# source is a mirror of the tarballs in our own binary cache.
+let
+  fetchurl = import <nix/fetchurl.nix>;
+
+  mirror = "https://repo.msys2.org/mingw/mingw64";
+
+  fetchMsys2 =
+    { file, sha256 }:
+    fetchurl {
+      url = "${mirror}/${file}";
+      inherit sha256;
+    };
+
+  # gcc's full runtime closure: gcc -> binutils, crt, gcc-libs, gmp, headers,
+  # isl, mpc, mpfr, windows-default-manifest, winpthreads, zlib, zstd;
+  # binutils -> gettext-runtime, libwinpthread; gcc-libs -> tzdata;
+  # gettext-runtime -> libiconv.  (cc-libs is virtual, provided by gcc-libs.)
+  packages = [
+    {
+      file = "mingw-w64-x86_64-gcc-16.1.0-5-any.pkg.tar.zst";
+      sha256 = "10f7c55275f7fbe7924209d61c368a1a6fcf775cffbdeac2eef1f5ccacdd35cd";
+    }
+    {
+      file = "mingw-w64-x86_64-binutils-2.46-3-any.pkg.tar.zst";
+      sha256 = "c2dc93c7a403574dce6c4b68584a12a95251e1088424bf3c43bc5130808fc626";
+    }
+    {
+      file = "mingw-w64-x86_64-gcc-libs-16.1.0-5-any.pkg.tar.zst";
+      sha256 = "aa560f5438c35b71c3e7b24fd5becbca028f70c5b4d1f1697a86ff80fec947da";
+    }
+    {
+      file = "mingw-w64-x86_64-crt-14.0.0.r59.g93753750c-1-any.pkg.tar.zst";
+      sha256 = "74eb6daf7909f4418e3580ba1761b2ecd54d24def12270fdf4a8f3ee5c5c3663";
+    }
+    {
+      file = "mingw-w64-x86_64-headers-14.0.0.r59.g93753750c-1-any.pkg.tar.zst";
+      sha256 = "da4d28cbf691f9a1a1735004c03f28b5b667212bb829a186ddbfbcb68e12e549";
+    }
+    {
+      file = "mingw-w64-x86_64-gmp-6.3.0-2-any.pkg.tar.zst";
+      sha256 = "8924433974c4add46cb46ea4f6ef283b5c5139d3f552375115b5580f855015cc";
+    }
+    {
+      file = "mingw-w64-x86_64-isl-0.27-1-any.pkg.tar.zst";
+      sha256 = "25a18fb1ed2f580a96cb5ea6b7baa34cc385154ee5ee711175337584cc763a97";
+    }
+    {
+      file = "mingw-w64-x86_64-mpc-1.4.1-1-any.pkg.tar.zst";
+      sha256 = "ce024a90d59c8a591d2c88ef94a386c6367750bf9edc6a944e80815ec5d93344";
+    }
+    {
+      file = "mingw-w64-x86_64-mpfr-4.2.2-3-any.pkg.tar.zst";
+      sha256 = "9ecbc05f1f855bc656a8f111d367f61fbd90dbbfcf469ba74d6d5dd1ec07a542";
+    }
+    {
+      file = "mingw-w64-x86_64-windows-default-manifest-6.4-4-any.pkg.tar.zst";
+      sha256 = "716b48ad9fe4a9c88c3a323279224943b79a04152bce66797debc83491bb91fa";
+    }
+    {
+      file = "mingw-w64-x86_64-winpthreads-14.0.0.r59.g93753750c-1-any.pkg.tar.zst";
+      sha256 = "c27ee207be6633c78f3fe83c095cfa534bea6da0b88fe8f7c79a799cfdadb06d";
+    }
+    {
+      file = "mingw-w64-x86_64-libwinpthread-14.0.0.r59.g93753750c-1-any.pkg.tar.zst";
+      sha256 = "425567f0c88e660a73c9d5bb89f79e53c22d58e6ee8249480771732fbec2c6b7";
+    }
+    {
+      file = "mingw-w64-x86_64-zlib-1.3.2-2-any.pkg.tar.zst";
+      sha256 = "9e75842a070ba648e986e12424e1c92c9d7d77200e85f6a34eeb600819f2e694";
+    }
+    {
+      file = "mingw-w64-x86_64-zstd-1.5.7-2-any.pkg.tar.zst";
+      sha256 = "1add6705b344664f6aca108c85f79ab5bdd9e1162662bb06a4cf40a34f6e0907";
+    }
+    {
+      file = "mingw-w64-x86_64-gettext-runtime-1.0-1-any.pkg.tar.zst";
+      sha256 = "be68d7f260633284b910c588c6d82ee304a81c8817a686d2cd9df83f872c27af";
+    }
+    {
+      file = "mingw-w64-x86_64-tzdata-2026b-1-any.pkg.tar.zst";
+      sha256 = "e197c0f945d0461f704b46463ec7f8455d376431e8b9b489233d721275033360";
+    }
+    {
+      file = "mingw-w64-x86_64-libiconv-1.19-1-any.pkg.tar.zst";
+      sha256 = "21e334d0911f25de75d3e18e0697648bcecfa9658256d600cad0827d719c2f35";
+    }
+  ];
+in
+derivation {
+  name = "mingw-w64-seed";
+  system = "builtin";
+  builder = "builtin:unpack";
+  srcs = map fetchMsys2 packages;
+}

--- a/src/Nix/Builder.hs
+++ b/src/Nix/Builder.hs
@@ -57,6 +57,7 @@ import qualified Data.Text.IO as TIO
 import qualified Network.HTTP.Client as HTTP
 import qualified Network.HTTP.Client.TLS as HTTPS
 import qualified Network.HTTP.Types.Status as HTTP
+import Nix.Builder.Unpack (builtinUnpackBuilder, runBuiltinUnpack)
 import Nix.DependencyGraph (DepGraph, TopoResult (..), buildDepGraph, topoSort)
 import qualified Nix.DependencyGraph
 import Nix.Derivation (Derivation (..), DerivationOutput (..), fromATerm)
@@ -198,7 +199,9 @@ buildDerivationInner config store drv = do
       -- everything else is a normal subprocess.  The output validation and
       -- registration below are shared by both paths.
       exitResult <- case drvBuilder drv of
-        b | b == builtinFetchurlBuilder -> runBuiltinFetchurl drv outputDirs
+        b
+          | b == builtinFetchurlBuilder -> runBuiltinFetchurl drv outputDirs
+          | b == builtinUnpackBuilder -> runBuiltinUnpack drv outputDirs
         _ -> runBuilder builderPath builderArgs environ buildDir
       case exitResult of
         Left (exitCode, stderrText) -> do

--- a/src/Nix/Builder/Unpack.hs
+++ b/src/Nix/Builder/Unpack.hs
@@ -1,0 +1,369 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- | __builtin:unpack__ — in-process archive extraction for the bootstrap seed.
+--
+-- == Why this is a builtin
+--
+-- The Windows stdenv bootstrap fetches pre-built toolchain tarballs (MSYS2
+-- @.pkg.tar.zst@ packages) into the store before any toolchain exists there.
+-- Nothing in the store can unpack them — the unpacker is the thing being
+-- bootstrapped — and ambient @tar.exe@ is unpinned and may lack zstd support.
+-- So, like 'Nix.Builder.runBuiltinFetchurl', extraction runs in-process:
+-- a derivation whose @builder@ is @builtin:unpack@ is handled by this module
+-- instead of being spawned as a subprocess.
+--
+-- == Derivation interface
+--
+-- * @srcs@ — whitespace-separated archive store paths, extracted in order
+--   into the single @out@ output.  MSYS2 packages share a top-level
+--   @mingw64\/@ prefix, so extracting a package set into one output yields a
+--   working toolchain root directly (no separate union step).
+-- * @out@ — the merged tree.
+--
+-- == Determinism
+--
+-- Extraction is a pure function of the archive bytes: entries are written in
+-- archive order, a file appearing in two archives is an error (pacman
+-- enforces the same no-conflict invariant), and pacman's per-package
+-- metadata entries (@.PKGINFO@, @.MTREE@, …) are skipped — they are not part
+-- of the installed tree and would otherwise collide across packages.
+--
+-- Symlink and hardlink entries are materialized by __copying__ their target:
+-- symlinks on Windows require elevation or Developer Mode, so a link in the
+-- store would make the output machine-dependent.  Copying is deterministic
+-- everywhere at a small size cost.
+module Nix.Builder.Unpack
+  ( -- * Builder name
+    builtinUnpackBuilder,
+
+    -- * Derivation environment keys
+    envSrcs,
+
+    -- * Running
+    runBuiltinUnpack,
+  )
+where
+
+import qualified Codec.Archive.Tar as Tar
+import qualified Codec.Archive.Tar.Entry as TarEntry
+import qualified Codec.Compression.Zstd.Lazy as Zstd
+import Control.Exception (SomeException, try)
+import Control.Monad (when)
+import Data.Bits ((.&.))
+import qualified Data.ByteString.Lazy as BL
+import Data.Char (toLower)
+import Data.List (isPrefixOf, isSuffixOf)
+import qualified Data.Map.Strict as Map
+import Data.Text (Text)
+import qualified Data.Text as T
+import Nix.Derivation (Derivation (..))
+import System.Directory
+  ( copyFile,
+    createDirectoryIfMissing,
+    doesDirectoryExist,
+    doesFileExist,
+    doesPathExist,
+    getPermissions,
+    listDirectory,
+    setOwnerExecutable,
+    setPermissions,
+  )
+import System.FilePath (isAbsolute, joinPath, splitDirectories, takeDirectory, (</>))
+import qualified System.Info
+
+-- ---------------------------------------------------------------------------
+-- Named constants
+-- ---------------------------------------------------------------------------
+
+-- | The magic builder string for the built-in archive extractor.  A
+-- derivation with this builder is not executed as a process — the Builder
+-- extracts its @srcs@ archives into @$out@ (see 'runBuiltinUnpack').
+builtinUnpackBuilder :: Text
+builtinUnpackBuilder = "builtin:unpack"
+
+-- | Derivation environment key holding the whitespace-separated archive
+-- store paths to extract.  Store paths never contain whitespace (store-name
+-- validation rejects it), so splitting on words is unambiguous.
+envSrcs :: Text
+envSrcs = "srcs"
+
+-- | Name of the output the merged tree is extracted into.
+unpackOutputName :: Text
+unpackOutputName = "out"
+
+-- | Owner-execute bit of a tar header's mode field (octal @0o100@).
+ownerExecuteMode :: TarEntry.Permissions
+ownerExecuteMode = 0o100
+
+-- | Pax per-file extended header ('x') and global header ('g') type codes.
+-- 'Tar.decodeLongNames' already applies pax path\/linkpath overrides; any
+-- header entries still present carry only metadata we do not record (mtime,
+-- xattrs), so they are skipped rather than rejected.
+paxPerFileCode, paxGlobalCode :: Char
+paxPerFileCode = 'x'
+paxGlobalCode = 'g'
+
+-- | True on a Windows host.  NTFS has no executable bit (PATHEXT decides),
+-- so tar mode bits are only materialized on Unix.
+isWindowsHost :: Bool
+isWindowsHost = System.Info.os == "mingw32"
+
+-- ---------------------------------------------------------------------------
+-- Entry types after long-name decoding
+-- ---------------------------------------------------------------------------
+
+-- | Entries as produced by 'Tar.decodeLongNames': GNU\/pax long names are
+-- resolved, so paths and link targets are plain 'FilePath's.
+type DecodedEntries =
+  Tar.GenEntries BL.ByteString FilePath FilePath DecodeError
+
+-- | A single decoded entry.
+type DecodedEntry = Tar.GenEntry BL.ByteString FilePath FilePath
+
+-- | Format errors from 'Tar.read' or long-name decoding.
+type DecodeError = Either Tar.FormatError Tar.DecodeLongNamesError
+
+-- ---------------------------------------------------------------------------
+-- Entry point
+-- ---------------------------------------------------------------------------
+
+-- | Run a @builtin:unpack@ derivation: extract every archive listed in its
+-- @srcs@ env into the @out@ output directory.  Returns the same
+-- @Either (exit, msg) ()@ shape as the process runner, so the shared
+-- output-validation and registration path in "Nix.Builder" is reused
+-- unchanged.
+runBuiltinUnpack :: Derivation -> [(Text, FilePath)] -> IO (Either (Int, Text) ())
+runBuiltinUnpack drv outputDirs =
+  case (Map.lookup envSrcs (drvEnv drv), lookup unpackOutputName outputDirs) of
+    (Nothing, _) -> failure "derivation has no 'srcs'"
+    (Just srcs, _)
+      | null (sourcePaths srcs) -> failure "'srcs' is empty"
+    (_, Nothing) -> failure "derivation defines no 'out' output"
+    (Just srcs, Just outDir) -> do
+      createDirectoryIfMissing True outDir
+      result <- unpackAll outDir (sourcePaths srcs)
+      pure $ case result of
+        Left msg -> Left (1, "builtin:unpack: " <> msg)
+        Right () -> Right ()
+  where
+    failure msg = pure (Left (1, "builtin:unpack: " <> msg))
+    sourcePaths = map T.unpack . T.words
+
+-- | Extract archives in order, stopping at the first failure.
+unpackAll :: FilePath -> [FilePath] -> IO (Either Text ())
+unpackAll _ [] = pure (Right ())
+unpackAll outDir (archive : rest) = do
+  result <- unpackArchive outDir archive
+  case result of
+    Left err -> pure (Left err)
+    Right () -> unpackAll outDir rest
+
+-- | Unpack one archive into @outDir@.  The decompressor is chosen by file
+-- extension; the tar stream is decoded (GNU + pax long names) and extracted
+-- entry by entry.  Decompression errors surface lazily mid-stream, so the
+-- whole extraction is exception-wrapped into a clean failure.
+unpackArchive :: FilePath -> FilePath -> IO (Either Text ())
+unpackArchive outDir archivePath = do
+  attempt <- try run
+  pure $ case attempt of
+    Left (e :: SomeException) ->
+      Left (T.pack archivePath <> ": " <> T.pack (show e))
+    Right result -> result
+  where
+    run = case decoderFor archivePath of
+      Nothing -> pure (Left ("unsupported archive format: " <> T.pack archivePath))
+      Just decoder -> do
+        raw <- BL.readFile archivePath
+        extractEntries outDir (Tar.decodeLongNames (Tar.read (decoder raw)))
+
+-- | Choose a decompressor from the archive file name.  @.tar.zst@ (MSYS2
+-- packages) and plain @.tar@ are supported.  MSYS2's zstd frames do not
+-- pledge a content size, so the lazy (streaming) zstd decoder is required —
+-- the strict single-shot API rejects them.
+decoderFor :: FilePath -> Maybe (BL.ByteString -> BL.ByteString)
+decoderFor path
+  | ".tar.zst" `isSuffixOf` lowered = Just Zstd.decompress
+  | ".tar" `isSuffixOf` lowered = Just id
+  | otherwise = Nothing
+  where
+    lowered = map toLower path
+
+-- ---------------------------------------------------------------------------
+-- Entry extraction
+-- ---------------------------------------------------------------------------
+
+-- | Walk the entry stream, extracting each entry under @outDir@.
+extractEntries :: FilePath -> DecodedEntries -> IO (Either Text ())
+extractEntries outDir = go
+  where
+    go stream = case stream of
+      Tar.Done -> pure (Right ())
+      Tar.Fail err -> pure (Left ("malformed archive: " <> T.pack (show err)))
+      Tar.Next entry rest -> do
+        result <- extractEntry outDir entry
+        case result of
+          Left err -> pure (Left err)
+          Right () -> go rest
+
+-- | Extract a single entry, after validating its path stays inside the
+-- archive root and skipping pacman package metadata.
+extractEntry :: FilePath -> DecodedEntry -> IO (Either Text ())
+extractEntry outDir entry =
+  case entryComponents (TarEntry.entryTarPath entry) of
+    Left err -> pure (Left err)
+    -- The archive root itself (an entry for "." or "./").
+    Right [] -> pure (Right ())
+    Right comps
+      | isPackageMetadata comps -> pure (Right ())
+      | otherwise -> extractContent outDir comps entry
+
+-- | Extract a path-validated entry's content.  @comps@ is non-empty (the
+-- empty case is consumed by 'extractEntry').
+extractContent :: FilePath -> [FilePath] -> DecodedEntry -> IO (Either Text ())
+extractContent outDir comps entry =
+  case TarEntry.entryContent entry of
+    Tar.Directory -> do
+      createDirectoryIfMissing True dest
+      pure (Right ())
+    Tar.NormalFile bytes _size -> do
+      fresh <- freshDestination dest
+      case fresh of
+        Left err -> pure (Left err)
+        Right () -> do
+          createDirectoryIfMissing True (takeDirectory dest)
+          BL.writeFile dest bytes
+          when (executableEntry entry && not isWindowsHost) (markExecutable dest)
+          pure (Right ())
+    -- A symlink target is relative to the link's own directory.
+    Tar.SymbolicLink target ->
+      copyLinkTarget "symlink" (resolveLinkTarget parentComps target)
+    -- A hardlink target is relative to the archive root.
+    Tar.HardLink target ->
+      copyLinkTarget "hardlink" (entryComponents target)
+    Tar.OtherEntryType code _ _
+      | code == paxPerFileCode || code == paxGlobalCode -> pure (Right ())
+      | otherwise ->
+          pure (Left ("unsupported tar entry type '" <> T.singleton code <> "': " <> pathText))
+    Tar.CharacterDevice _ _ -> unsupportedSpecial "character device"
+    Tar.BlockDevice _ _ -> unsupportedSpecial "block device"
+    Tar.NamedPipe -> unsupportedSpecial "named pipe"
+  where
+    dest = outDir </> joinPath comps
+    parentComps = take (length comps - 1) comps
+    pathText = T.pack (TarEntry.entryTarPath entry)
+    unsupportedSpecial kind =
+      pure (Left ("unsupported " <> kind <> " entry: " <> pathText))
+    copyLinkTarget kind resolved = case resolved of
+      Left err -> pure (Left err)
+      Right targetComps -> do
+        let targetPath = outDir </> joinPath targetComps
+        isFile <- doesFileExist targetPath
+        isDir <- doesDirectoryExist targetPath
+        copyTarget kind targetPath isFile isDir
+    copyTarget kind targetPath isFile isDir
+      | isFile = do
+          fresh <- freshDestination dest
+          case fresh of
+            Left err -> pure (Left err)
+            Right () -> do
+              createDirectoryIfMissing True (takeDirectory dest)
+              copyFile targetPath dest
+              pure (Right ())
+      | isDir = do
+          copyTree targetPath dest
+          pure (Right ())
+      | otherwise =
+          pure
+            ( Left
+                ( kind
+                    <> " target not present (links must follow their targets in the archive): "
+                    <> pathText
+                    <> " -> "
+                    <> T.pack targetPath
+                )
+            )
+
+-- ---------------------------------------------------------------------------
+-- Path validation
+-- ---------------------------------------------------------------------------
+
+-- | Split a tar entry path into validated components: relative, no @..@, no
+-- @:@ (drive letters, NTFS alternate data streams).  Tar paths use @/@;
+-- 'splitDirectories' accepts both separators on Windows.  @.@ components are
+-- dropped, so @./mingw64@ and @mingw64@ agree.
+entryComponents :: FilePath -> Either Text [FilePath]
+entryComponents raw
+  | isAbsolute raw = Left ("absolute entry path: " <> T.pack raw)
+  | ".." `elem` comps = Left ("entry path escapes archive root: " <> T.pack raw)
+  | any (elem ':') comps = Left ("entry path contains ':': " <> T.pack raw)
+  | otherwise = Right comps
+  where
+    comps = filter (/= ".") (splitDirectories raw)
+
+-- | Resolve a symlink target (relative to the link's parent directory)
+-- against the archive root.  @..@ components are allowed but must not climb
+-- above the root.
+resolveLinkTarget :: [FilePath] -> FilePath -> Either Text [FilePath]
+resolveLinkTarget parentComps target
+  | isAbsolute target = Left ("absolute symlink target: " <> T.pack target)
+  | otherwise = walk (reverse parentComps) targetComps
+  where
+    targetComps = filter (/= ".") (splitDirectories target)
+    walk stack remaining = case (stack, remaining) of
+      (_, []) -> Right (reverse stack)
+      ([], ".." : _) ->
+        Left ("symlink target escapes archive root: " <> T.pack target)
+      (_ : popped, ".." : rest) -> walk popped rest
+      (_, comp : rest)
+        | ':' `elem` comp -> Left ("symlink target contains ':': " <> T.pack target)
+        | otherwise -> walk (comp : stack) rest
+
+-- | pacman package metadata at the archive root (@.PKGINFO@, @.BUILDINFO@,
+-- @.MTREE@, @.INSTALL@): describes the package to pacman, is not part of the
+-- installed tree, and collides across packages when several archives merge
+-- into one output — so root-level dotfile entries are skipped.
+isPackageMetadata :: [FilePath] -> Bool
+isPackageMetadata comps = case comps of
+  [name] -> "." `isPrefixOf` name
+  _ -> False
+
+-- ---------------------------------------------------------------------------
+-- Filesystem helpers
+-- ---------------------------------------------------------------------------
+
+-- | Guard that nothing was already extracted at @dest@.  Two archives in one
+-- seed providing the same file is a packaging error worth failing loudly on
+-- (pacman enforces the same no-conflict invariant between its packages).
+freshDestination :: FilePath -> IO (Either Text ())
+freshDestination dest = do
+  exists <- doesPathExist dest
+  pure $
+    if exists
+      then Left ("file collision between archives: " <> T.pack dest)
+      else Right ()
+
+-- | True when the entry's tar mode has the owner-execute bit.
+executableEntry :: DecodedEntry -> Bool
+executableEntry entry = TarEntry.entryPermissions entry .&. ownerExecuteMode /= 0
+
+-- | Materialize the executable bit on Unix hosts.
+markExecutable :: FilePath -> IO ()
+markExecutable path = do
+  perms <- getPermissions path
+  setPermissions path (setOwnerExecutable True perms)
+
+-- | Recursively copy a directory tree (used to materialize directory
+-- symlinks, which cannot be store-portable links on Windows).
+copyTree :: FilePath -> FilePath -> IO ()
+copyTree src dest = do
+  createDirectoryIfMissing True dest
+  names <- listDirectory src
+  mapM_ copyOne names
+  where
+    copyOne name = do
+      let from = src </> name
+          to = dest </> name
+      isDir <- doesDirectoryExist from
+      if isDir
+        then copyTree from to
+        else copyFile from to

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -3,11 +3,15 @@
 
 module Main (main) where
 
+import qualified Codec.Archive.Tar as Tar
+import qualified Codec.Archive.Tar.Entry as TarEntry
+import qualified Codec.Compression.Zstd.Lazy as ZstdL
 import Control.Exception (bracket_)
 import Control.Monad (filterM, void, when)
 import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as BL
 import qualified Data.Map.Strict as Map
-import Data.Maybe (isJust)
+import Data.Maybe (fromMaybe, isJust)
 import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as T
@@ -16,6 +20,7 @@ import qualified Data.Text.IO as TIO
 import Foreign.Ptr (castPtr)
 import Foreign.StablePtr (StablePtr, castPtrToStablePtr, castStablePtrToPtr, deRefStablePtr, freeStablePtr, newStablePtr)
 import Nix.Builder (BuildConfig (..), BuildResult (..), buildDerivation, buildWithDeps, defaultBuildConfig)
+import Nix.Builder.Unpack (builtinUnpackBuilder, envSrcs)
 import Nix.Builtins (builtinEnv, parseNixPath)
 import qualified Nix.DependencyGraph as DepGraph
 import Nix.Derivation (Derivation (..), DerivationOutput (..), Platform (..), currentPlatform, fromATerm, platformToText, toATerm)
@@ -2724,6 +2729,178 @@ testTrivialBuildIO = do
               Fail ("build failed (exit " <> T.pack (show code) <> "): " <> msg)
           ]
 
+-- | Zstd compression level for test archives (zstd's own default).
+testZstdCompressionLevel :: Int
+testZstdCompressionLevel = 3
+
+-- | Build a @.tar.zst@ archive from tar entries, MSYS2-package style.
+compressArchive :: [TarEntry.Entry] -> BL.ByteString
+compressArchive = ZstdL.compress testZstdCompressionLevel . Tar.write
+
+-- | Test-setup helpers: the paths and link targets below are short literals,
+-- so encoding them cannot fail; 'error' marks setup bugs, not test failures.
+tarPathOrDie :: Bool -> FilePath -> TarEntry.TarPath
+tarPathOrDie isDir p =
+  either (error . ("test tar path: " ++)) id (TarEntry.toTarPath isDir p)
+
+linkOrDie :: FilePath -> TarEntry.LinkTarget
+linkOrDie t =
+  fromMaybe (error ("test link target: " ++ t)) (TarEntry.toLinkTarget t)
+
+tarDir :: FilePath -> TarEntry.Entry
+tarDir p = TarEntry.directoryEntry (tarPathOrDie True p)
+
+tarFile :: FilePath -> BL.ByteString -> TarEntry.Entry
+tarFile p = TarEntry.fileEntry (tarPathOrDie False p)
+
+tarExecFile :: FilePath -> BL.ByteString -> TarEntry.Entry
+tarExecFile p content = (tarFile p content) {TarEntry.entryPermissions = 0o755}
+
+tarHardLink :: FilePath -> FilePath -> TarEntry.Entry
+tarHardLink p target =
+  TarEntry.simpleEntry (tarPathOrDie False p) (Tar.HardLink (linkOrDie target))
+
+tarSymLink :: FilePath -> FilePath -> TarEntry.Entry
+tarSymLink p target =
+  TarEntry.simpleEntry (tarPathOrDie False p) (Tar.SymbolicLink (linkOrDie target))
+
+-- | Step 3 of the ladder: @builtin:unpack@, the stage-0 seed extractor.
+-- Two zstd-compressed tar archives sharing a top-level prefix (the MSYS2
+-- @mingw64\/@ shape) are extracted into ONE output: regular files, an
+-- executable, a hardlink and a relative symlink (both materialized as
+-- copies), with pacman metadata (@.PKGINFO@\/@.MTREE@) skipped.  A second
+-- build proves cross-archive file collisions fail loudly, and a third that
+-- path traversal is rejected.
+testUnpackBuildIO :: IO [Bool]
+testUnpackBuildIO = do
+  putStrLn "builder/unpack-seed-archives"
+  withTempStore $ \store -> do
+    let storeDir = stDir store
+    tmpBase <- getTemporaryDirectory
+    let workDir = tmpBase </> "nova-nix-test-unpack-src"
+    forceRemoveIfExists workDir
+    createDirectoryIfMissing True workDir
+    let archiveTools = workDir </> "pkg-tools.tar.zst"
+        archiveData = workDir </> "pkg-data.tar.zst"
+        archiveCollide = workDir </> "pkg-collide.tar.zst"
+        archiveEscape = workDir </> "pkg-escape.tar.zst"
+    BL.writeFile archiveTools $
+      compressArchive
+        [ tarDir "pkg",
+          tarDir "pkg/bin",
+          tarExecFile "pkg/bin/tool.exe" "tool-payload",
+          tarHardLink "pkg/bin/tool-link.exe" "pkg/bin/tool.exe",
+          tarSymLink "pkg/bin/sh.exe" "tool.exe",
+          tarFile ".PKGINFO" "pkgname = tools"
+        ]
+    BL.writeFile archiveData $
+      compressArchive
+        [ tarDir "pkg",
+          tarDir "pkg/share",
+          tarFile "pkg/share/data.txt" "shared-data",
+          tarFile ".MTREE" "mtree-bytes"
+        ]
+    BL.writeFile archiveCollide $
+      compressArchive [tarFile "pkg/bin/tool.exe" "conflicting"]
+    BL.writeFile archiveEscape $
+      compressArchive [tarFile "../evil.txt" "escape"]
+    let mkUnpackDrv outP srcFiles =
+          Derivation
+            { drvOutputs =
+                [ DerivationOutput
+                    { doName = "out",
+                      doPath = outP,
+                      doHashAlgo = "",
+                      doHash = ""
+                    }
+                ],
+              drvInputDrvs = Map.empty,
+              drvInputSrcs = [],
+              drvPlatform = currentPlatform,
+              drvBuilder = builtinUnpackBuilder,
+              drvArgs = [],
+              drvEnv =
+                Map.fromList
+                  [(envSrcs, T.intercalate " " (map T.pack srcFiles))]
+            }
+        seedOut = StorePath (T.replicate 31 "0" <> "2") "unpack-seed"
+        collideOut = StorePath (T.replicate 31 "0" <> "3") "unpack-collide"
+        escapeOut = StorePath (T.replicate 31 "0" <> "4") "unpack-escape"
+    buildTmp <- (</> "nova-nix-test-unpack-build-tmp") <$> getTemporaryDirectory
+    forceRemoveIfExists buildTmp
+    createDirectoryIfMissing True buildTmp
+    let config = (defaultBuildConfig storeDir) {bcTmpDir = buildTmp}
+    seedResult <- buildDerivation config store (mkUnpackDrv seedOut [archiveTools, archiveData])
+    collideResult <- buildDerivation config store (mkUnpackDrv collideOut [archiveTools, archiveCollide])
+    escapeResult <- buildDerivation config store (mkUnpackDrv escapeOut [archiveEscape])
+    forceRemoveIfExists buildTmp
+    forceRemoveIfExists workDir
+    seedChecks <- case seedResult of
+      BuildFailure msg code ->
+        sequence
+          [ runTest "unpack seed build succeeds" $
+              Fail ("build failed (exit " <> T.pack (show code) <> "): " <> msg)
+          ]
+      BuildSuccess sp -> do
+        let outRoot = storePathToFilePath storeDir sp
+            readOut rel = do
+              let path = outRoot </> rel
+              exists <- Dir.doesFileExist path
+              if exists then Just <$> TIO.readFile path else pure Nothing
+        tool <- readOut ("pkg" </> "bin" </> "tool.exe")
+        toolLink <- readOut ("pkg" </> "bin" </> "tool-link.exe")
+        shLink <- readOut ("pkg" </> "bin" </> "sh.exe")
+        dataFile <- readOut ("pkg" </> "share" </> "data.txt")
+        pkgInfo <- Dir.doesFileExist (outRoot </> ".PKGINFO")
+        mtree <- Dir.doesFileExist (outRoot </> ".MTREE")
+        execBitOk <-
+          if SI.os == "mingw32"
+            then pure True -- NTFS has no exec bit; PATHEXT decides
+            else Dir.executable <$> getPermissions (outRoot </> "pkg" </> "bin" </> "tool.exe")
+        narInfo <- queryPathInfo (stDB store) sp
+        let realNarHash = case narInfo of
+              Just info ->
+                piNarSize info > 0 && T.isPrefixOf "sha256:" (piNarHash info)
+              Nothing -> False
+        sequence
+          [ runTest "unpack seed build succeeds" Pass,
+            runTest "unpack: file extracted with content" $
+              assertEqual "tool.exe" (Just "tool-payload") tool,
+            runTest "unpack: hardlink materialized as copy" $
+              assertEqual "tool-link.exe" (Just "tool-payload") toolLink,
+            runTest "unpack: relative symlink materialized as copy" $
+              assertEqual "sh.exe" (Just "tool-payload") shLink,
+            runTest "unpack: second archive merged into shared prefix" $
+              assertEqual "data.txt" (Just "shared-data") dataFile,
+            runTest "unpack: pacman metadata skipped" $
+              if pkgInfo || mtree
+                then Fail ".PKGINFO/.MTREE leaked into the output"
+                else Pass,
+            runTest "unpack: executable bit materialized (unix)" $
+              if execBitOk then Pass else Fail "tool.exe not executable",
+            runTest "unpack: real NAR hash registered" $
+              if realNarHash then Pass else Fail (T.pack (show narInfo))
+          ]
+    collideChecks <-
+      sequence
+        [ runTest "unpack: cross-archive file collision fails loudly" $
+            case collideResult of
+              BuildFailure msg _
+                | "file collision" `T.isInfixOf` msg -> Pass
+                | otherwise -> Fail ("wrong failure: " <> msg)
+              BuildSuccess _ -> Fail "collision build unexpectedly succeeded"
+        ]
+    escapeChecks <-
+      sequence
+        [ runTest "unpack: path traversal rejected" $
+            case escapeResult of
+              BuildFailure msg _
+                | "escapes archive root" `T.isInfixOf` msg -> Pass
+                | otherwise -> Fail ("wrong failure: " <> msg)
+              BuildSuccess _ -> Fail "escape build unexpectedly succeeded"
+        ]
+    pure (seedChecks ++ collideChecks ++ escapeChecks)
+
 -- | Step 2 of the ladder: a dependency-aware build end-to-end.  A root
 -- derivation depends on a leaf; both @.drv@ files are pre-written to the store
 -- (as the build driver's closure-writing does), and 'buildWithDeps' must read
@@ -4452,6 +4629,7 @@ main = bracket_ arenaInit arenaDestroy $ do
           testStorePaths,
           testDerivation,
           testTrivialBuildIO,
+          testUnpackBuildIO,
           testDependentBuildIO,
           testEvalFidelity,
           testHashHelpers,


### PR DESCRIPTION
First half of stdenv attack-plan step 3: the in-process archive extractor that breaks the bootstrap chicken-and-egg (nothing in the store can unpack the toolchain that is being bootstrapped, and ambient tar is unpinned).

- `builtin:unpack` derivations extract `.tar.zst` / `.tar` archives listed in `srcs` into the single `out` output, in order. MSYS2 packages share the `mingw64/` prefix, so a package set merges into a working toolchain root with no union step.
- Symlinks and hardlinks are materialized as copies: store outputs must not depend on Developer Mode/elevation on Windows.
- pacman per-package metadata (`.PKGINFO`, `.MTREE`, ...) is skipped; cross-archive file collisions and path traversal (absolute paths, `..`, `:`) fail the build loudly.
- MSYS2 zstd frames carry no pledged content size, so decompression uses the lazy streaming API; tar 0.7.1 decodes GNU and pax long names. New deps: `zstd`, `tar`.
- Shares the fetchurl dispatch and the whole output-validation / reference-scan / NAR-hash / registration path.
- `data/nix/fetchurl.nix` documentation rewritten as original prose (the functional content is fixed by derivation-hash parity and unchanged).

10 new tests (`builder/unpack-seed-archives`), 646/646 green, `-Werror` + C-strict + ormolu + hlint clean. Verified end-to-end against the real 47.8MB `mingw-w64-x86_64-gcc` package: extraction lands `mingw64/bin/gcc.exe` in a store path with a real NAR hash.

Next on this branch: the pinned 17-package seed expression and the end-to-end native build gate.