### PR TITLE
Codebase audit fixes: ship-blockers, evaluator correctness, lexer parity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,10 @@ on:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
+# Drop the default GITHUB_TOKEN to read-only; nothing here writes via it.
+permissions:
+  contents: read
+
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -33,6 +33,10 @@ on:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
+# Drop the default GITHUB_TOKEN to read-only; nothing here writes via it.
+permissions:
+  contents: read
+
 jobs:
   parity:
     name: drvPath vs upstream Nix

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,11 @@ on:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
+# Drop the default GITHUB_TOKEN to read-only; the Hackage upload uses its own
+# token (HACKAGE_TOKEN), not GITHUB_TOKEN.
+permissions:
+  contents: read
+
 jobs:
   ci:
     name: CI

--- a/cbits/nn_thunk.c
+++ b/cbits/nn_thunk.c
@@ -386,6 +386,18 @@ nn_thunk_mark_blackhole(nn_thunk_t *thunk)
     return 1;
 }
 
+/* Restore BLACKHOLE -> PENDING after a force threw and was caught upstream.
+ * mark_blackhole only flips the state byte, so payload + bc_idx are intact and
+ * the thunk is fully re-forceable; a later force re-evaluates rather than
+ * misreporting infinite recursion.  Returns 1 on success, 0 if not BLACKHOLE. */
+int
+nn_thunk_mark_pending(nn_thunk_t *thunk)
+{
+    if (thunk->state != NN_THUNK_BLACKHOLE) return 0;
+    thunk->state = NN_THUNK_PENDING;
+    return 1;
+}
+
 void *
 nn_thunk_set_computed(nn_thunk_t *thunk, void *value)
 {

--- a/cbits/nn_thunk.h
+++ b/cbits/nn_thunk.h
@@ -163,6 +163,12 @@ void    *nn_thunk_get_lambda(const nn_thunk_t *thunk);
  * Returns 1 on success, 0 if thunk is not PENDING. */
 int nn_thunk_mark_blackhole(nn_thunk_t *thunk);
 
+/* Transition BLACKHOLE -> PENDING (a force threw and was caught upstream).
+ * Payload + bc_idx are preserved, so the thunk is re-forceable; matches C++
+ * Nix restoring a thunk after a caught exception during force.
+ * Returns 1 on success, 0 if thunk is not BLACKHOLE. */
+int nn_thunk_mark_pending(nn_thunk_t *thunk);
+
 /* Set a non-COMPUTED thunk to COMPUTED with a StablePtr value (NN_VALUE_PTR).
  * Accepts PENDING or BLACKHOLE state (skips blackhole for direct memoization).
  * Returns the old payload (pending StablePtr for caller to free).

--- a/src/Nix/Builder.hs
+++ b/src/Nix/Builder.hs
@@ -605,7 +605,7 @@ prepareOutput config store candidates tempPairs drvPathText (output, (_outName, 
           -- Scan whichever artifact we will register: a leftover store path if
           -- present, otherwise the fresh build output.
           let scanPath = if onDisk then targetPath else outDir
-          inputRefs <- scanReferences (bcStoreDir config) candidates scanPath
+          inputRefs <- scanReferences candidates scanPath
           selfRefs <- scanTempReferences tempPairs scanPath
           let refs = dedupStorePaths (inputRefs ++ selfRefs)
           reg <-

--- a/src/Nix/Builder/Unpack.hs
+++ b/src/Nix/Builder/Unpack.hs
@@ -41,6 +41,10 @@ module Nix.Builder.Unpack
 
     -- * Running
     runBuiltinUnpack,
+
+    -- * Path validation (exposed for testing)
+    entryComponents,
+    resolveLinkTarget,
   )
 where
 

--- a/src/Nix/Builder/Unpack.hs
+++ b/src/Nix/Builder/Unpack.hs
@@ -68,7 +68,7 @@ import System.Directory
     setOwnerExecutable,
     setPermissions,
   )
-import System.FilePath (isAbsolute, joinPath, splitDirectories, takeDirectory, (</>))
+import System.FilePath (isAbsolute, isPathSeparator, joinPath, splitDirectories, takeDirectory, (</>))
 import qualified System.Info
 
 -- ---------------------------------------------------------------------------
@@ -294,6 +294,7 @@ extractContent outDir comps entry =
 entryComponents :: FilePath -> Either Text [FilePath]
 entryComponents raw
   | isAbsolute raw = Left ("absolute entry path: " <> T.pack raw)
+  | startsAtRoot comps = Left ("rooted entry path: " <> T.pack raw)
   | ".." `elem` comps = Left ("entry path escapes archive root: " <> T.pack raw)
   | any (elem ':') comps = Left ("entry path contains ':': " <> T.pack raw)
   | otherwise = Right comps
@@ -306,6 +307,7 @@ entryComponents raw
 resolveLinkTarget :: [FilePath] -> FilePath -> Either Text [FilePath]
 resolveLinkTarget parentComps target
   | isAbsolute target = Left ("absolute symlink target: " <> T.pack target)
+  | startsAtRoot targetComps = Left ("rooted symlink target: " <> T.pack target)
   | otherwise = walk (reverse parentComps) targetComps
   where
     targetComps = filter (/= ".") (splitDirectories target)
@@ -317,6 +319,19 @@ resolveLinkTarget parentComps target
       (_, comp : rest)
         | ':' `elem` comp -> Left ("symlink target contains ':': " <> T.pack target)
         | otherwise -> walk (comp : stack) rest
+
+-- | True when the first path component is a bare separator, i.e. a path rooted
+-- at the current drive rather than a named location (a leading @/@ or @\\@ with
+-- no drive letter).  On Windows 'isAbsolute' returns 'False' for such paths -
+-- it wants a drive letter or a UNC prefix - yet 'System.FilePath.combine' still
+-- discards the output directory when the right operand begins with a separator,
+-- so joining one onto @outDir@ drops @outDir@ and the write lands at the drive
+-- root.  'isPathSeparator' follows the host convention, so on POSIX a leading
+-- @\\@ is an ordinary filename character and correctly is not treated as rooted.
+startsAtRoot :: [FilePath] -> Bool
+startsAtRoot comps = case comps of
+  (comp : _) -> not (null comp) && all isPathSeparator comp
+  [] -> False
 
 -- | pacman package metadata at the archive root (@.PKGINFO@, @.BUILDINFO@,
 -- @.MTREE@, @.INSTALL@): describes the package to pacman, is not part of the

--- a/src/Nix/Eval.hs
+++ b/src/Nix/Eval.hs
@@ -75,10 +75,10 @@ import qualified Data.ByteString as BS
 import Data.Char (chr, digitToInt, isAlpha, isDigit, isHexDigit, isOctDigit, ord)
 import Data.IORef (IORef, atomicModifyIORef', newIORef)
 import Data.Int (Int64)
-import Data.List (find, foldl', sort)
+import Data.List (find, foldl', partition, sort)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import Data.Maybe (catMaybes, fromMaybe, isJust, isNothing, maybeToList)
+import Data.Maybe (catMaybes, fromMaybe, isJust, isNothing)
 import Data.Sequence (Seq (..))
 import qualified Data.Sequence as Seq
 import qualified Data.Set as Set
@@ -596,6 +596,20 @@ evalBcNonRecAttrs env bindings = do
   thunkMap <- buildBcThunkMap env bindings
   pure (VAttrs (attrSetFromMap thunkMap))
 
+-- | Build a let\/rec frame env, sharing the parent-chain and with-scope
+-- plumbing otherwise repeated across the positional and dynamic paths.  The
+-- frame's own bindings are positional slots (@slots@\/@slotCount@) or a lazy
+-- name-table @scope@; the parent and with-scopes come from the enclosing @env@
+-- and @captureInfo@.
+newFrameEnv :: Env -> CaptureInfo -> Ptr CThunkPtr -> Int -> Maybe AttrSet -> Env
+newFrameEnv env captureInfo slots slotCount scope =
+  newCEnv slots slotCount scope (Just (buildCaptureEnv env captureInfo)) withArr withCount
+  where
+    (withArr, withCount) = case captureInfo of
+      NoCaptureInfo -> envWithScopesRaw env
+      Captures _ -> (nullPtr, 0)
+      CapturesWithScopes _ -> withScopesForCapture env
+
 -- | Evaluate a recursive attr set from bytecode bindings.
 evalBcRecAttrs :: (MonadEval m) => Env -> [BcBinding] -> CaptureInfo -> m NixValue
 evalBcRecAttrs env bindings captureInfo
@@ -603,30 +617,29 @@ evalBcRecAttrs env bindings captureInfo
       -- Positional path: slots for variable lookup, CAttrSet for return.
       let slotCount = bcBindingSlotCount bindings
           slotsPtr = allocCSlots slotCount
-          parentEnv = buildCaptureEnv env captureInfo
-          (withArr, withCount) = case captureInfo of
-            NoCaptureInfo -> envWithScopesRaw env
-            Captures _ -> (nullPtr, 0)
-            CapturesWithScopes _ -> withScopesForCapture env
-          recEnv = newCEnv slotsPtr slotCount Nothing (Just parentEnv) withArr withCount
+          recEnv = newFrameEnv env captureInfo slotsPtr slotCount Nothing
           thunkList = buildBcSlotThunks recEnv env bindings
           filled = fillCSlots slotsPtr thunkList
           attrMap = buildBcAttrMapFromSlots bindings thunkList
        in filled `seq` pure (VAttrs (attrSetFromMap attrMap))
   | otherwise = do
-      -- Fallback: dynamic/nested keys - two-phase CAttrSet.
-      allKeys <- bcBindingAllKeys env bindings
-      let cset = buildCAttrSetKeys allKeys
-          attrSet = AttrSet cset
-          parentEnv = buildCaptureEnv env captureInfo
-          (withArr, withCount) = case captureInfo of
-            NoCaptureInfo -> envWithScopesRaw env
-            Captures _ -> (nullPtr, 0)
-            CapturesWithScopes _ -> withScopesForCapture env
-          recEnv = newCEnv nullPtr 0 (Just attrSet) (Just parentEnv) withArr withCount
-      thunkMap <- buildBcThunkMap recEnv bindings
-      let filled = fillCAttrSetValues cset thunkMap
-       in filled `seq` pure (VAttrs attrSet)
+      -- Dynamic-key path: the set has a ${dynamic} key or a nested a.b path, so
+      -- names are not all known at compile time.  Not a corner-cutting fallback:
+      -- it follows C++ Nix's env2 semantics.  The rec env holds the
+      -- statically-named bindings as thunks, and the dynamic keys AND values are
+      -- evaluated against it - so they can see static siblings and enclosing
+      -- vars, but not another dynamic key.  The result is the static bindings
+      -- plus the dynamic (name -> value) pairs.
+      let scopeCset = buildCAttrSetKeys (bcBindingStaticKeys bindings)
+          recEnv = newFrameEnv env captureInfo nullPtr 0 (Just (AttrSet scopeCset))
+          (staticBs, dynBs) = partition bcBindingIsStatic bindings
+      staticThunks <- buildBcThunkMap recEnv staticBs
+      let scopeFilled = fillCAttrSetValues scopeCset staticThunks
+      dynThunks <- scopeFilled `seq` buildBcThunkMap recEnv dynBs
+      let allThunks = Map.unionWith mergeThunks dynThunks staticThunks
+          resultCset = buildCAttrSetKeys (Map.keys allThunks)
+          filled = fillCAttrSetValues resultCset allThunks
+       in filled `seq` pure (VAttrs (AttrSet resultCset))
 
 -- | Evaluate a let expression from bytecode.
 evalBcLet :: (MonadEval m) => Env -> Word32 -> m NixValue
@@ -642,24 +655,15 @@ evalBcLet env bcIdx0 = do
       -- Positional path: slots for O(1) lookup.
       let slotCount = bcBindingSlotCount bindings
           slotsPtr = allocCSlots slotCount
-          parentEnv = buildCaptureEnv env captureInfo
-          (withArr, withCount) = case captureInfo of
-            NoCaptureInfo -> envWithScopesRaw env
-            Captures _ -> (nullPtr, 0)
-            CapturesWithScopes _ -> withScopesForCapture env
-          letEnv = newCEnv slotsPtr slotCount Nothing (Just parentEnv) withArr withCount
+          letEnv = newFrameEnv env captureInfo slotsPtr slotCount Nothing
           filled = fillCSlots slotsPtr (buildBcSlotThunks letEnv env bindings)
        in filled `seq` evalBytecode letEnv bodyIdx
     else do
-      -- Fallback: dynamic/nested keys - two-phase CAttrSet.
-      allKeys <- bcBindingAllKeys env bindings
-      let cset = buildCAttrSetKeys allKeys
-          parentEnv = buildCaptureEnv env captureInfo
-          (withArr, withCount) = case captureInfo of
-            NoCaptureInfo -> envWithScopesRaw env
-            Captures _ -> (nullPtr, 0)
-            CapturesWithScopes _ -> withScopesForCapture env
-          letEnv = newCEnv nullPtr 0 (Just (AttrSet cset)) (Just parentEnv) withArr withCount
+      -- Dynamic path: a nested a.b binding (a dynamic top-level key is not valid
+      -- in a let).  Every top-level key is therefore static; sub-keys and values
+      -- resolve in the let env, which the body also sees.
+      let cset = buildCAttrSetKeys (bcBindingStaticKeys bindings)
+          letEnv = newFrameEnv env captureInfo nullPtr 0 (Just (AttrSet cset))
       thunkMap <- buildBcThunkMap letEnv bindings
       let filled = fillCAttrSetValues cset thunkMap
        in filled `seq` evalBytecode letEnv bodyIdx
@@ -774,20 +778,27 @@ buildBcNestedAttr thunkEnv [key] valBcIdx =
 buildBcNestedAttr thunkEnv (key : rest) valBcIdx =
   Map.singleton key (evaluated (VAttrs (attrSetFromMap (buildBcNestedAttr thunkEnv rest valBcIdx))))
 
--- | Extract all top-level keys from bytecode bindings, resolving
--- dynamic keys as needed.  Used by the fallback path (two-phase
--- CAttrSet construction) where all keys must be known before thunks.
-bcBindingAllKeys :: (MonadEval m) => Env -> [BcBinding] -> m [Text]
-bcBindingAllKeys env bindings = fmap concat (mapM oneBinding bindings)
+-- | Top-level keys knowable without evaluating any dynamic key: static keys
+-- and inherited names.  These populate the rec env's name table while the
+-- dynamic keys are evaluated, so a dynamic key can reference a static sibling
+-- or an enclosing variable (matching C++ Nix's env2), but not another dynamic
+-- key.
+bcBindingStaticKeys :: [BcBinding] -> [Text]
+bcBindingStaticKeys = concatMap oneBinding
   where
-    oneBinding (BcNamed (key : _) _) = do
-      resolved <- resolveBcKey env key
-      pure (maybeToList resolved)
-    oneBinding (BcNamed [] _) = pure []
-    oneBinding (BcInherit syms) =
-      pure (map (symbolText . Symbol) syms)
-    oneBinding (BcInheritFrom _ syms) =
-      pure (map (symbolText . Symbol) syms)
+    oneBinding (BcNamed (BcStaticKey sym : _) _) = [symbolText (Symbol sym)]
+    oneBinding (BcNamed _ _) = []
+    oneBinding (BcInherit syms) = map (symbolText . Symbol) syms
+    oneBinding (BcInheritFrom _ syms) = map (symbolText . Symbol) syms
+
+-- | True when a binding's top-level key is known statically (a static key or an
+-- inherit).  These bindings populate the rec env's name table (C++ Nix's env2);
+-- a binding with a dynamic top-level key does not - it is added to the value.
+bcBindingIsStatic :: BcBinding -> Bool
+bcBindingIsStatic (BcNamed (BcStaticKey _ : _) _) = True
+bcBindingIsStatic (BcNamed _ _) = False
+bcBindingIsStatic (BcInherit _) = True
+bcBindingIsStatic (BcInheritFrom _ _) = True
 
 -- ---------------------------------------------------------------------------
 -- Search paths (<nixpkgs>, <nixpkgs/lib>)
@@ -1669,11 +1680,16 @@ mergeSorted :: (MonadEval m) => NixValue -> [NixValue] -> [NixValue] -> m [NixVa
 mergeSorted _ [] ys = pure ys
 mergeSorted _ xs [] = pure xs
 mergeSorted cmp (x : xs) (y : ys) = do
-  partial <- applyValue cmp x
-  result <- applyValue partial y
+  -- Stable merge: take the right element only when it is STRICTLY less than the
+  -- left (@cmp y x@).  On a tie - neither strictly less - take the left element,
+  -- so comparator-equal elements keep their input order, matching C++ Nix's
+  -- std::stable_sort.  (Comparing @cmp x y@ instead would emit @y@ on a tie and
+  -- reverse equal runs.)
+  partial <- applyValue cmp y
+  result <- applyValue partial x
   case result of
-    VBool True -> (x :) <$> mergeSorted cmp xs (y : ys)
-    VBool False -> (y :) <$> mergeSorted cmp (x : xs) ys
+    VBool True -> (y :) <$> mergeSorted cmp (x : xs) ys
+    VBool False -> (x :) <$> mergeSorted cmp xs (y : ys)
     _ -> throwEvalError "builtins.sort: comparator must return a bool"
 
 builtinConcatMap :: (MonadEval m) => NixValue -> NixValue -> m NixValue
@@ -2125,10 +2141,12 @@ builtinDirOf other =
 
 dirComponent :: Text -> Text
 dirComponent t =
-  let idx = T.findIndex (== '/') (T.reverse t)
-   in case idx of
-        Nothing -> "."
-        Just n -> T.take (T.length t - n - 1) t
+  case T.findIndex (== '/') (T.reverse t) of
+    Nothing -> "."
+    Just n ->
+      let dir = T.take (T.length t - n - 1) t
+       in -- A leading or sole '/' leaves an empty prefix; Nix's dirOf yields "/".
+          if T.null dir then "/" else dir
 
 builtinConcatLists :: (MonadEval m) => NixValue -> m NixValue
 builtinConcatLists (VList cl) = do
@@ -2553,7 +2571,9 @@ splitVersionStr t
 splitVersionAfterComponent :: Text -> [Text]
 splitVersionAfterComponent t = case T.uncons t of
   Nothing -> []
-  Just ('.', rest) -> splitVersionStr rest
+  -- '.' and '-' are both component separators in Nix's version grammar, so a
+  -- '-' is skipped, not emitted as a one-character component.
+  Just (sep, rest) | sep == '.' || sep == '-' -> splitVersionStr rest
   Just _ -> splitVersionStr t
 
 spanComponent :: Text -> (Text, Text)
@@ -3168,13 +3188,53 @@ getTempDir = do
 
 -- | Fetch a URL and optionally verify its hash.
 fetchUrlSimple :: (MonadEval m) => Text -> Maybe Text -> m NixValue
-fetchUrlSimple url _sha256 = do
-  (code, stdout, stderr) <- runProcess "curl" ["-sSfL", "--", url] ""
+fetchUrlSimple url mSha256 = do
+  -- Download to a file, not through the text-mode stdout pipe (which mangles
+  -- binary), read the raw bytes, verify the pin if one was given, then store at
+  -- the canonical fixed-output path.
+  tmpDir <- getTempDir
+  let tmpFile = tmpDir <> "/nova-nix-fetchurl-" <> sha256Hex (TE.encodeUtf8 url)
+  (code, _, stderr) <- runProcess "curl" ["-sSfL", "-o", tmpFile, "--", url] ""
   if code /= 0
-    then throwEvalError ("fetch failed: " <> stderr)
+    then throwEvalError ("builtins.fetchurl: fetch failed: " <> stderr)
     else do
-      storePath <- writeToStore "fetchurl-result" stdout
+      bytes <- readFileBytes tmpFile
+      mapM_ (verifyFetchPin "builtins.fetchurl" url bytes) mSha256
+      storePath <- addFixedOutputFile (urlBaseName url) bytes
       pure (VPath storePath)
+
+-- | Store name for a fetched URL: its basename (minus query/fragment), matching
+-- C++ Nix's @baseNameOf url@ default so the fixed-output path agrees with it.
+urlBaseName :: Text -> Text
+urlBaseName url =
+  let stripped = T.takeWhile (\c -> c /= '?' && c /= '#') url
+      base = T.takeWhileEnd (/= '/') stripped
+   in if T.null base then "source" else base
+
+-- | Verify fetched bytes against a user-supplied sha256 pin, erroring on
+-- mismatch.  Accepts SRI, @sha256:@-prefixed, and bare digest forms.
+verifyFetchPin :: (MonadEval m) => Text -> Text -> BS.ByteString -> Text -> m ()
+verifyFetchPin ctx url bytes expectedStr = do
+  expected <- decodeSha256Pin ctx expectedStr
+  let got = sha256Digest bytes
+  when (expected /= got) $
+    throwEvalError
+      ( ctx
+          <> ": hash mismatch for "
+          <> url
+          <> "\n  expected: "
+          <> expectedStr
+          <> "\n  got:      sha256:"
+          <> bytesToHexText got
+      )
+
+-- | Decode a sha256 pin to raw bytes, reusing the convertHash decoders (SRI,
+-- @sha256:@-prefixed, or a bare hex/nix32/base64 digest).
+decodeSha256Pin :: (MonadEval m) => Text -> Text -> m BS.ByteString
+decodeSha256Pin ctx s
+  | Just (_, b64) <- parseSRI s = decodeBase64E ctx b64
+  | Just (algo, rest) <- parseAlgoPrefix s = snd <$> decodeWithAlgo algo rest
+  | otherwise = snd <$> decodeWithAlgo "sha256" s
 
 -- | Force a required string attribute from an attrset, using full Nix string
 -- coercion (VStr, VPath, VInt, VBool, VAttrs via __toString/outPath).

--- a/src/Nix/Eval/CThunk.hs
+++ b/src/Nix/Eval/CThunk.hs
@@ -61,6 +61,7 @@ module Nix.Eval.CThunk
 
     -- * State transitions
     cthunkMarkBlackhole,
+    cthunkMarkPending,
     cthunkSetComputed,
     cthunkSetComputedInt,
     cthunkSetComputedFloat,
@@ -183,6 +184,9 @@ foreign import ccall unsafe "nn_thunk_get_lambda"
 
 foreign import ccall unsafe "nn_thunk_mark_blackhole"
   c_nn_thunk_mark_blackhole :: CThunkPtr -> IO CInt
+
+foreign import ccall unsafe "nn_thunk_mark_pending"
+  c_nn_thunk_mark_pending :: CThunkPtr -> IO CInt
 
 foreign import ccall unsafe "nn_thunk_set_computed"
   c_nn_thunk_set_computed :: CThunkPtr -> Ptr () -> IO (Ptr ())
@@ -373,6 +377,14 @@ cthunkGetLambda = c_nn_thunk_get_lambda
 cthunkMarkBlackhole :: CThunkPtr -> IO Bool
 cthunkMarkBlackhole ptr = do
   result <- c_nn_thunk_mark_blackhole ptr
+  pure (result /= 0)
+
+-- | Restore a BLACKHOLE thunk to PENDING after a caught throw during its force,
+-- so a later force re-evaluates instead of misreporting infinite recursion.
+-- Returns 'True' on success, 'False' if the thunk was not BLACKHOLE.
+cthunkMarkPending :: CThunkPtr -> IO Bool
+cthunkMarkPending ptr = do
+  result <- c_nn_thunk_mark_pending ptr
   pure (result /= 0)
 
 -- | Set a BLACKHOLE thunk to COMPUTED with a StablePtr value (complex types).

--- a/src/Nix/Eval/IO.hs
+++ b/src/Nix/Eval/IO.hs
@@ -28,7 +28,7 @@ module Nix.Eval.IO
   )
 where
 
-import Control.Exception (Exception, SomeAsyncException, SomeException, displayException, fromException, throwIO, try)
+import Control.Exception (Exception, SomeAsyncException, SomeException, displayException, fromException, onException, throwIO, try)
 import Control.Monad (unless, when)
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Reader (ReaderT (..), ask, asks, local)
@@ -47,7 +47,7 @@ import Foreign.StablePtr (castPtrToStablePtr, castStablePtrToPtr, deRefStablePtr
 import Nix.Builtins (builtinEnv, builtinEnvWithScope, parseNixPath)
 import Nix.Eval (eval)
 import Nix.Eval.CList (CList (..))
-import Nix.Eval.CThunk (CThunkPtr, cthunkGetAttrs, cthunkGetBcIdx, cthunkGetBool, cthunkGetCtxStr, cthunkGetFloat, cthunkGetInt, cthunkGetLambda, cthunkGetList, cthunkGetPath, cthunkGetStr, cthunkMarkBlackhole, cthunkPayload, cthunkSetComputed, cthunkSetComputedAttrs, cthunkSetComputedBool, cthunkSetComputedCtxStr, cthunkSetComputedFloat, cthunkSetComputedInt, cthunkSetComputedLambda, cthunkSetComputedList, cthunkSetComputedNull, cthunkSetComputedPath, cthunkSetComputedStr, cthunkState, cthunkValueTag)
+import Nix.Eval.CThunk (CThunkPtr, cthunkGetAttrs, cthunkGetBcIdx, cthunkGetBool, cthunkGetCtxStr, cthunkGetFloat, cthunkGetInt, cthunkGetLambda, cthunkGetList, cthunkGetPath, cthunkGetStr, cthunkMarkBlackhole, cthunkMarkPending, cthunkPayload, cthunkSetComputed, cthunkSetComputedAttrs, cthunkSetComputedBool, cthunkSetComputedCtxStr, cthunkSetComputedFloat, cthunkSetComputedInt, cthunkSetComputedLambda, cthunkSetComputedList, cthunkSetComputedNull, cthunkSetComputedPath, cthunkSetComputedStr, cthunkState, cthunkValueTag)
 import Nix.Eval.Symbol (Symbol (..), symbolIntern, symbolText)
 import Nix.Eval.Types (AttrSet (..), Env (..), MonadEval (..), NixValue (..), Thunk (..), attrSetSize, emptyContext, marshalLambda, marshalStringContext, unmarshalLambdaValue, unmarshalStringContext, pattern ValueAttrs, pattern ValueBool, pattern ValueCtxStr, pattern ValueFloat, pattern ValueInt, pattern ValueLambda, pattern ValueList, pattern ValueNull, pattern ValuePath, pattern ValueStr)
 import Nix.Expr.Types (AttrKey (..), Binding (..), Expr (..), Formal (..), Formals (..), NixAtom (..), StringPart (..))
@@ -344,6 +344,17 @@ instance MonadEval EvalIO where
     wrapIO (copyToStoreIfMissing (T.unpack srcPath) destFilePath storeDir)
     pure destPath
 
+  addFixedOutputFile name bytes = do
+    -- Canonical fixed-output path: a sha256-pinned fetch must land at the same
+    -- store path C++ Nix computes, so it stays reproducible and cache-compatible.
+    let sp = makeFixedOutputPath name "sha256" "flat" (sha256Digest bytes)
+        filePath = SP.storePathToFilePath SP.defaultStoreDir sp
+        storePath = SP.storePathToText SP.defaultStoreDir sp
+    wrapIO $ do
+      Dir.createDirectoryIfMissing True (takeDirectory filePath)
+      BS.writeFile filePath bytes
+    pure storePath
+
   traceMessage msg = EvalIO (liftIO (hPutStrLn stderr (T.unpack msg)))
 
   resolvePathLiteral path = do
@@ -384,7 +395,17 @@ instance MonadEval EvalIO where
         -- Mark blackhole BEFORE evaluation - any re-entry hits the
         -- BLACKHOLE branch above.
         _ <- EvalIO (liftIO (cthunkMarkBlackhole ptr))
-        val <- evalFn env bcIdx
+        -- If the force throws (a builtins.throw caught by an upstream tryEval,
+        -- a type error, a failed import), restore the thunk to PENDING and
+        -- rethrow, so a later force of this shared thunk re-evaluates instead of
+        -- taking the BLACKHOLE branch above and aborting with a bogus "infinite
+        -- recursion".  Mirrors C++ Nix forceValue: catch (...) { restore; throw }.
+        -- A genuine self-recursion still rethrows its NixAbortError, which
+        -- escapes tryEval exactly as before.
+        val <- EvalIO $ do
+          st <- ask
+          liftIO
+            (runReaderT (unEvalIO (evalFn env bcIdx)) st `onException` cthunkMarkPending ptr)
         oldPayload <- EvalIO (liftIO (storeComputed ptr val))
         -- Free the pending env StablePtr.
         when (oldPayload /= nullPtr) $

--- a/src/Nix/Eval/Types.hs
+++ b/src/Nix/Eval/Types.hs
@@ -901,7 +901,11 @@ unmarshalLambdaValue rawPtr = do
       pure (EFNamedSet (symbolText (Symbol nameSym)) entries (extra /= 0))
   pure (VLambda (Env envPtr) formals bodyIdx)
   where
-    readLambdaEntries lamPtr count = mapM (readOneEntry lamPtr) [0 .. count - 1]
+    -- Zero-formal set patterns ({}:, { ... }:) store count 0 and a NULL
+    -- entries array; count - 1 would underflow Word16 to 65535.
+    readLambdaEntries lamPtr count
+      | count == 0 = pure []
+      | otherwise = mapM (readOneEntry lamPtr) [0 .. count - 1]
     readOneEntry lamPtr idx = do
       nameSym <- clambdaEntryName lamPtr idx
       hasDef <- clambdaEntryHasDefault lamPtr idx
@@ -943,7 +947,12 @@ unmarshalStringContext ptr = do
   textSym <- cctxstrText ptr
   count <- cctxstrCtxCount ptr
   let textVal = symbolText (Symbol textSym)
-  elems <- mapM (readElem ptr) [0 .. count - 1]
+  -- count - 1 underflows Word16 at 0 (defensive: marshal sites store
+  -- only non-empty contexts today).
+  elems <-
+    if count == 0
+      then pure []
+      else mapM (readElem ptr) [0 .. count - 1]
   pure (textVal, StringContext (Set.fromList elems))
   where
     readElem cptr idx = do
@@ -1082,6 +1091,11 @@ class (Monad m) => MonadEval m where
   -- First argument is the source path, second is the store name.
   copyPathToStore :: Text -> Text -> m Text
 
+  -- | Write raw bytes to the store at a canonical flat fixed-output path
+  -- (@makeFixedOutputPath name "sha256" "flat"@), so a hash-pinned fetch lands
+  -- at the same store path C++ Nix computes - reproducible and cacheable.
+  addFixedOutputFile :: Text -> ByteString -> m Text
+
   -- | Print a trace/warning message.
   -- IO evaluators write to stderr; pure evaluators silently discard.
   traceMessage :: Text -> m ()
@@ -1156,6 +1170,7 @@ instance MonadEval PureEval where
   getFileType _ = throwEvalError "readFileType: not available in pure evaluation"
   runProcess _ _ _ = throwEvalError "runProcess: not available in pure evaluation"
   copyPathToStore _ _ = throwEvalError "builtins.path: not available in pure evaluation"
+  addFixedOutputFile _ _ = throwEvalError "builtins.fetchurl: not available in pure evaluation"
   traceMessage _ = pure ()
   lookupDrvHash _ = pure Nothing
   cacheDrvHash _ _ = pure ()

--- a/src/Nix/Expr/Resolve.hs
+++ b/src/Nix/Expr/Resolve.hs
@@ -54,10 +54,13 @@ resolve stack expr = case expr of
             innerStack = scope : stack
          in EAttrs True (concatMap (resolveLetBinding stack innerStack) bindings) NoCaptureInfo
     | otherwise ->
-        -- Fallback: dynamic keys or nested paths - use NameBarrier.
+        -- Fallback: dynamic keys or nested paths - use NameBarrier.  Bindings
+        -- resolve against newStack (siblings visible), but a plain @inherit x@
+        -- must reference the OUTER scope - resolveLetBinding handles that, so
+        -- the barrier does not turn @inherit x@ into a self-reference.
         let names = collectBindingNames bindings
             newStack = NameBarrier names : stack
-         in EAttrs True (concatMap (resolveBinding newStack) bindings) NoCaptureInfo
+         in EAttrs True (concatMap (resolveLetBinding stack newStack) bindings) NoCaptureInfo
   EAttrs False bindings _captureInfo ->
     -- Non-recursive: bindings use the outer scope.
     EAttrs False (concatMap (resolveBinding stack) bindings) NoCaptureInfo
@@ -78,10 +81,12 @@ resolve stack expr = case expr of
             innerStack = scope : stack
          in ELet (concatMap (resolveLetBinding stack innerStack) bindings) (resolve innerStack body) NoCaptureInfo
     | otherwise ->
-        -- Fallback: dynamic keys or nested paths - use NameBarrier.
+        -- Fallback: dynamic keys or nested paths - use NameBarrier.  As above,
+        -- resolveLetBinding resolves a plain @inherit x@ against the outer scope
+        -- so the barrier does not make @x@ self-referential.
         let names = collectBindingNames bindings
             newStack = NameBarrier names : stack
-         in ELet (concatMap (resolveBinding newStack) bindings) (resolve newStack body) NoCaptureInfo
+         in ELet (concatMap (resolveLetBinding stack newStack) bindings) (resolve newStack body) NoCaptureInfo
   EIf c t f -> EIf (resolve stack c) (resolve stack t) (resolve stack f)
   EWithVar _ -> expr
   EWith scope body ->
@@ -207,14 +212,16 @@ lexicalScopeFromBindings bindings =
     -- Unreachable: allStaticSingleKey guards this path.
     bindingNames _ = []
 
--- | Resolve bindings in a let\/rec block that uses positional resolution.
--- Takes two stacks: @outerStack@ (before the let scope) and @innerStack@
--- (with the let's 'LexicalScope' pushed).
+-- | Resolve bindings in a let\/rec block, for both the positional
+-- ('LexicalScope') and fallback ('NameBarrier') paths.  Takes two stacks:
+-- @outerStack@ (before the block) and @innerStack@ (with the block's scope
+-- entry pushed).
 --
 -- Regular bindings resolve their RHS against @innerStack@ (recursive).
--- @inherit x@ desugars to @x = x@ where the RHS resolves against
--- @outerStack@ - the inherited name must reference the enclosing scope,
--- not the let scope being defined.
+-- @inherit x@ desugars to @x = x@ where the RHS resolves against @outerStack@:
+-- the inherited name must reference the enclosing scope, not the block being
+-- defined - otherwise the pushed scope\/barrier makes @x@ a self-reference and
+-- forcing it recurses forever.
 resolveLetBinding :: [ScopeEntry] -> [ScopeEntry] -> Binding -> [Binding]
 resolveLetBinding _ innerStack (NamedBinding path bodyExpr) =
   [NamedBinding (map (resolveKey innerStack) path) (resolve innerStack bodyExpr)]

--- a/src/Nix/Parser/Lexer.hs
+++ b/src/Nix/Parser/Lexer.hs
@@ -309,8 +309,9 @@ lexIndStringMode st acc
               -- Check for escape sequences: ''', ''$, ''\x, ''${
               case T.uncons rest2 of
                 Just ('\'', rest3) ->
-                  -- ''' is a literal single quote (consume all 3)
-                  let litTok = Located (lsLine st) (lsCol st) (TokStringLit "'")
+                  -- ''' escapes a literal '' (two quotes) - Nix's escape for the
+                  -- indented-string terminator, not a single quote.
+                  let litTok = Located (lsLine st) (lsCol st) (TokStringLit "''")
                       newSt = advanceCol 3 st {lsInput = rest3}
                    in lexIndStringMode newSt (litTok : acc)
                 Just ('$', rest3)
@@ -333,7 +334,8 @@ lexIndStringMode st acc
                             't' -> "\t"
                             'r' -> "\r"
                             '\\' -> "\\"
-                            _ -> "\\" <> T.singleton ec
+                            -- Unknown escape: Nix drops the backslash (''\q -> q).
+                            _ -> T.singleton ec
                           litTok = Located (lsLine st) (lsCol st) (TokStringLit escaped)
                           newSt = advanceCol 4 st {lsInput = rest4}
                        in lexIndStringMode newSt (litTok : acc)
@@ -381,6 +383,11 @@ lexStringLiteral st0 acc = go st0 mempty
             }
       Just (c, rest) -> case c of
         '"' -> finishChunk st builder
+        -- \$$ is two literal dollars (maximal munch): the second $ cannot begin an
+        -- interpolation, so $${ does not interpolate (documented Nix behavior).
+        '$'
+          | Just '$' <- safeHead rest ->
+              go (advanceCol 2 st {lsInput = T.drop 1 rest}) (builder <> TB.singleton '$' <> TB.singleton '$')
         '$' | Just '{' <- safeHead rest -> finishChunk st builder
         '\\' -> case T.uncons rest of
           Just (ec, rest2) ->
@@ -391,7 +398,8 @@ lexStringLiteral st0 acc = go st0 mempty
                   '\\' -> TB.singleton '\\'
                   '"' -> TB.singleton '"'
                   '$' -> TB.singleton '$'
-                  _ -> TB.singleton '\\' <> TB.singleton ec
+                  -- Unknown escape: Nix drops the backslash (\q -> q).
+                  _ -> TB.singleton ec
                 newSt = advanceBy ec (advanceCol 1 st {lsInput = rest2})
              in go newSt (builder <> escaped)
           Nothing ->
@@ -441,6 +449,11 @@ lexIndStringLiteral st0 acc = go st0 0
                   | Just ('\'', _) <- T.uncons rest1 ->
                       finishChunk st consumed
                 Just ('$', rest1)
+                  | Just ('$', _) <- T.uncons rest1 ->
+                      -- \$$ is two literal dollars; the second cannot begin an
+                      -- interpolation (matches lexStringLiteral and Nix).
+                      go (advanceCol 2 st {lsInput = T.drop 1 rest1}) (consumed + 2)
+                Just ('$', rest1)
                   | Just ('{', _) <- T.uncons rest1 ->
                       finishChunk st consumed
                 Just ('\n', rest1) ->
@@ -473,16 +486,17 @@ lexNumber st acc =
   let (digits, after) = T.span isDigit (lsInput st)
       len = T.length digits
    in case T.uncons after of
-        Just ('.', after2)
-          | Just (d, _) <- T.uncons after2,
-            isDigit d ->
-              let (decimals, after3) = T.span isDigit after2
-                  (expVal, after4, expLen) = lexExponent after3
-                  fullLen = T.length digits + 1 + T.length decimals + expLen
-                  val = applyExponent (readDouble digits decimals) expVal
-                  tok = Located (lsLine st) (lsCol st) (TokFloat val)
-                  newSt = advanceCol fullLen st {lsInput = after4}
-               in lexNormalMode newSt (tok : acc)
+        -- A '.' after the integer part starts a float even with no fractional
+        -- digits or with only an exponent - Nix's grammar is [0-9]+\.[0-9]*(exp)?,
+        -- so 12. and 12.e5 are floats, not an integer followed by a dot.
+        Just ('.', after2) ->
+          let (decimals, after3) = T.span isDigit after2
+              (expVal, after4, expLen) = lexExponent after3
+              fullLen = T.length digits + 1 + T.length decimals + expLen
+              val = applyExponent (readDouble digits decimals) expVal
+              tok = Located (lsLine st) (lsCol st) (TokFloat val)
+              newSt = advanceCol fullLen st {lsInput = after4}
+           in lexNormalMode newSt (tok : acc)
         _
           -- C++ Nix rejects out-of-range integer literals rather than
           -- silently wrapping modulo 2^64.

--- a/src/Nix/Store.hs
+++ b/src/Nix/Store.hs
@@ -59,7 +59,6 @@ where
 import Control.Exception (IOException, catch)
 import Control.Monad (when)
 import qualified Data.ByteString as BS
-import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as T
@@ -202,33 +201,28 @@ copyDirectoryRecursive src dest = do
 
 -- | Byte-scan all files under a directory for store path references.
 --
--- Builds a 'Set' of candidate hash strings from the given store paths.
--- Walks all regular files, reads each as ByteString, searches for the
--- store dir prefix followed by a 32-character hash.  Returns matching
--- store paths from the candidate set.
-scanReferences :: StoreDir -> [StorePath] -> FilePath -> IO [StorePath]
-scanReferences storeDir candidates dir = do
+-- Searches file bytes for each candidate's bare 32-character hash - the
+-- same needle upstream Nix scans for.  Matching the hash rather than a
+-- store-dir-prefixed path keeps the scan independent of the spelling the
+-- builder embedded (canonical @\/nix\/store\/...@, @C:\\nix\\store\\...@,
+-- MSYS2 forms): eval injects canonical forward-slash text into builder
+-- environments, which a platform-store-dir prefix never matches on
+-- Windows.
+scanReferences :: [StorePath] -> FilePath -> IO [StorePath]
+scanReferences candidates dir = do
   let candidateSet = Set.fromList [(spHash sp, sp) | sp <- candidates]
-      storeDirStr = unStoreDir storeDir
-      -- Scan for both forward-slash and backslash store prefixes.  On Windows,
-      -- binaries may contain either separator style.  Both separators are a
-      -- single ASCII byte, so the two prefixes share a length.
-      prefixFwd = TE.encodeUtf8 (T.pack (storeDirStr <> "/"))
-      prefixBwd = TE.encodeUtf8 (T.pack (storeDirStr <> "\\"))
-      prefixLen = BS.length prefixFwd
+      needles = [(TE.encodeUtf8 h, h) | (h, _) <- Set.toList candidateSet]
   files <- collectRegularFiles dir
   foundHashes <- foldlIO Set.empty files $ \acc filePath -> do
     contents <- BS.readFile filePath
-    -- Scan with forward-slash prefix, then backslash (for Windows)
-    let acc1 = scanBytes prefixFwd prefixLen storePathHashLen contents acc
-    pure (scanBytes prefixBwd prefixLen storePathHashLen contents acc1)
+    pure (Set.union acc (Set.fromList [h | (needle, h) <- needles, needle `BS.isInfixOf` contents]))
   pure [sp | (h, sp) <- Set.toList candidateSet, Set.member h foundHashes]
 
 -- | Scan an output for references to build-temp output locations.
 --
 -- The builder runs under a temp directory, so an output that embeds its own or
--- a sibling output's path embeds the TEMP path - which 'scanReferences' (store
--- prefix only) cannot see.  Given @(tempDir, storePath)@ for every output of
+-- a sibling output's path embeds the TEMP path - which 'scanReferences' does
+-- not look for.  Given @(tempDir, storePath)@ for every output of
 -- the derivation, returns the store paths whose temp location is referenced
 -- from the scanned output, capturing self- and cross-output references.
 --
@@ -264,21 +258,6 @@ collectRegularFiles path = do
         else do
           isFile <- doesFileExist fullPath
           pure [fullPath | isFile]
-
--- | Scan a ByteString for store path prefix occurrences, extract hashes.
-scanBytes :: BS.ByteString -> Int -> Int -> BS.ByteString -> Set Text -> Set Text
-scanBytes prefix prefixLen hashLen bs =
-  go 0
-  where
-    bsLen = BS.length bs
-    go !idx !found
-      | idx + prefixLen + hashLen > bsLen = found
-      | BS.isPrefixOf prefix (BS.drop idx bs) =
-          let hashBytes = BS.take hashLen (BS.drop (idx + prefixLen) bs)
-           in case TE.decodeUtf8' hashBytes of
-                Right hashText -> go (idx + prefixLen + hashLen) (Set.insert hashText found)
-                Left _ -> go (idx + 1) found
-      | otherwise = go (idx + 1) found
 
 -- | Strict left fold over a list in IO.
 foldlIO :: a -> [b] -> (a -> b -> IO a) -> IO a

--- a/src/Nix/Store/Path.hs
+++ b/src/Nix/Store/Path.hs
@@ -42,6 +42,7 @@ module Nix.Store.Path
     storePathToFilePath,
     storePathToText,
     parseStorePath,
+    parseStorePathBaseName,
 
     -- * Constants
     storePathHashLen,
@@ -117,17 +118,21 @@ storePathHashLen = 32
 parseStorePath :: StoreDir -> Text -> Maybe StorePath
 parseStorePath (StoreDir dir) path =
   let dirText = T.pack dir
-      tryWithSep sep = T.stripPrefix (dirText <> sep) path >>= parseRest
+      tryWithSep sep = T.stripPrefix (dirText <> sep) path >>= parseStorePathBaseName
    in case tryWithSep "/" of
         Just sp -> Just sp
         Nothing -> tryWithSep "\\"
-  where
-    parseRest rest
-      | T.length rest < storePathHashLen + 2 = Nothing
-      | otherwise =
-          let hashPart = T.take storePathHashLen rest
-              afterHash = T.drop storePathHashLen rest
-           in case T.uncons afterHash of
-                Just ('-', name)
-                  | not (T.null name) -> Just (StorePath hashPart name)
-                _ -> Nothing
+
+-- | Parse a store path basename like @abc...-name@ - the form narinfo
+-- @References@ and @Deriver@ fields carry on the wire - into a
+-- 'StorePath': 32-char hash, dash, non-empty name.
+parseStorePathBaseName :: Text -> Maybe StorePath
+parseStorePathBaseName basename
+  | T.length basename < storePathHashLen + 2 = Nothing
+  | otherwise =
+      let hashPart = T.take storePathHashLen basename
+          afterHash = T.drop storePathHashLen basename
+       in case T.uncons afterHash of
+            Just ('-', name)
+              | not (T.null name) -> Just (StorePath hashPart name)
+            _ -> Nothing

--- a/src/Nix/Substituter.hs
+++ b/src/Nix/Substituter.hs
@@ -47,6 +47,7 @@ module Nix.Substituter
     decompressNar,
     unpackNarEntry,
     parseReferences,
+    parseDeriver,
   )
 where
 
@@ -65,7 +66,7 @@ import qualified Network.HTTP.Client.TLS as HTTPS
 import qualified Network.HTTP.Types.Status as HTTP
 import Nix.Store (Store (..), setReadOnly)
 import Nix.Store.DB (PathRegistration (..), registerPath)
-import Nix.Store.Path (StoreDir, StorePath (..), parseStorePath, storePathHashLen, storePathToFilePath)
+import Nix.Store.Path (StoreDir, StorePath (..), parseStorePathBaseName, storePathHashLen, storePathToFilePath)
 import qualified NovaCache.Hash as Hash
 import qualified NovaCache.NAR as NAR
 import qualified NovaCache.NarInfo as NarInfo
@@ -196,9 +197,11 @@ unpackAndRegister store sp narInfo rawNar =
   -- trusting its bytes.  The NAR hash is the content-addressed integrity
   -- contract; the signature only attests to the narinfo, not the body, so
   -- network corruption or a compromised cache must be caught here.
-  case verifyNarHash narInfo rawNar of
+  -- Narinfo metadata is likewise parsed before any disk write: a malformed
+  -- narinfo must not leave an unpacked-but-unregistered path behind.
+  case verifyNarHash narInfo rawNar >> registrationMeta of
     Left err -> pure (SubstError err)
-    Right () -> case NAR.deserialise rawNar of
+    Right (refs, deriver) -> case NAR.deserialise rawNar of
       Left err -> pure (SubstError ("NAR deserialisation failed: " <> T.pack err))
       Right narEntry -> do
         let destPath = storePathToFilePath (stDir store) sp
@@ -214,10 +217,15 @@ unpackAndRegister store sp narInfo rawNar =
                 { prPath = sp,
                   prNarHash = NarInfo.niNarHash narInfo,
                   prNarSize = fromInteger (NarInfo.niNarSize narInfo),
-                  prDeriver = NarInfo.niDeriver narInfo,
-                  prReferences = parseReferences (stDir store) (NarInfo.niReferences narInfo)
+                  prDeriver = deriver,
+                  prReferences = refs
                 }
             pure (SubstSuccess sp)
+  where
+    registrationMeta = do
+      refs <- parseReferences (NarInfo.niReferences narInfo)
+      deriver <- parseDeriver (stDir store) (NarInfo.niDeriver narInfo)
+      pure (refs, deriver)
 
 -- | Verify that the downloaded NAR bytes hash to the narinfo's declared
 -- NarHash.  Compares decoded hash bytes, so any valid encoding of the digest
@@ -365,10 +373,31 @@ decompressNar compression narData
   | compression == "xz" = Left "xz decompression not yet available (enable nova-cache compression flag)"
   | otherwise = Left ("unsupported compression: " <> compression)
 
--- | Parse narinfo references (store path basenames) into StorePaths.
-parseReferences :: StoreDir -> [Text] -> [StorePath]
-parseReferences storeDir refs =
-  [sp | ref <- refs, Just sp <- [parseStorePath storeDir ref]]
+-- | Parse narinfo references (store path basenames, e.g.
+-- @abc...-glibc-2.40@) into StorePaths.  A malformed token is an error,
+-- not filtered: silently dropping a reference registers the path with a
+-- hole in its closure, which re-push then publishes as a signed narinfo
+-- missing runtime deps, and GC reads as permission to delete them.
+parseReferences :: [Text] -> Either Text [StorePath]
+parseReferences = traverse parseRef
+  where
+    parseRef ref =
+      maybe (Left ("malformed narinfo reference: " <> ref)) Right (parseStorePathBaseName ref)
+
+-- | The sentinel upstream caches emit for a path whose deriver is unknown.
+unknownDeriverSentinel :: Text
+unknownDeriverSentinel = "unknown-deriver"
+
+-- | Parse a narinfo Deriver - a store path basename on the wire, or the
+-- @unknown-deriver@ sentinel - into the full path text the store DB
+-- records (the form 'Nix.Push' parses back with 'parseStorePath').
+parseDeriver :: StoreDir -> Maybe Text -> Either Text (Maybe Text)
+parseDeriver _ Nothing = Right Nothing
+parseDeriver storeDir (Just txt)
+  | txt == unknownDeriverSentinel = Right Nothing
+  | otherwise = case parseStorePathBaseName txt of
+      Just sp -> Right (Just (T.pack (storePathToFilePath storeDir sp)))
+      Nothing -> Left ("malformed narinfo deriver: " <> txt)
 
 -- ---------------------------------------------------------------------------
 -- NAR unpacking

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -424,7 +424,24 @@ testEvalRecAttrs = do
     [ runTest "rec self-reference" $
         assertEval "rec-self" "rec { a = 1; b = a + 1; }.b" (VInt 2),
       runTest "rec mutual reference" $
-        assertEval "rec-mutual" "rec { a = 1; b = a; }.b" (VInt 1)
+        assertEval "rec-mutual" "rec { a = 1; b = a; }.b" (VInt 1),
+      -- A plain inherit inside a fallback (nested-path) rec/let must reference
+      -- the OUTER binding, not self-reference into infinite recursion.
+      runTest "inherit in fallback rec set references outer" $
+        assertEval "inherit-fallback-rec" "let n = 7; in (rec { inherit n; a.b = 1; }).n" (VInt 7),
+      runTest "inherit in fallback let references outer" $
+        assertEval "inherit-fallback-let" "let x = 5; in let a.b = 1; inherit x; in x" (VInt 5),
+      -- Guard the fix: a genuine sibling reference in a fallback rec still resolves.
+      runTest "sibling reference survives in fallback rec" $
+        assertEval "sibling-fallback-rec" "(rec { a = 1; b = a + 10; c.d = 2; }).b" (VInt 11),
+      -- Dynamic rec-set keys evaluate in the rec env (C++ Nix env2): a key may
+      -- reference an enclosing var or a static sibling, and must not abort.
+      runTest "dynamic key references enclosing var" $
+        assertEval "dyn-key-enclosing" "let k = \"x\"; in (rec { p.q = 1; ${k} = 2; }).x" (VInt 2),
+      runTest "dynamic key resolves the correct enclosing slot" $
+        assertEval "dyn-key-slot" "let a = \"A\"; b = \"B\"; in let c = \"C\"; in (rec { p.q = 1; ${b} = 2; }).B" (VInt 2),
+      runTest "dynamic key references a static rec sibling" $
+        assertEval "dyn-key-sibling" "(rec { a = \"b\"; ${a} = 1; }).b" (VInt 1)
     ]
 
 -- ---------------------------------------------------------------------------
@@ -458,7 +475,16 @@ testEvalLambda = do
       runTest "set pattern" $
         assertEval "set-pat" "({ a, b }: a + b) { a = 1; b = 2; }" (VInt 3),
       runTest "default param" $
-        assertEval "default" "({ a ? 10 }: a) { }" (VInt 10)
+        assertEval "default" "({ a ? 10 }: a) { }" (VInt 10),
+      -- Regression: zero-formal set patterns marshal count 0 / entries NULL;
+      -- the second force of the same lambda thunk re-reads the entries and
+      -- must not underflow the Word16 count (crashed pre-fix).
+      runTest "empty formals forced twice" $
+        assertEval "empty-formals" "let f = {}: 1; in f {} + f {}" (VInt 2),
+      runTest "ellipsis-only formals forced twice" $
+        assertEval "ellipsis-only" "let f = { ... }: 1; in f {} + f {}" (VInt 2),
+      runTest "named empty formals forced twice" $
+        assertEval "named-empty" "let f = args@{ ... }: 1; in f {} + f {}" (VInt 2)
     ]
 
 -- ---------------------------------------------------------------------------
@@ -605,6 +631,17 @@ testEvalHigherOrder = do
         assertEval "sort" "builtins.sort (a: b: a < b) [ 3 1 2 ] == [ 1 2 3 ]" (VBool True),
       runTest "sort already sorted" $
         assertEval "sort-sorted" "builtins.sort (a: b: a < b) [ 1 2 3 ] == [ 1 2 3 ]" (VBool True),
+      -- Stable: comparator-equal elements keep their input order (std::stable_sort).
+      runTest "sort is stable across ties" $
+        assertEval
+          "sort-stable"
+          "builtins.sort (a: b: a.k < b.k) [ { k = 1; v = 1; } { k = 0; v = 2; } { k = 1; v = 3; } { k = 0; v = 4; } ] == [ { k = 0; v = 2; } { k = 0; v = 4; } { k = 1; v = 1; } { k = 1; v = 3; } ]"
+          (VBool True),
+      runTest "sort preserves order of all-equal elements" $
+        assertEval
+          "sort-stable-all"
+          "builtins.sort (a: b: a.k < b.k) [ { k = 0; v = 1; } { k = 0; v = 2; } { k = 0; v = 3; } ] == [ { k = 0; v = 1; } { k = 0; v = 2; } { k = 0; v = 3; } ]"
+          (VBool True),
       -- concatMap
       runTest "concatMap" $
         assertEval "concatMap" "builtins.concatMap (x: [ x (x * 2) ]) [ 1 2 ] == [ 1 2 2 4 ]" (VBool True),
@@ -1163,6 +1200,10 @@ testBatch1 = do
         assertEval "dirOf-str" "builtins.dirOf \"/foo/bar/baz\"" (mkStr "/foo/bar"),
       runTest "dirOf no slash" $
         assertEval "dirOf-flat" "builtins.dirOf \"filename\"" (mkStr "."),
+      runTest "dirOf root-level path" $
+        assertEval "dirOf-root" "builtins.dirOf \"/foo\"" (mkStr "/"),
+      runTest "dirOf root" $
+        assertEval "dirOf-slash" "builtins.dirOf \"/\"" (mkStr "/"),
       -- concatLists
       runTest "concatLists basic" $
         assertEval "concatLists" "builtins.concatLists [ [ 1 2 ] [ 3 ] [ 4 5 ] ] == [ 1 2 3 4 5 ]" (VBool True),
@@ -1298,6 +1339,8 @@ testBatch4 = do
         assertEval "cmpVer-gt" "builtins.compareVersions \"2.0\" \"1.9\"" (VInt 1),
       runTest "compareVersions type error" $
         assertEvalFail "cmpVer-err" "builtins.compareVersions 1 2",
+      runTest "compareVersions treats - as a separator" $
+        assertEval "cmpVer-dash" "builtins.compareVersions \"1.0-2\" \"1.0.2\"" (VInt 0),
       -- splitVersion
       runTest "splitVersion basic" $
         assertEval "splitVer" "builtins.splitVersion \"1.2.3\" == [ \"1\" \"2\" \"3\" ]" (VBool True),
@@ -1476,6 +1519,26 @@ runTestIOFail label baseDir source = do
 -- | Quoted path literal for embedding absolute paths in Nix source.
 nixQuotedPath :: FilePath -> Text
 nixQuotedPath p = T.pack (show p)
+
+-- | Regression: a thunk whose force throws a catchable error (builtins.throw,
+-- a type error) must be restored to PENDING, not left BLACKHOLE - otherwise a
+-- later force of the same shared thunk aborts with a bogus "infinite recursion"
+-- that escapes tryEval.  Genuine self-recursion must still escape tryEval.
+-- EvalIO-only: PureEval never blackholes.
+testBlackholeRecoveryIO :: IO [Bool]
+testBlackholeRecoveryIO = do
+  putStrLn "eval/blackhole-recovery-io"
+  sequence
+    [ runTestIO
+        "tryEval twice on a shared throwing thunk recovers (no bogus recursion)"
+        "."
+        "let x = builtins.throw \"boom\"; in (if (builtins.tryEval x).success then 1 else 0) + (if (builtins.tryEval x).success then 1 else 0)"
+        (VInt 0),
+      runTestIOFail
+        "genuine infinite recursion still escapes tryEval"
+        "."
+        "builtins.tryEval (let y = y; in y)"
+    ]
 
 testImportIO :: IO [Bool]
 testImportIO = do
@@ -2277,16 +2340,32 @@ testSubstituter = do
         case Subst.decompressNar "brotli" "data" of
           Left _ -> Pass
           Right _ -> Fail "expected error for unknown",
-      -- parseReferences: valid store paths
-      runTest "parseReferences valid" $
-        let refs = ["/nix/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-hello"]
-            parsed = Subst.parseReferences defaultStoreDir refs
-         in assertEqual "parse-refs" 1 (length parsed),
-      -- parseReferences: invalid paths filtered
-      runTest "parseReferences invalid filtered" $
-        let refs = ["not-a-store-path", "/nix/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-hello"]
-            parsed = Subst.parseReferences defaultStoreDir refs
-         in assertEqual "parse-refs-filter" 1 (length parsed),
+      -- parseReferences: narinfo references are wire-format basenames
+      runTest "parseReferences basenames" $
+        let refs = ["aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-hello", "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-dep-2.0"]
+            expected =
+              [ StorePath "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" "hello",
+                StorePath "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" "dep-2.0"
+              ]
+         in assertEqual "parse-refs" (Right expected) (Subst.parseReferences refs),
+      -- parseReferences: a malformed token is a loud error, never dropped
+      runTest "parseReferences malformed rejected" $
+        case Subst.parseReferences ["not-a-store-path"] of
+          Left _ -> Pass
+          Right refs -> Fail ("expected rejection, got: " <> T.pack (show refs)),
+      -- parseDeriver: basename becomes the DB's full path text
+      runTest "parseDeriver basename" $
+        let sp = StorePath "cccccccccccccccccccccccccccccccc" "hello.drv"
+            expected = Just (T.pack (storePathToFilePath defaultStoreDir sp))
+         in assertEqual "parse-deriver" (Right expected) (Subst.parseDeriver defaultStoreDir (Just "cccccccccccccccccccccccccccccccc-hello.drv")),
+      -- parseDeriver: upstream's unknown-deriver sentinel means no deriver
+      runTest "parseDeriver unknown sentinel" $
+        assertEqual "parse-deriver-unknown" (Right Nothing) (Subst.parseDeriver defaultStoreDir (Just "unknown-deriver")),
+      -- parseDeriver: absent stays absent, malformed is an error
+      runTest "parseDeriver absent and malformed" $
+        case (Subst.parseDeriver defaultStoreDir Nothing, Subst.parseDeriver defaultStoreDir (Just "bogus")) of
+          (Right Nothing, Left _) -> Pass
+          other -> Fail ("unexpected: " <> T.pack (show other)),
       -- trySubstitute: empty caches returns SubstNotFound
       runTestM "trySubstitute no caches" $ do
         tmpBase <- getTemporaryDirectory
@@ -2901,8 +2980,9 @@ tarSymLink p target =
 -- @mingw64\/@ shape) are extracted into ONE output: regular files, an
 -- executable, a hardlink and a relative symlink (both materialized as
 -- copies), with pacman metadata (@.PKGINFO@\/@.MTREE@) skipped.  A second
--- build proves cross-archive file collisions fail loudly, and a third that
--- path traversal is rejected.
+-- build proves cross-archive file collisions fail loudly, and further builds
+-- that a parent-climbing (..) entry and drive-rooted file, symlink, and
+-- hardlink paths are all rejected.
 testUnpackBuildIO :: IO [Bool]
 testUnpackBuildIO = do
   putStrLn "builder/unpack-seed-archives"
@@ -2916,6 +2996,9 @@ testUnpackBuildIO = do
         archiveData = workDir </> "pkg-data.tar.zst"
         archiveCollide = workDir </> "pkg-collide.tar.zst"
         archiveEscape = workDir </> "pkg-escape.tar.zst"
+        archiveRootFile = workDir </> "pkg-root-file.tar.zst"
+        archiveRootSymlink = workDir </> "pkg-root-symlink.tar.zst"
+        archiveRootHardlink = workDir </> "pkg-root-hardlink.tar.zst"
     BL.writeFile archiveTools $
       compressArchive
         [ tarDir "pkg",
@@ -2936,6 +3019,14 @@ testUnpackBuildIO = do
       compressArchive [tarFile "pkg/bin/tool.exe" "conflicting"]
     BL.writeFile archiveEscape $
       compressArchive [tarFile "../evil.txt" "escape"]
+    -- A leading '/' entry: rooted at the current drive.  tar stores paths with
+    -- '/', so this is the on-disk form even of a Windows-native "\..." name.
+    BL.writeFile archiveRootFile $
+      compressArchive [tarFile "/planted-abs.txt" "rooted-file"]
+    BL.writeFile archiveRootSymlink $
+      compressArchive [tarSymLink "sneaky-link.txt" "/planted-link-target.txt"]
+    BL.writeFile archiveRootHardlink $
+      compressArchive [tarHardLink "sneaky-hardlink.txt" "/planted-hardlink-target.txt"]
     let mkUnpackDrv outP srcFiles =
           Derivation
             { drvOutputs =
@@ -2958,6 +3049,9 @@ testUnpackBuildIO = do
         seedOut = StorePath (T.replicate 31 "0" <> "2") "unpack-seed"
         collideOut = StorePath (T.replicate 31 "0" <> "3") "unpack-collide"
         escapeOut = StorePath (T.replicate 31 "0" <> "4") "unpack-escape"
+        rootFileOut = StorePath (T.replicate 31 "0" <> "5") "unpack-root-file"
+        rootSymlinkOut = StorePath (T.replicate 31 "0" <> "6") "unpack-root-symlink"
+        rootHardlinkOut = StorePath (T.replicate 31 "0" <> "7") "unpack-root-hardlink"
     buildTmp <- (</> "nova-nix-test-unpack-build-tmp") <$> getTemporaryDirectory
     forceRemoveIfExists buildTmp
     createDirectoryIfMissing True buildTmp
@@ -2965,6 +3059,9 @@ testUnpackBuildIO = do
     seedResult <- buildDerivation config store (mkUnpackDrv seedOut [archiveTools, archiveData])
     collideResult <- buildDerivation config store (mkUnpackDrv collideOut [archiveTools, archiveCollide])
     escapeResult <- buildDerivation config store (mkUnpackDrv escapeOut [archiveEscape])
+    rootFileResult <- buildDerivation config store (mkUnpackDrv rootFileOut [archiveRootFile])
+    rootSymlinkResult <- buildDerivation config store (mkUnpackDrv rootSymlinkOut [archiveRootSymlink])
+    rootHardlinkResult <- buildDerivation config store (mkUnpackDrv rootHardlinkOut [archiveRootHardlink])
     forceRemoveIfExists buildTmp
     forceRemoveIfExists workDir
     seedChecks <- case seedResult of
@@ -3031,7 +3128,21 @@ testUnpackBuildIO = do
                 | otherwise -> Fail ("wrong failure: " <> msg)
               BuildSuccess _ -> Fail "escape build unexpectedly succeeded"
         ]
-    pure (seedChecks ++ collideChecks ++ escapeChecks)
+    let rejectedWith needle res = case res of
+          BuildFailure msg _
+            | needle `T.isInfixOf` msg -> Pass
+            | otherwise -> Fail ("wrong failure: " <> msg)
+          BuildSuccess _ -> Fail "rooted entry unexpectedly built"
+    rootChecks <-
+      sequence
+        [ runTest "unpack: rooted file entry rejected" $
+            rejectedWith "planted-abs.txt" rootFileResult,
+          runTest "unpack: rooted symlink target rejected" $
+            rejectedWith "planted-link-target.txt" rootSymlinkResult,
+          runTest "unpack: rooted hardlink target rejected" $
+            rejectedWith "planted-hardlink-target.txt" rootHardlinkResult
+        ]
+    pure (seedChecks ++ collideChecks ++ escapeChecks ++ rootChecks)
 
 -- | Step 2 of the ladder: a dependency-aware build end-to-end.  A root
 -- derivation depends on a leaf; both @.drv@ files are pre-written to the store
@@ -3195,17 +3306,33 @@ testStoreOps = do
   withTempStore $ \store -> do
     let sd = stDir store
     sequence
-      [ -- scanReferences finds embedded store path
-        runTestM "scanReferences finds ref" $ do
+      [ -- scanReferences finds the canonical /nix/store text eval injects
+        -- into builder envs, independent of the platform store dir (the
+        -- bare hash is the needle, matching upstream Nix).
+        runTestM "scanReferences finds canonical ref" $ do
           tmpBase <- getTemporaryDirectory
           let scanDir = tmpBase </> "nova-nix-test-scan"
           removeIfExists scanDir
           createDirectoryIfMissing True scanDir
           let candidate = StorePath "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" "dep1"
-              prefix = unStoreDir sd
-              refString = prefix <> "/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-dep1"
+              refString = "/nix/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-dep1"
           BS.writeFile (scanDir </> "output.txt") (TE.encodeUtf8 (T.pack ("hello " <> refString <> " world")))
-          refs <- scanReferences sd [candidate] scanDir
+          refs <- scanReferences [candidate] scanDir
+          removeIfExists scanDir
+          pure $
+            if candidate `elem` refs
+              then Pass
+              else Fail ("expected to find ref, got: " <> T.pack (show refs)),
+        -- scanReferences finds a Windows-form embedding too
+        runTestM "scanReferences finds windows-form ref" $ do
+          tmpBase <- getTemporaryDirectory
+          let scanDir = tmpBase </> "nova-nix-test-scan-win"
+          removeIfExists scanDir
+          createDirectoryIfMissing True scanDir
+          let candidate = StorePath "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" "dep1"
+              refString = "C:\\nix\\store\\aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-dep1"
+          BS.writeFile (scanDir </> "output.txt") (TE.encodeUtf8 (T.pack ("exec " <> refString)))
+          refs <- scanReferences [candidate] scanDir
           removeIfExists scanDir
           pure $
             if candidate `elem` refs
@@ -3219,7 +3346,7 @@ testStoreOps = do
           createDirectoryIfMissing True scanDir
           let candidate = StorePath "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" "dep1"
           BS.writeFile (scanDir </> "output.txt") "no store paths here"
-          refs <- scanReferences sd [candidate] scanDir
+          refs <- scanReferences [candidate] scanDir
           removeIfExists scanDir
           pure (assertEqual "no refs" [] refs),
         -- scanReferences ignores partial match
@@ -3229,11 +3356,10 @@ testStoreOps = do
           removeIfExists scanDir
           createDirectoryIfMissing True scanDir
           let candidate = StorePath "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" "dep1"
-              prefix = unStoreDir sd
-              -- Only 20 chars of hash - should not match 32-char candidate
-              partialRef = prefix <> "/aaaaaaaaaaaaaaaaaaaa"
+              -- Only 20 chars of hash - should not match the 32-char needle
+              partialRef = "/nix/store/aaaaaaaaaaaaaaaaaaaa"
           BS.writeFile (scanDir </> "output.txt") (TE.encodeUtf8 (T.pack partialRef))
-          refs <- scanReferences sd [candidate] scanDir
+          refs <- scanReferences [candidate] scanDir
           removeIfExists scanDir
           pure (assertEqual "no partial refs" [] refs),
         -- addToStore moves dir + registers in DB
@@ -4795,6 +4921,7 @@ main = bracket_ arenaInit arenaDestroy $ do
           testBatch7,
           testImportPure,
           testImportIO,
+          testBlackholeRecoveryIO,
           testBatchA,
           testBatchAIO,
           testBatchB,

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -283,6 +283,12 @@ testEvalArithmetic = do
         assertEval "float-add" "1.5 + 2.5" (VFloat 4.0),
       runTest "int-float promotion" $
         assertEval "promote" "1 + 2.0" (VFloat 3.0),
+      runTest "trailing-dot float" $
+        assertEval "trailing-dot" "12. == 12.0" (VBool True),
+      runTest "trailing-dot float with exponent" $
+        assertEval "trailing-dot-exp" "12.e2 == 1200.0" (VBool True),
+      runTest "trailing-dot float typeOf" $
+        assertEval "trailing-dot-type" "builtins.typeOf 12." (mkStr "float"),
       runTest "negate int" $
         assertEval "negate" "- 5" (VInt (-5)),
       runTest "division by zero" $
@@ -570,6 +576,17 @@ testEvalBuiltins = do
         assertEval "isNull-f" "builtins.isNull 1" (VBool False),
       runTest "stringLength" $
         assertEval "strlen" "builtins.stringLength \"hello\"" (VInt 5),
+      -- Lexer divergences (audit): $${ is literal, ''' escapes to '', \q -> q.
+      runTest "$${ does not interpolate (double dollar is literal)" $
+        assertEval "dollar-dollar-str" "builtins.stringLength \"a$${b}c\"" (VInt 7),
+      runTest "$${ literal in indented string" $
+        assertEval "dollar-dollar-ind" "builtins.stringLength ''a$${b}c''" (VInt 7),
+      runTest "''' escapes two quotes in indented string" $
+        assertEval "triple-quote" "''a'''b'' == \"a''b\"" (VBool True),
+      runTest "unknown escape drops backslash (regular string)" $
+        assertEval "esc-drop-str" "\"a\\qb\" == \"aqb\"" (VBool True),
+      runTest "unknown escape drops backslash (indented string)" $
+        assertEval "esc-drop-ind" "''a''\\qb'' == \"aqb\"" (VBool True),
       runTest "toString int" $
         assertEval "toStr" "builtins.toString 42" (mkStr "42")
     ]
@@ -732,6 +749,12 @@ testLexer = do
       runTest "float" $
         assertRight "lex float" (tokenize "<test>" "3.14") $ \toks ->
           assertEqual "tokens" [TokFloat 3.14] (tokenTypes toks),
+      runTest "trailing-dot float lexes as one float token" $
+        assertRight "lex trailing-dot" (tokenize "<test>" "12.") $ \toks ->
+          assertEqual "tokens" [TokFloat 12.0] (tokenTypes toks),
+      runTest "trailing-dot float with exponent lexes as one float token" $
+        assertRight "lex trailing-dot-exp" (tokenize "<test>" "12.e2") $ \toks ->
+          assertEqual "tokens" [TokFloat 1200.0] (tokenTypes toks),
       runTest "true" $
         assertRight "lex true" (tokenize "<test>" "true") $ \toks ->
           assertEqual "tokens" [TokTrue] (tokenTypes toks),

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -20,7 +20,7 @@ import qualified Data.Text.IO as TIO
 import Foreign.Ptr (castPtr)
 import Foreign.StablePtr (StablePtr, castPtrToStablePtr, castStablePtrToPtr, deRefStablePtr, freeStablePtr, newStablePtr)
 import Nix.Builder (BuildConfig (..), BuildResult (..), buildDerivation, buildWithDeps, defaultBuildConfig)
-import Nix.Builder.Unpack (builtinUnpackBuilder, envSrcs)
+import Nix.Builder.Unpack (builtinUnpackBuilder, entryComponents, envSrcs, resolveLinkTarget)
 import Nix.Builtins (builtinEnv, parseNixPath)
 import qualified Nix.DependencyGraph as DepGraph
 import Nix.Derivation (Derivation (..), DerivationOutput (..), Platform (..), currentPlatform, fromATerm, platformToText, toATerm)
@@ -3020,8 +3020,8 @@ testUnpackBuildIO = do
         archiveCollide = workDir </> "pkg-collide.tar.zst"
         archiveEscape = workDir </> "pkg-escape.tar.zst"
         archiveRootFile = workDir </> "pkg-root-file.tar.zst"
-        archiveRootSymlink = workDir </> "pkg-root-symlink.tar.zst"
-        archiveRootHardlink = workDir </> "pkg-root-hardlink.tar.zst"
+        archiveEscapeSymlink = workDir </> "pkg-escape-symlink.tar.zst"
+        archiveEscapeHardlink = workDir </> "pkg-escape-hardlink.tar.zst"
     BL.writeFile archiveTools $
       compressArchive
         [ tarDir "pkg",
@@ -3046,10 +3046,13 @@ testUnpackBuildIO = do
     -- '/', so this is the on-disk form even of a Windows-native "\..." name.
     BL.writeFile archiveRootFile $
       compressArchive [tarFile "/planted-abs.txt" "rooted-file"]
-    BL.writeFile archiveRootSymlink $
-      compressArchive [tarSymLink "sneaky-link.txt" "/planted-link-target.txt"]
-    BL.writeFile archiveRootHardlink $
-      compressArchive [tarHardLink "sneaky-hardlink.txt" "/planted-hardlink-target.txt"]
+    -- Escaping link targets: '..' climbs above the archive root.  Unlike a
+    -- rooted ('/') target, this builds portably - tar's toLinkTarget accepts a
+    -- relative path on every host - so the real unpacker is exercised end to end.
+    BL.writeFile archiveEscapeSymlink $
+      compressArchive [tarSymLink "sneaky-link.txt" "../escape-link-target.txt"]
+    BL.writeFile archiveEscapeHardlink $
+      compressArchive [tarHardLink "sneaky-hardlink.txt" "../escape-hardlink-target.txt"]
     let mkUnpackDrv outP srcFiles =
           Derivation
             { drvOutputs =
@@ -3073,8 +3076,8 @@ testUnpackBuildIO = do
         collideOut = StorePath (T.replicate 31 "0" <> "3") "unpack-collide"
         escapeOut = StorePath (T.replicate 31 "0" <> "4") "unpack-escape"
         rootFileOut = StorePath (T.replicate 31 "0" <> "5") "unpack-root-file"
-        rootSymlinkOut = StorePath (T.replicate 31 "0" <> "6") "unpack-root-symlink"
-        rootHardlinkOut = StorePath (T.replicate 31 "0" <> "7") "unpack-root-hardlink"
+        escapeSymlinkOut = StorePath (T.replicate 31 "0" <> "6") "unpack-escape-symlink"
+        escapeHardlinkOut = StorePath (T.replicate 31 "0" <> "7") "unpack-escape-hardlink"
     buildTmp <- (</> "nova-nix-test-unpack-build-tmp") <$> getTemporaryDirectory
     forceRemoveIfExists buildTmp
     createDirectoryIfMissing True buildTmp
@@ -3083,8 +3086,8 @@ testUnpackBuildIO = do
     collideResult <- buildDerivation config store (mkUnpackDrv collideOut [archiveTools, archiveCollide])
     escapeResult <- buildDerivation config store (mkUnpackDrv escapeOut [archiveEscape])
     rootFileResult <- buildDerivation config store (mkUnpackDrv rootFileOut [archiveRootFile])
-    rootSymlinkResult <- buildDerivation config store (mkUnpackDrv rootSymlinkOut [archiveRootSymlink])
-    rootHardlinkResult <- buildDerivation config store (mkUnpackDrv rootHardlinkOut [archiveRootHardlink])
+    escapeSymlinkResult <- buildDerivation config store (mkUnpackDrv escapeSymlinkOut [archiveEscapeSymlink])
+    escapeHardlinkResult <- buildDerivation config store (mkUnpackDrv escapeHardlinkOut [archiveEscapeHardlink])
     forceRemoveIfExists buildTmp
     forceRemoveIfExists workDir
     seedChecks <- case seedResult of
@@ -3155,17 +3158,31 @@ testUnpackBuildIO = do
           BuildFailure msg _
             | needle `T.isInfixOf` msg -> Pass
             | otherwise -> Fail ("wrong failure: " <> msg)
-          BuildSuccess _ -> Fail "rooted entry unexpectedly built"
-    rootChecks <-
+          BuildSuccess _ -> Fail "malicious entry unexpectedly built"
+    -- Integration: the real unpacker rejects a rooted entry path and an
+    -- escaping ('..') symlink/hardlink target, end to end.
+    maliciousChecks <-
       sequence
         [ runTest "unpack: rooted file entry rejected" $
             rejectedWith "planted-abs.txt" rootFileResult,
-          runTest "unpack: rooted symlink target rejected" $
-            rejectedWith "planted-link-target.txt" rootSymlinkResult,
-          runTest "unpack: rooted hardlink target rejected" $
-            rejectedWith "planted-hardlink-target.txt" rootHardlinkResult
+          runTest "unpack: escaping symlink target rejected" $
+            rejectedWith "escape-link-target.txt" escapeSymlinkResult,
+          runTest "unpack: escaping hardlink target rejected" $
+            rejectedWith "escape-hardlink-target.txt" escapeHardlinkResult
         ]
-    pure (seedChecks ++ collideChecks ++ escapeChecks ++ rootChecks)
+    -- Unit: the rooted (drive-relative) case is the Blocker-4 Windows vuln.
+    -- tar's toLinkTarget refuses an absolute payload on POSIX, so exercise the
+    -- guard predicate directly - portable and exact on every host.
+    guardChecks <-
+      sequence
+        [ runTest "unpack guard: rooted entry path rejected" $
+            assertLeft "rooted entry" (entryComponents "/planted-abs.txt"),
+          runTest "unpack guard: rooted symlink target rejected" $
+            assertLeft "rooted symlink" (resolveLinkTarget [] "/planted-link-target.txt"),
+          runTest "unpack guard: rooted hardlink target rejected" $
+            assertLeft "rooted hardlink" (entryComponents "/planted-hardlink-target.txt")
+        ]
+    pure (seedChecks ++ collideChecks ++ escapeChecks ++ maliciousChecks ++ guardChecks)
 
 -- | Step 2 of the ladder: a dependency-aware build end-to-end.  A root
 -- derivation depends on a leaf; both @.drv@ files are pre-written to the store


### PR DESCRIPTION
Ongoing eval-correctness work from the full codebase audit. Two batches so far on this branch; more findings are queued.

## Batch 1 - ship-blockers and evaluator correctness (`10ce5b3`)

**Ship-blockers**
- Zero-formal set-pattern lambdas (`{}:`, `{ ... }:`, `x@{...}:`) crashed on a second force: `readLambdaEntries` iterated `[0 .. count - 1]` with `count :: Word16 == 0`, wrapping to 65536 and dereferencing a NULL C array. Guard `count == 0`.
- Windows reference scanning was a silent no-op - it searched build outputs for a store-dir-prefixed path the builder never embeds. It now scans for the bare 32-character hash like upstream, so references are found regardless of store-dir spelling and substituted paths register their real closure.
- `builtin:unpack` accepted drive-rooted/UNC entry, symlink, and hardlink paths that `isAbsolute` reports as relative on Windows, letting a tar entry escape `$out`. A `startsAtRoot` guard rejects a leading bare separator.

**Evaluator crashes (would abort on real nixpkgs)**
- `forceThunk` left a thunk BLACKHOLE on a catchable throw, so a caught throw (`tryEval`) + any later force of the same shared thunk aborted with a bogus, uncatchable "infinite recursion". It now restores the thunk to pending on a thrown force and rethrows, matching C++ Nix's `forceValue`; genuine self-recursion still escapes `tryEval`.
- A plain `inherit x` inside a fallback (nested-path or dynamic-key) let/rec set resolved against the block's own name barrier, making `inherit x` a self-reference that recursed forever. It now resolves against the outer scope, like the positional path.
- Dynamic rec-set keys evaluated in the outer env while the resolver counted de Bruijn levels through the rec barrier (hard `NN_ASSERT` abort / wrong slot). The dynamic path now follows C++ Nix's env2: the rec env holds the static bindings as thunks, and both keys and values evaluate against it.

**Fetch / store**
- `builtins.fetchurl` silently ignored its `sha256` argument and round-tripped the download through a text-mode pipe, corrupting binary content. It now downloads to a file, verifies the pin (SRI / `sha256:` / bare digest) and rejects a mismatch, and stores at the canonical fixed-output path so pins are reproducible and cache-compatible.

**Eval parity**
- `builtins.sort` is now stable: the merge emitted the right element on a tie, reversing comparator-equal runs; it now keeps the left element, matching `std::stable_sort`.
- `builtins.dirOf` returns `"/"` for a root-level path (`/foo`) and for `/` itself, not `""`.
- `builtins.compareVersions` treats `-` as a component separator, matching `builtins.splitVersion` and upstream.

**CI**
- Default `GITHUB_TOKEN` dropped to read-only across the CI, parity, and publish workflows.

## Batch 2 - lexer literal divergences (`5123354`)

- The `''` escape `'''` now produces a literal `''` (two quotes), not a single quote.
- Unknown escapes drop the backslash (`\q` -> `q`, `''\q` -> `q`) in both `"..."` and `''` strings.
- A `$` not followed by `{` stays literal in both string modes: `$$` is two dollars and `$${` does not interpolate (Nix's maximal munch).
- Trailing-dot floats: `12.` and `12.e5` lex as one `TokFloat`, per Nix's `[0-9]+\.[0-9]*(exp)?` grammar.

## Deferred (not in this branch yet)

Two lexer findings are intentionally held for a focused pass - both are state-machine / ambiguity changes with broad regression surface:
- **Brace-depth:** a single shared `Int` counter reset on every `${` corrupts nested interpolations; needs an `Int` -> `[Int]` stack across ~5 sites.
- **Dot-relative path:** `.github/x` should lex as a path but hits `TokDot`; the naive fix collides with attr-select (`x.foo/bar`).

## Verification

694/694 tests pass; `cabal build --ghc-options=-Werror` clean; `ormolu` + `hlint` clean. Findings verified by dogfooding nova-nix's own `eval --expr`.
