### PR TITLE
Codebase audit fixes: fetch pinning, store and push robustness, lexer and fromTOML parity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,5 +128,14 @@ jobs:
       - name: Build
         run: cabal build --enable-tests --ghc-options="-Werror"
 
+      # Eval-time store writes materialize at /nix by design; the runner
+      # lacks it, so the store-writing eval tests would skip.  Provisioning
+      # it keeps that coverage real on Linux.  (macOS cannot: / is a sealed
+      # read-only volume, and the synthetic.conf dance is not worth it for
+      # a test fixture - those tests skip loudly there.)
+      - name: Provision the store root (Linux)
+        if: runner.os == 'Linux'
+        run: sudo mkdir -p /nix && sudo chown "$USER" /nix
+
       - name: Test
         run: cabal test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,8 +122,11 @@ jobs:
           key: cabal-${{ runner.os }}-${{ hashFiles('nova-nix.cabal') }}
           restore-keys: cabal-${{ runner.os }}-
 
+      # --enable-tests compiles the test suite under -Werror too (a bare
+      # `cabal build` skips test components entirely, so test-code warnings
+      # would never fail CI) and shares one solver plan with the test step.
       - name: Build
-        run: cabal build --ghc-options="-Werror"
+        run: cabal build --enable-tests --ghc-options="-Werror"
 
       - name: Test
         run: cabal test

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -32,11 +32,11 @@ import Nix.Eval.IO (EvalState (..), newEvalState, runEvalIO)
 import Nix.Eval.Types (clistFromThunks, clistThunks, thunkToCPtr)
 import Nix.Parser (parseNix, readFileAutoEncoding)
 import Nix.Push (PushConfig (..), PushSummary (..), loadApiKeyFile, pushPaths)
-import Nix.Store (Store (..), closeStore, isValid, openStore, queryAllValidPaths, registerPaths, registrationFor, setReadOnly, writeDrv, writeDrvAterm)
+import Nix.Store (Store (..), closeStore, isValid, openStore, queryAllValidPaths, registerPath, registrationFor, setReadOnly, writeDrv, writeDrvAterm)
 import Nix.Store.Path (StoreDir (..), StorePath (..), defaultStoreDir, parseStorePath, platformStoreDir, storePathHashLen, storePathToFilePath)
 import Nix.Substituter (CacheConfig (..))
 import Paths_nova_nix (getDataDir)
-import System.Directory (canonicalizePath, copyFile, createDirectoryIfMissing, doesDirectoryExist, getCurrentDirectory, getTemporaryDirectory, listDirectory)
+import System.Directory (canonicalizePath, copyFile, createDirectoryIfMissing, createDirectoryLink, createFileLink, doesDirectoryExist, doesPathExist, getCurrentDirectory, getSymbolicLinkTarget, getTemporaryDirectory, listDirectory, pathIsSymbolicLink)
 import System.Environment (getArgs)
 import System.Exit (exitFailure)
 import System.FilePath (takeDirectory)
@@ -80,10 +80,13 @@ data PushArgs = PushArgs
 emptyPushArgs :: PushArgs
 emptyPushArgs = PushArgs Nothing Nothing False []
 
-parseArgs :: [String] -> CliOpts
+-- | Parse the command line.  A malformed invocation is an error, never a
+-- silent drop: an unknown or typo'd flag once ended parsing and quietly
+-- discarded everything after it (e.g. a requested @--substituter@).
+parseArgs :: [String] -> Either String CliOpts
 parseArgs = go (CliOpts [] False False Nothing Nothing Nothing CmdHelp)
   where
-    go opts [] = opts
+    go opts [] = Right opts
     go opts ("--nix-path" : val : rest) =
       go (opts {optNixPaths = optNixPaths opts ++ [T.pack val]}) rest
     go opts ("--strict" : rest) =
@@ -97,22 +100,28 @@ parseArgs = go (CliOpts [] False False Nothing Nothing Nothing CmdHelp)
     go opts ("--trusted-key" : key : rest) =
       go (opts {optTrustedKey = Just key}) rest
     go opts ("eval" : rest) = goEval opts rest
+    go _ ["build"] = Left "build requires a FILE.nix argument"
     go opts ("build" : path : rest) =
       go (opts {optCommand = CmdBuild path}) rest
     go opts ("push" : rest) = goPush opts emptyPushArgs rest
-    go opts _ = opts
+    go _ [flag]
+      | flag `elem` valueFlags = Left (flag ++ " requires a value")
+    go _ (arg : _) = Left ("unknown argument: " ++ arg ++ " (run nova-nix with no arguments for usage)")
     -- Sub-parser for eval: handles --strict and --expr interleaved with the file arg.
-    goEval opts [] = opts
+    goEval opts [] = Right opts
     goEval opts ("--strict" : rest) = goEval (opts {optStrict = True}) rest
     goEval opts ("--aterm" : rest) = goEval (opts {optAterm = True}) rest
     goEval opts ("--nix-path" : val : rest) =
       goEval (opts {optNixPaths = optNixPaths opts ++ [T.pack val]}) rest
     goEval opts ("--expr" : expr : rest) =
       go (opts {optCommand = CmdEvalExpr (T.pack expr)}) rest
+    goEval _ [flag]
+      | flag `elem` valueFlags = Left (flag ++ " requires a value")
+    goEval _ (arg@('-' : _) : _) = Left ("unknown eval flag: " ++ arg)
     goEval opts (path : rest) =
       go (opts {optCommand = CmdEvalFile path}) rest
     -- Sub-parser for push: flags and explicit store paths in any order.
-    goPush opts pushArgs [] = opts {optCommand = CmdPush pushArgs}
+    goPush opts pushArgs [] = Right opts {optCommand = CmdPush pushArgs}
     goPush opts pushArgs ("--store" : dir : rest) =
       goPush (opts {optStore = Just dir}) pushArgs rest
     goPush opts pushArgs ("--cache" : url : rest) =
@@ -121,8 +130,14 @@ parseArgs = go (CliOpts [] False False Nothing Nothing Nothing CmdHelp)
       goPush opts (pushArgs {paKeyFile = Just path}) rest
     goPush opts pushArgs ("--all" : rest) =
       goPush opts (pushArgs {paAll = True}) rest
+    goPush _ _ [flag]
+      | flag `elem` valueFlags = Left (flag ++ " requires a value")
+    goPush _ _ (arg@('-' : _) : _) = Left ("unknown push flag: " ++ arg)
     goPush opts pushArgs (path : rest) =
       goPush opts (pushArgs {paPaths = paPaths pushArgs ++ [path]}) rest
+    -- Flags that consume the following argument as their value.
+    valueFlags =
+      ["--nix-path", "--store", "--substituter", "--trusted-key", "--expr", "--cache", "--key-file"]
 
 -- | Merge --nix-path entries, bundled data dir, and NIX_PATH search paths.
 -- The data dir is appended last so user paths take priority.
@@ -141,7 +156,7 @@ main = do
   arenaInit
   args <- getArgs
   dataDir <- getDataDir
-  let opts = parseArgs args
+  opts <- either (failWith . T.pack) pure (parseArgs args)
   case optCommand opts of
     CmdEvalFile filePath -> evalFile (optStrict opts) (optNixPaths opts) dataDir filePath
     CmdEvalExpr expr
@@ -425,12 +440,16 @@ resolvePushRoots store pushArgs
       pure (traverse parseDbPath pathTexts)
   | otherwise = pure (traverse parseArgPath (paPaths pushArgs))
   where
+    -- DB rows are rendered with the OPENED store's dir - parsing against
+    -- platformStoreDir made 'push --all --store DIR' fail on every row of
+    -- a non-default store.
     parseDbPath txt =
-      maybe (Left ("unparseable store DB path: " <> txt)) Right (parseStorePath platformStoreDir txt)
+      maybe (Left ("unparseable store DB path: " <> txt)) Right (parseStorePath (stDir store) txt)
     parseArgPath raw =
       let txt = T.pack raw
           attempts =
-            [ parseStorePath platformStoreDir txt,
+            [ parseStorePath (stDir store) txt,
+              parseStorePath platformStoreDir txt,
               parseStorePath defaultStoreDir txt,
               parseBareBasename txt
             ]
@@ -457,33 +476,57 @@ failWith msg = do
 -- writes).  Each entry not already valid is copied in, made read-only, and
 -- registered with its real NAR hash.  A copied source carries no references.
 materializeEvalSources :: Store -> Map.Map T.Text T.Text -> IO ()
-materializeEvalSources store sourceCache = do
-  regs <- catMaybes <$> mapM adopt (Map.toList sourceCache)
-  registerPaths (stDB store) regs
+materializeEvalSources store sourceCache = mapM_ adopt (Map.toList sourceCache)
   where
+    -- Each source registers IMMEDIATELY after its copy (sources carry no
+    -- cross-references, so there is nothing to batch), and a source
+    -- already on disk is adopted without touching its files - re-copying
+    -- onto a read-only tree fails on Windows, so an interrupted earlier
+    -- run would otherwise wedge the store permanently.  Mirrors the
+    -- builder's own prepareOutput recovery.
     adopt (rawPath, spText) =
       case parseStorePath defaultStoreDir spText of
-        Nothing -> pure Nothing
+        Nothing -> pure ()
         Just sp -> do
           valid <- isValid store sp
           if valid
-            then pure Nothing
+            then pure ()
             else do
               let dest = storePathToFilePath (stDir store) sp
-              copyPathInto (T.unpack rawPath) dest
-              setReadOnly dest
-              Just <$> registrationFor store sp Nothing []
+              onDisk <- doesPathExist dest
+              if onDisk
+                then pure ()
+                else do
+                  copyPathInto (T.unpack rawPath) dest
+                  setReadOnly dest
+              reg <- registrationFor store sp Nothing []
+              registerPath (stDB store) reg
 
 -- | Recursively copy a file or directory tree to a destination path.
+-- A symlink is replicated as a symlink: the store path's name came from a
+-- NAR hash that ENCODES the link entry, so dereferencing it here would
+-- store content that no longer matches its own address (and a
+-- self-referential link would recurse forever).  On Windows without
+-- symlink privilege the link creation fails loudly rather than silently
+-- corrupting the content address.
 copyPathInto :: FilePath -> FilePath -> IO ()
 copyPathInto src dest = do
-  isDir <- doesDirectoryExist src
-  if isDir
+  isLink <- pathIsSymbolicLink src
+  if isLink
     then do
-      createDirectoryIfMissing True dest
-      names <- listDirectory src
-      mapM_ (\name -> copyPathInto (src FP.</> name) (dest FP.</> name)) names
-    else copyFile src dest
+      target <- getSymbolicLinkTarget src
+      linkedDir <- doesDirectoryExist src
+      if linkedDir
+        then createDirectoryLink target dest
+        else createFileLink target dest
+    else do
+      isDir <- doesDirectoryExist src
+      if isDir
+        then do
+          createDirectoryIfMissing True dest
+          names <- listDirectory src
+          mapM_ (\name -> copyPathInto (src FP.</> name) (dest FP.</> name)) names
+        else copyFile src dest
 
 -- | Write every recorded @.drv@ ATerm (keyed by its store-path text) to the
 -- store.  Keys come from evaluation via 'storePathToText' so they always parse;

--- a/cbits/nn_env.c
+++ b/cbits/nn_env.c
@@ -60,13 +60,20 @@ align_up(uint32_t n, uint32_t alignment)
 }
 
 /* Allocate raw bytes from the page-based bump allocator.
- * Returns aligned, zero-initialized memory. */
+ * Returns aligned, zero-initialized memory, or NULL on overflow/OOM. */
 static void *
 nn_env_alloc_raw(uint32_t bytes)
 {
+    /* align_up would wrap for sizes near UINT32_MAX; such a request can
+     * only be corrupt input, so fail it instead of wrapping small. */
+    if (bytes > UINT32_MAX - (NN_ENV_ALIGN - 1)) return NULL;
     bytes = align_up(bytes, NN_ENV_ALIGN);
 
-    if (!g_current_page || g_current_page->used + bytes > g_current_page->capacity) {
+    /* used <= capacity always holds, so capacity - used cannot underflow;
+     * the additive form (used + bytes > capacity) overflows uint32_t for
+     * near-4GB requests and would pass the check, then memset past the
+     * end of a 256 KB page. */
+    if (!g_current_page || bytes > g_current_page->capacity - g_current_page->used) {
         uint32_t page_cap = bytes > NN_ENV_PAGE_SIZE ? bytes : NN_ENV_PAGE_SIZE;
         struct nn_env_page *page = alloc_page(page_cap);
         if (!page) return NULL;

--- a/cbits/nn_thunk.c
+++ b/cbits/nn_thunk.c
@@ -15,6 +15,7 @@
 
 #include "nn_thunk.h"
 
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -85,14 +86,19 @@ nn_thunk_init(uint32_t initial_capacity)
     uint32_t cap = initial_capacity > 0 ? initial_capacity
                                         : NN_THUNK_DEFAULT_BLOCK_CAPACITY;
 
+    /* An allocation failure here would leave g_arena NULL and the first
+     * thunk allocation would dereference it - fail loudly at startup
+     * instead (same policy as nn_env_init). */
     g_arena = (struct nn_thunk_arena *)malloc(sizeof(struct nn_thunk_arena));
-    if (!g_arena) return;
+    if (!g_arena) {
+        fprintf(stderr, "nn_thunk_init: arena alloc failed\n");
+        abort();
+    }
 
     struct nn_thunk_block *first = alloc_block(cap);
     if (!first) {
-        free(g_arena);
-        g_arena = NULL;
-        return;
+        fprintf(stderr, "nn_thunk_init: block alloc failed\n");
+        abort();
     }
 
     g_arena->head = first;

--- a/nova-nix.cabal
+++ b/nova-nix.cabal
@@ -30,6 +30,7 @@ build-type:         Simple
 tested-with:        GHC == 9.8.4
 extra-doc-files:
     CHANGELOG.md
+    NOTICE
     README.md
 -- C data-layer headers.  These are #included by the cbits/*.c sources
 -- (via include-dirs: cbits) but are not auto-added to the sdist by the
@@ -117,7 +118,10 @@ library
     cbits/nn_bytecode.c
     cbits/nn_lambda.c
   include-dirs:     cbits
-  cc-options:       -std=c99 -Wall -Wextra -pedantic -Werror
+  -- -Werror deliberately NOT baked in: a future gcc/clang adding a new
+  -- -Wall diagnostic must not retroactively break installing published
+  -- releases.  CI enforces warnings-as-errors via its C99-strict job.
+  cc-options:       -std=c99 -Wall -Wextra -pedantic
   hs-source-dirs:   src
   default-language:  Haskell2010
   default-extensions:

--- a/pkgs/windows/setup.sh
+++ b/pkgs/windows/setup.sh
@@ -37,6 +37,11 @@ toBash() {
 # For each buildInput, make its headers and libraries visible to the compiler.
 # The mingw gcc is a native tool, so -I/-L take C:/ "mixed" paths, while its bin
 # goes on PATH in the bash drive-mounted form.
+# Start from EMPTY flag sets: host-inherited CPPFLAGS/LDFLAGS would inject
+# ambient -I/-L directories ahead of the declared buildInputs, silently
+# leaking undeclared dependencies into every configure/make line.
+CPPFLAGS=""
+LDFLAGS=""
 for dep in $buildInputs; do
   depWin="$(cygpath -m "$(toBash "$dep")")"
   CPPFLAGS="$CPPFLAGS -I$depWin/include"
@@ -138,14 +143,25 @@ isSystemDll() {
 }
 
 bundleDlls() {
-  local bindir="$1" changed bin needed found dir
+  local bindir="$1" changed bin needed found dir imports
   [ -d "$bindir" ] || return 0
+  # A missing or broken objdump must FAIL the fixup, not read as "this
+  # binary has no imports" - that would silently register an output
+  # missing its bundled DLLs.
+  command -v objdump >/dev/null 2>&1 || {
+    echo "fixup: objdump not found; cannot scan DLL imports" >&2
+    exit 1
+  }
   changed=1
   while [ "$changed" = 1 ]; do
     changed=0
     for bin in "$bindir"/*.exe "$bindir"/*.dll; do
       [ -e "$bin" ] || continue
-      for needed in $(objdump -p "$bin" 2>/dev/null | sed -n 's/^[[:space:]]*DLL Name: //p'); do
+      imports="$(objdump -p "$bin")" || {
+        echo "fixup: objdump failed on $bin" >&2
+        exit 1
+      }
+      for needed in $(printf '%s\n' "$imports" | sed -n 's/^[[:space:]]*DLL Name: //p'); do
         isSystemDll "$needed" && continue
         [ -e "$bindir/$needed" ] && continue
         found=0

--- a/src/Nix/Builder.hs
+++ b/src/Nix/Builder.hs
@@ -39,6 +39,9 @@ module Nix.Builder
     -- * Build configuration
     BuildConfig (..),
     defaultBuildConfig,
+
+    -- * Pure pieces (exported for tests)
+    verifyFetchHash,
   )
 where
 

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -56,15 +56,20 @@ builtinEnv timestamp searchPaths =
 
 -- | Builtins exposed at the top level (without @builtins.@ prefix).
 -- This matches real Nix - nixpkgs uses these unqualified everywhere.
+-- Exactly upstream's unprefixed surface: fetchurl and toFile are
+-- deliberately NOT here (upstream exposes them only under @builtins.@,
+-- and nixpkgs relies on @with pkgs; fetchurl@ binding pkgs.fetchurl).
 topLevelBuiltinNames :: [Text]
 topLevelBuiltinNames =
   [ "abort",
     "baseNameOf",
+    "break",
     "derivation",
+    "derivationStrict",
     "dirOf",
     "fetchGit",
     "fetchTarball",
-    "fetchurl",
+    "fromTOML",
     "import",
     "isNull",
     "map",
@@ -72,7 +77,6 @@ topLevelBuiltinNames =
     "removeAttrs",
     "scopedImport",
     "throw",
-    "toFile",
     "toString"
   ]
 

--- a/src/Nix/Eval.hs
+++ b/src/Nix/Eval.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE TupleSections #-}
 
 -- | Nix expression evaluator.
 --
@@ -123,10 +124,10 @@ import Nix.Eval.Types
     attrSetSize,
     attrSetToAscList,
     attrSetToMap,
-    attrSetUnionWith,
     buildCAttrSetKeys,
     buildCSlots,
     cheapThunkBc,
+    checkedEnvPtr,
     clistFromThunks,
     clistLen,
     clistThunks,
@@ -163,6 +164,7 @@ import Nix.Hash (bytesToHexText, hashPlaceholder, hexToBytes, makeFixedOutputPat
 import Nix.Store.Path (StorePath (..), defaultStoreDir, defaultStoreDirText, parseStorePath, storePathToFilePath, storePathToText)
 import qualified NovaCache.Base32 as Nix32
 import qualified NovaCache.Base64 as B64
+import qualified NovaCache.NAR as NAR
 import System.IO.Unsafe (unsafePerformIO)
 import qualified System.Info
 import Text.Regex.TDFA (matchAllText)
@@ -255,7 +257,9 @@ evalBytecode env bcIdx =
                 condVal <- evalBytecode env condIdx
                 case condVal of
                   VBool True -> evalBytecode env bodyIdx
-                  VBool False -> throwEvalError "assertion failed"
+                  -- A failed assert is catchable by tryEval (upstream
+                  -- AssertionError); a non-bool condition is a type error.
+                  VBool False -> throwCatchableError "assertion failed"
                   _ -> throwEvalError ("assertion condition must be a Boolean, got " <> typeName condVal)
         OpUnary ->
           let flags_ = unsafePerformIO (cbcFlags bcIdx)
@@ -333,25 +337,38 @@ evalAddWithCoercion left right = case (left, right) of
   (VFloat _, _) -> evalBinary force OpAdd left right
   (_, VFloat _) -> evalBinary force OpAdd left right
   (VInt _, VInt _) -> evalBinary force OpAdd left right
-  -- Path: direct concat
-  (VPath _, _) -> evalBinary force OpAdd left right
-  -- String-like: direct concat when both are string/path
+  -- Path + path: raw concatenation, still a path.
+  (VPath a, VPath b) -> pure (VPath (a <> b))
+  -- Path + coercible: the result stays a path, the right side coerces
+  -- WITHOUT a store copy, and a right side carrying string context is an
+  -- error, as upstream (a store-path reference cannot survive inside a
+  -- path value).
+  (VPath a, _) -> do
+    (rightStr, rightCtx) <- coerceAddOperand right
+    if rightCtx == emptyContext
+      then pure (VPath (a <> rightStr))
+      else throwEvalError "cannot append a string with context (a store-path reference) to a path"
+  -- Strings: direct concat.
   (VStr {}, VStr {}) -> evalBinary force OpAdd left right
-  (VStr {}, VPath _) -> evalBinary force OpAdd left right
   -- Otherwise: string concatenation with STRICT coercion (Nix coerceMore=false)
-  -- - only strings and sets with __toString/outPath coerce; numbers, bools,
-  -- null, lists, and functions are type errors, matching C++ Nix's `+`.
+  -- - only strings, sets with __toString/outPath, and paths coerce; numbers,
+  -- bools, null, lists, and functions are type errors, matching C++ Nix's `+`.
+  -- A path on the right of a string is COPIED to the store (upstream
+  -- copyToStore=true), so "x" + ./src concatenates the source's store path
+  -- and carries it in the result's context.
   _ -> do
     (leftStr, leftCtx) <- coerceAddOperand left
     (rightStr, rightCtx) <- coerceAddOperand right
     pure (VStr (leftStr <> rightStr) (leftCtx <> rightCtx))
 
 -- | Strict string coercion for the @+@ operator (Nix @coerceMore = false@):
--- strings, and sets with @__toString@/@outPath@, coerce; numbers, booleans,
--- null, lists, and functions are type errors.
+-- strings, sets with @__toString@\/@outPath@, and paths (copied to the
+-- store, carrying context) coerce; numbers, booleans, null, lists, and
+-- functions are type errors.
 coerceAddOperand :: (MonadEval m) => NixValue -> m (Text, StringContext)
 coerceAddOperand v@(VStr {}) = coerceToString False force applyValue v
 coerceAddOperand v@(VAttrs {}) = coerceToString False force applyValue v
+coerceAddOperand v@(VPath _) = coerceToStoreString v
 coerceAddOperand v =
   throwEvalError ("cannot coerce " <> typeName v <> " to a string with the + operator")
 
@@ -636,10 +653,15 @@ evalBcRecAttrs env bindings captureInfo
       staticThunks <- buildBcThunkMap recEnv staticBs
       let scopeFilled = fillCAttrSetValues scopeCset staticThunks
       dynThunks <- scopeFilled `seq` buildBcThunkMap recEnv dynBs
-      let allThunks = Map.unionWith mergeThunks dynThunks staticThunks
-          resultCset = buildCAttrSetKeys (Map.keys allThunks)
-          filled = fillCAttrSetValues resultCset allThunks
-       in filled `seq` pure (VAttrs (AttrSet resultCset))
+      -- A dynamic key colliding with a static sibling is an eval error
+      -- upstream ("dynamic attribute already defined"), never a merge.
+      case Map.keys (Map.intersection dynThunks staticThunks) of
+        (dupKey : _) -> throwEvalError ("dynamic attribute '" <> dupKey <> "' already defined")
+        [] ->
+          let allThunks = Map.union dynThunks staticThunks
+              resultCset = buildCAttrSetKeys (Map.keys allThunks)
+              filled = fillCAttrSetValues resultCset allThunks
+           in filled `seq` pure (VAttrs (AttrSet resultCset))
 
 -- | Evaluate a let expression from bytecode.
 evalBcLet :: (MonadEval m) => Env -> Word32 -> m NixValue
@@ -737,12 +759,12 @@ buildBcThunkMap thunkEnv = foldM addBinding Map.empty
       case sequence resolvedKeys of
         Nothing -> pure acc -- null key -> skip
         Just [key] ->
-          pure (insertWithMerge acc key (mkThunkBc thunkEnv valBcIdx))
+          insertChecked acc key (mkThunkBc thunkEnv valBcIdx)
         Just path ->
           let nested = buildBcNestedAttr thunkEnv path valBcIdx
-           in pure (foldl' (\a (k, t0) -> insertWithMerge a k t0) acc (Map.toList nested))
+           in foldM (\a (k, t0) -> insertChecked a k t0) acc (Map.toList nested)
     addBinding acc (BcInherit syms) =
-      pure (foldl' (\a sym -> let name = symbolText (Symbol sym) in insertWithMerge a name (inheritLookup thunkEnv name)) acc syms)
+      foldM (\a sym -> let name = symbolText (Symbol sym) in insertChecked a name (inheritLookup thunkEnv name)) acc syms
     addBinding acc (BcInheritFrom fromBcIdx syms) =
       -- inherit (from) name selects name from the from-expr.
       -- Create a small env with the from value at slot 0, then a
@@ -752,13 +774,16 @@ buildBcThunkMap thunkEnv = foldM addBinding Map.empty
                 selectExpr = ESelect (EResolvedVar 0 0) [StaticKey name] Nothing
                 (sp, sc) = buildCSlots [mkThunkBc thunkEnv fromBcIdx]
                 fromEnv = newMinimalEnv sp sc
-             in insertWithMerge a name (mkSyntheticThunk fromEnv selectExpr)
-       in pure (foldl' addInheritFrom acc syms)
+             in insertChecked a name (mkSyntheticThunk fromEnv selectExpr)
+       in foldM addInheritFrom acc syms
 
-    insertWithMerge acc key thunk =
+    -- The parser normalizes static keys to appear exactly once, so a
+    -- collision here means an evaluated DYNAMIC key hit an existing
+    -- attr - an eval error upstream, never a silent merge.
+    insertChecked acc key thunk =
       case Map.lookup key acc of
-        Nothing -> Map.insert key thunk acc
-        Just existing -> Map.insert key (mergeThunks existing thunk) acc
+        Nothing -> pure (Map.insert key thunk acc)
+        Just _ -> throwEvalError ("dynamic attribute '" <> key <> "' already defined")
 
 -- | Resolve a bytecode attr key to text.
 resolveBcKey :: (MonadEval m) => Env -> BcAttrKey -> m (Maybe Text)
@@ -898,7 +923,7 @@ pushLazyWithScope (Thunk thunkPtr) =
 {-# NOINLINE pushWithScopeRaw #-}
 pushWithScopeRaw :: Ptr () -> Env -> Env
 pushWithScopeRaw ptr (Env envPtr) =
-  Env (unsafePerformIO (cenvPushWith envPtr ptr))
+  Env (checkedEnvPtr "pushWithScopeRaw" (unsafePerformIO (cenvPushWith envPtr ptr)))
 
 -- ---------------------------------------------------------------------------
 -- Formals matching + env helpers (used by evalBcApp, applyValue, etc.)
@@ -979,16 +1004,6 @@ inheritLookup env name =
   case envLookup name env of
     Just thunk -> thunk
     Nothing -> error ("inheritLookup: undefined variable '" <> T.unpack name <> "' (unreachable)")
-
--- | Merge two thunks for nested attribute update.
--- If both are computed attrsets, recursively merge with attrSetUnionWith.
--- Otherwise the new value wins.
-mergeThunks :: Thunk -> Thunk -> Thunk
-mergeThunks a b =
-  case (readThunkValue a, readThunkValue b) of
-    (Just (VAttrs aa), Just (VAttrs bb)) ->
-      evaluated (VAttrs (attrSetUnionWith mergeThunks aa bb))
-    _ -> b
 
 -- ---------------------------------------------------------------------------
 -- Builtin registry (single-definition-site for all builtins)
@@ -1209,18 +1224,21 @@ applyBuiltin name accArgs arg =
 -- (the pattern string), compile it immediately and store the compiled
 -- RE.Regex in a VCompiledRegex, replacing the raw VStr.  The compiled
 -- form is carried in VBuiltin's accumulated args and reused on every
--- subsequent application - zero recompilation.
+-- subsequent application - zero recompilation.  Both builtins compile
+-- the RAW pattern: match's whole-string requirement is a span check at
+-- match time, not textual @^...$@ anchoring, which would misparse a
+-- top-level alternation (@^a|b$@ is @(^a)|(b$)@).
 precompileArgs :: Text -> [NixValue] -> [NixValue]
-precompileArgs "match" [VStr pat _] =
-  let anchored = "^" <> pat <> "$"
-   in case cachedCompileRegex anchored of
-        Just compiled -> [VCompiledRegex (CompiledRegex pat compiled)]
-        Nothing -> [VStr pat emptyContext] -- fail later at execute time
-precompileArgs "split" [VStr pat _] =
-  case cachedCompileRegex pat of
-    Just compiled -> [VCompiledRegex (CompiledRegex pat compiled)]
-    Nothing -> [VStr pat emptyContext] -- fail later at execute time
+precompileArgs "match" [VStr pat _] = compiledRegexArg pat
+precompileArgs "split" [VStr pat _] = compiledRegexArg pat
 precompileArgs _ args = args
+
+-- | The single-element arg list for a regex builtin: the compiled pattern
+-- if valid, the raw string otherwise (the error surfaces at execute time).
+compiledRegexArg :: Text -> [NixValue]
+compiledRegexArg pat = case cachedCompileRegex pat of
+  Just compiled -> [VCompiledRegex (CompiledRegex pat compiled)]
+  Nothing -> [VStr pat emptyContext]
 
 -- | Apply a function value (lambda or builtin) to one argument.
 -- Used by higher-order builtins to invoke user-supplied functions.
@@ -1232,6 +1250,21 @@ applyValue (VBuiltin name accArgs) arg =
   applyBuiltin name accArgs arg
 applyValue other _ =
   throwEvalError ("attempt to call " <> typeName other <> ", which is not a function")
+
+-- | Apply a function value to an UNFORCED thunk argument.  Upstream's
+-- higher-order list builtins (filter, any, all, partition, groupBy,
+-- foldl') pass elements as unforced values, so an element the function
+-- never inspects may contain a throw without failing the call.  A
+-- builtin callee still receives a forced value (builtins force their
+-- arguments regardless), and set-pattern formals force on destructuring
+-- exactly as upstream does.
+applyValueLazy :: (MonadEval m) => NixValue -> Thunk -> m NixValue
+applyValueLazy (VLambda closureEnv formals bodyBcIdx) argThunk = do
+  extEnv <- matchFormals closureEnv formals argThunk
+  evalBytecode extEnv bodyBcIdx
+applyValueLazy other argThunk = do
+  val <- force argThunk
+  applyValue other val
 
 -- | Execute a builtin once all arguments are collected.
 --
@@ -1480,7 +1513,7 @@ builtinStringLength other =
 -- ---------------------------------------------------------------------------
 
 builtinThrow :: (MonadEval m) => NixValue -> m NixValue
-builtinThrow (VStr msg _) = throwEvalError msg
+builtinThrow (VStr msg _) = throwCatchableError msg
 builtinThrow other = throwEvalError ("builtins.throw: expected a string, got " <> typeName other)
 
 builtinAbort :: (MonadEval m) => NixValue -> m NixValue
@@ -1634,8 +1667,7 @@ builtinFilter _ other =
 filterThunks :: (MonadEval m) => NixValue -> [Thunk] -> m [Thunk]
 filterThunks _ [] = pure []
 filterThunks predFn (thunk : rest) = do
-  val <- force thunk
-  result <- applyValue predFn val
+  result <- applyValueLazy predFn thunk
   case result of
     VBool True -> (thunk :) <$> filterThunks predFn rest
     VBool False -> filterThunks predFn rest
@@ -1720,8 +1752,7 @@ builtinAny _ other =
 anyThunk :: (MonadEval m) => NixValue -> [Thunk] -> m Bool
 anyThunk _ [] = pure False
 anyThunk predFn (thunk : rest) = do
-  val <- force thunk
-  result <- applyValue predFn val
+  result <- applyValueLazy predFn thunk
   case result of
     VBool True -> pure True
     VBool False -> anyThunk predFn rest
@@ -1738,8 +1769,7 @@ builtinAll _ other =
 allThunk :: (MonadEval m) => NixValue -> [Thunk] -> m Bool
 allThunk _ [] = pure True
 allThunk predFn (thunk : rest) = do
-  val <- force thunk
-  result <- applyValue predFn val
+  result <- applyValueLazy predFn thunk
   case result of
     VBool True -> allThunk predFn rest
     VBool False -> pure False
@@ -1802,8 +1832,7 @@ partitionThunks predFn = go [] []
   where
     go !rs !ws [] = pure (reverse rs, reverse ws)
     go !rs !ws (thunk : rest) = do
-      val <- force thunk
-      result <- applyValue predFn val
+      result <- applyValueLazy predFn thunk
       case result of
         VBool True -> go (thunk : rs) ws rest
         VBool False -> go rs (thunk : ws) rest
@@ -1825,8 +1854,7 @@ groupByCollect ::
   m (Map Text [Thunk])
 groupByCollect _ [] acc = pure acc
 groupByCollect func (thunk : rest) acc = do
-  val <- force thunk
-  result <- applyValue func val
+  result <- applyValueLazy func thunk
   case result of
     VStr key _ ->
       groupByCollect func rest (Map.insertWith (++) key [thunk] acc)
@@ -1864,14 +1892,14 @@ builtinFoldl op initial (VList cl) =
 builtinFoldl _ _ other =
   throwEvalError ("builtins.foldl': expected a list, got " <> typeName other)
 
--- | Strict left fold: apply @op acc elem@ for each element.
--- @op@ is curried so we call @applyValue op acc@ then @applyValue partial elem@.
+-- | Strict left fold: apply @op acc elem@ for each element.  The
+-- accumulator is forced each step (upstream foldl' strictness); the
+-- element is passed as an unforced thunk, as upstream does.
 foldlStrict :: (MonadEval m) => NixValue -> NixValue -> [Thunk] -> m NixValue
 foldlStrict _ acc [] = pure acc
 foldlStrict op acc (thunk : rest) = do
-  val <- force thunk
   partial <- applyValue op acc
-  stepped <- applyValue partial val
+  stepped <- applyValueLazy partial thunk
   foldlStrict op stepped rest
 
 builtinSubstring :: (MonadEval m) => NixValue -> NixValue -> NixValue -> m NixValue
@@ -2396,11 +2424,18 @@ replaceAll pairs input = T.concat (go input)
 -- ---------------------------------------------------------------------------
 
 -- | Global regex compilation cache.  Keyed by the raw pattern string
--- (including anchoring for match).  Idempotent memoization via
+-- (match and split share entries).  Idempotent memoization via
 -- unsafePerformIO - same rationale as thunk memoization.
 {-# NOINLINE regexCacheRef #-}
 regexCacheRef :: IORef (Map Text RE.Regex)
 regexCacheRef = unsafePerformIO (newIORef Map.empty)
+
+-- | Compile options matching C++ Nix's POSIX ERE semantics: no multiline
+-- mode, so @^@\/@$@ anchor only at the string boundaries and @.@ (and a
+-- negated bracket class) match a newline.  regex-tdfa's default has
+-- multiline=True, which silently diverges on any subject containing @\n@.
+wholeStringCompOpt :: RE.CompOption
+wholeStringCompOpt = RE.defaultCompOpt {RE.multiline = False}
 
 -- | Compile a regex, using the global cache to avoid recompilation.
 -- Returns Nothing for invalid patterns.  NOINLINE prevents GHC from
@@ -2412,7 +2447,7 @@ cachedCompileRegex pat =
     cache <- atomicModifyIORef' regexCacheRef (\c -> (c, c))
     case Map.lookup pat cache of
       Just compiled -> pure (Just compiled)
-      Nothing -> case RE.makeRegexM (T.unpack pat) :: Maybe RE.Regex of
+      Nothing -> case RE.makeRegexOptsM wholeStringCompOpt RE.defaultExecOpt (T.unpack pat) :: Maybe RE.Regex of
         Nothing -> pure Nothing
         Just compiled -> do
           atomicModifyIORef' regexCacheRef (\c -> (Map.insert pat compiled c, ()))
@@ -2423,19 +2458,18 @@ cachedCompileRegex pat =
 -- ---------------------------------------------------------------------------
 
 -- | @builtins.match regex str@: match a POSIX ERE against a string.
--- The regex is implicitly anchored (must match the entire string).
+-- The regex must match the ENTIRE string (like C++ Nix's regex_match).
 -- Returns @null@ if no match, or a list of capture group strings
--- (empty string for unmatched optional groups).
+-- (@null@ for non-participating groups).
 builtinMatch :: (MonadEval m) => NixValue -> NixValue -> m NixValue
 -- Pre-compiled path: regex was compiled at partial-application time.
 builtinMatch (VCompiledRegex (CompiledRegex _ compiled)) (VStr str _) =
   matchWithCompiled compiled str
 -- Direct 2-arg call: use global compilation cache.
 builtinMatch (VStr regex _) (VStr str _) =
-  let anchored = "^" <> regex <> "$"
-   in case cachedCompileRegex anchored of
-        Nothing -> throwEvalError ("builtins.match: invalid regex: " <> regex)
-        Just compiled -> matchWithCompiled compiled str
+  case cachedCompileRegex regex of
+    Nothing -> throwEvalError ("builtins.match: invalid regex: " <> regex)
+    Just compiled -> matchWithCompiled compiled str
 builtinMatch (VStr _ _) other =
   throwEvalError ("builtins.match: expected a string, got " <> typeName other)
 builtinMatch (VCompiledRegex _) other =
@@ -2444,22 +2478,28 @@ builtinMatch other _ =
   throwEvalError ("builtins.match: expected a string (regex), got " <> typeName other)
 
 -- | Shared match logic for pre-compiled and freshly-compiled regex paths.
+--
+-- Whole-string semantics via a span check on the leftmost-longest match:
+-- if any whole-string match exists it starts at 0, and POSIX picks the
+-- longest match at the leftmost start, so the reported match spans the
+-- whole subject exactly when a whole-string match exists.  This is what
+-- regex_match gives C++ Nix; textual @^...$@ anchoring is NOT equivalent
+-- (it misparses top-level alternation).
 matchWithCompiled :: (MonadEval m) => RE.Regex -> Text -> m NixValue
 matchWithCompiled compiled str =
-  let matches = matchAllText compiled (T.unpack str)
-   in case matches of
-        [] -> pure VNull
-        (match : _) ->
+  case RE.matchOnceText compiled (T.unpack str) of
+    Just (beforeMatch, match, afterMatch)
+      | null beforeMatch,
+        null afterMatch ->
           -- match is an Array of (String, (offset, len)) pairs.
           -- Index 0 is the full match; indices 1.. are capture groups.
-          let groups = Array.elems match
-              -- Skip index 0 (full match) - return only capture groups.
-              captureGroups = drop 1 groups
+          let captureGroups = drop 1 (Array.elems match)
               -- A non-participating capture group has offset (-1); C++ Nix
               -- yields null for it, not the empty string.
               toThunk (s, (off, _)) =
                 if off < 0 then evaluated VNull else evaluated (mkStr (T.pack s))
            in pure (VList (clistFromThunks (map (thunkToCPtr . toThunk) captureGroups)))
+    _ -> pure VNull
 
 -- | @builtins.split regex str@: split a string by a POSIX ERE.
 -- Returns an alternating list of non-matched strings and match-group lists.
@@ -3099,13 +3139,30 @@ findFirst ((prefix, path) : rest) name
 -- ---------------------------------------------------------------------------
 
 builtinToFile :: (MonadEval m) => NixValue -> NixValue -> m NixValue
-builtinToFile (VStr name _) (VStr contents _) = do
-  storePath <- writeToStore name contents
-  pure (VPath storePath)
+builtinToFile (VStr name _) (VStr contents ctx) = do
+  refs <- toFileRefs ctx
+  storePath <- writeToStore name contents refs
+  -- Upstream returns a STRING whose context is the new path itself; the
+  -- refs travel through the store path computation, not the eval context.
+  let selfContext = maybe emptyContext plainContext (parseStorePath defaultStoreDir storePath)
+  pure (VStr storePath selfContext)
 builtinToFile (VStr _ _) other =
   throwEvalError ("builtins.toFile: expected a string, got " <> typeName other)
 builtinToFile other _ =
   throwEvalError ("builtins.toFile: expected a string, got " <> typeName other)
+
+-- | The store-path references a toFile output may carry: the contents'
+-- plain-path context, in sorted order.  A derivation-output reference is
+-- an error, exactly as upstream ("files created by builtins.toFile may
+-- not reference derivations").
+toFileRefs :: (MonadEval m) => StringContext -> m [StorePath]
+toFileRefs (StringContext elems) = mapM refOf (Set.toAscList elems)
+  where
+    refOf (SCPlain sp) = pure sp
+    refOf (SCDrvOutput _ _) =
+      throwEvalError "builtins.toFile: files created by toFile may not reference derivations"
+    refOf (SCAllOutputs _) =
+      throwEvalError "builtins.toFile: files created by toFile may not reference derivations"
 
 -- ---------------------------------------------------------------------------
 -- Builtin implementations - scoped import
@@ -3133,35 +3190,50 @@ builtinFetchurl other =
   throwEvalError ("builtins.fetchurl: expected a string or set, got " <> typeName other)
 
 builtinFetchTarball :: (MonadEval m) => NixValue -> m NixValue
-builtinFetchTarball (VStr url _) = fetchAndExtractTarball url
+builtinFetchTarball (VStr url _) = fetchAndExtractTarball url Nothing tarballSourceName
 builtinFetchTarball (VAttrs attrs) = do
   url <- forceAttrStr "builtins.fetchTarball" "url" attrs
-  fetchAndExtractTarball url
+  sha256 <- forceOptionalAttrStr attrs "sha256"
+  nameOverride <- forceOptionalAttrStr attrs "name"
+  fetchAndExtractTarball url sha256 (fromMaybe tarballSourceName nameOverride)
 builtinFetchTarball other =
   throwEvalError ("builtins.fetchTarball: expected a string or set, got " <> typeName other)
 
--- | Download a tarball, extract it, and return the path to the extracted
--- directory.  Uses a content-hashed temp directory.  Downloads and extracts
--- in a single shell pipeline to avoid binary-as-text encoding issues.
-fetchAndExtractTarball :: (MonadEval m) => Text -> m NixValue
-fetchAndExtractTarball url = do
+-- | Upstream's default store name for fetched source trees.
+tarballSourceName :: Text
+tarballSourceName = "source"
+
+-- | Download a tarball, extract it, verify the optional sha256 pin, and
+-- copy the tree to its content-addressed store path.  The pin is the
+-- recursive NAR hash of the EXTRACTED tree, as upstream.  Download and
+-- extraction share one shell pipeline to avoid binary-as-text encoding
+-- issues; the scratch dir is cleared first so an interrupted earlier
+-- extraction cannot leak stale files into this one.
+fetchAndExtractTarball :: (MonadEval m) => Text -> Maybe Text -> Text -> m NixValue
+fetchAndExtractTarball url mSha256 name = do
   sysTmp <- getTempDir
   let urlHash = sha256Hex (TE.encodeUtf8 url)
       extractDir = sysTmp <> "/nova-nix-tarball-" <> urlHash
-  -- Single pipeline: mkdir, download, extract with --strip-components=1
   -- The -- separator prevents argument injection from the URL.
   (code, _, errOut) <-
     runProcess
       "sh"
       [ "-c",
-        "mkdir -p \"$1\" && curl -sSfL -- \"$2\" | tar -xz -C \"$1\" --strip-components=1",
+        "rm -rf \"$1\" && mkdir -p \"$1\" && curl -sSfL -- \"$2\" | tar -xz -C \"$1\" --strip-components=1",
         "--",
         extractDir,
         url
       ]
       ""
   case code of
-    0 -> pure (VPath extractDir)
+    0 -> do
+      pin <- traverse (decodeSha256Pin "builtins.fetchTarball") mSha256
+      storePath <-
+        copyPathToStore
+          extractDir
+          name
+          (fmap ("builtins.fetchTarball: " <> url,) pin)
+      pure (VPath storePath)
     _ -> throwEvalError ("builtins.fetchTarball: " <> errOut)
 
 builtinFetchGit :: (MonadEval m) => NixValue -> m NixValue
@@ -3238,28 +3310,27 @@ decodeSha256Pin ctx s
 
 -- | Force a required string attribute from an attrset, using full Nix string
 -- coercion (VStr, VPath, VInt, VBool, VAttrs via __toString/outPath).
+-- A coercion failure (or a throwing attr value) propagates with its own
+-- message, as upstream - swallowing it here once masked user throws.
 forceAttrStr :: (MonadEval m) => Text -> Text -> AttrSet -> m Text
 forceAttrStr builtin key attrs =
   case attrSetLookup key attrs of
     Nothing -> throwEvalError (builtin <> ": missing required attribute '" <> key <> "'")
     Just thunk -> do
       val <- force thunk
-      result <- catchEvalError (coerceToString True force applyValue val)
-      case result of
-        Right (s, _ctx) -> pure s
-        Left _ -> throwEvalError (builtin <> ": '" <> key <> "' must be a string")
+      (s, _ctx) <- coerceToString True force applyValue val
+      pure s
 
--- | Force an optional string attribute via full Nix coercion.
+-- | Force an optional string attribute via full Nix coercion.  A present
+-- but uncoercible (or throwing) value is an error, not 'Nothing'.
 forceOptionalAttrStr :: (MonadEval m) => AttrSet -> Text -> m (Maybe Text)
 forceOptionalAttrStr attrs key =
   case attrSetLookup key attrs of
     Nothing -> pure Nothing
     Just thunk -> do
       val <- force thunk
-      result <- catchEvalError (coerceToString True force applyValue val)
-      case result of
-        Right (s, _ctx) -> pure (Just s)
-        Left _ -> pure Nothing
+      (s, _ctx) <- coerceToString True force applyValue val
+      pure (Just s)
 
 -- ---------------------------------------------------------------------------
 -- Builtin implementations - derivation construction
@@ -3277,6 +3348,17 @@ builtinDerivationStrict (VAttrs attrs) = do
   system <- forceAttrStr ("derivation \"" <> drvName <> "\"") "system" attrs
   builder <- forceAttrStr ("derivation \"" <> drvName <> "\"") "builder" attrs
 
+  -- __ignoreNulls: when true, null-valued attrs are dropped from the
+  -- derivation env (stdenv.mkDerivation sets it); when absent or false,
+  -- null coerces to "" like any other coerceMore value - C++ Nix semantics.
+  ignoreNulls <- case attrSetLookup "__ignoreNulls" attrs of
+    Nothing -> pure False
+    Just thunk -> do
+      val <- force thunk
+      case val of
+        VBool b -> pure b
+        other -> throwEvalError ("derivation: '__ignoreNulls' must be a boolean, got " <> typeName other)
+
   -- Extract optional outputs (default ["out"])
   outputNames <- case attrSetLookup "outputs" attrs of
     Nothing -> pure ["out"]
@@ -3284,6 +3366,9 @@ builtinDerivationStrict (VAttrs attrs) = do
       val <- force thunk
       case val of
         VList cl -> mapM (forceToText . Thunk) (clistThunks cl)
+        -- A null outputs attr is dropped by __ignoreNulls, falling back to
+        -- the default output set; without it, null is an error as upstream.
+        VNull | ignoreNulls -> pure ["out"]
         _ -> throwEvalError "derivation: 'outputs' must be a list of strings"
 
   -- Extract optional args (default []).  Path literals in args (e.g. stdenv's
@@ -3297,6 +3382,7 @@ builtinDerivationStrict (VAttrs attrs) = do
         VList cl -> do
           parts <- mapM (\t -> force (Thunk t) >>= coerceToStoreString) (clistThunks cl)
           pure (map fst parts, mconcat (map snd parts))
+        VNull | ignoreNulls -> pure ([], mempty)
         _ -> throwEvalError "derivation: 'args' must be a list of strings"
 
   -- Materialize once, reuse for both env collection and result merge
@@ -3305,7 +3391,7 @@ builtinDerivationStrict (VAttrs attrs) = do
   -- Collect string-coercible attrs into the build env, EXCLUDING "args"
   -- (C++ Nix puts args in the Derive() args field, never the env).  The
   -- per-output env vars ($out, ...) are added below.  Carries merged context.
-  (drvEnvPairs, envContext) <- collectDrvEnvWithContext (Map.delete "__ignoreNulls" (Map.delete "args" materialized))
+  (drvEnvPairs, envContext) <- collectDrvEnvWithContext ignoreNulls (Map.delete "__ignoreNulls" (Map.delete "args" materialized))
 
   let fullContext = envContext <> argsContext
       inputDrvs = extractInputDrvs fullContext
@@ -3531,27 +3617,31 @@ forceToText thunk = do
   (s, _ctx) <- coerceToString True force applyValue val
   pure s
 
--- | Collect all string-coercible attributes for the derivation environment,
--- along with the merged string context from all collected values.
--- Uses 'coerceToStringPermissive' for full Nix coercion including
--- __toString, outPath, and list-to-space-separated-string.
-collectDrvEnvWithContext :: (MonadEval m) => Map Text Thunk -> m ([(Text, Text)], StringContext)
-collectDrvEnvWithContext attrs = do
+-- | Collect all derivation attributes into env pairs via full Nix coercion
+-- (__toString, outPath, list-to-space-separated-string), along with the
+-- merged string context from all collected values.
+--
+-- A coercion failure (a thrown attr value, an uncoercible function, a failed
+-- import inside the value) fails the WHOLE derivation, as in C++ Nix.
+-- Swallowing it silently produces a wrong .drv - this exact bug once turned
+-- a seed derivation with 17 failed src attrs into an empty no-input drv that
+-- "built" successfully.  Null attrs are dropped only under __ignoreNulls;
+-- otherwise null coerces to @""@ like any other coerceMore value.
+collectDrvEnvWithContext :: (MonadEval m) => Bool -> Map Text Thunk -> m ([(Text, Text)], StringContext)
+collectDrvEnvWithContext ignoreNulls attrs = do
   let pairs = Map.toList attrs
-  results <- mapM tryCoerce pairs
+  results <- mapM coerceEnvAttr pairs
   let envPairs = catMaybes [fmap (\(k, v, _) -> (k, v)) r | r <- results]
       mergedCtx = mconcat [ctx | Just (_, _, ctx) <- results]
   pure (envPairs, mergedCtx)
   where
-    tryCoerce (key, thunk) = do
+    coerceEnvAttr (key, thunk) = do
       val <- force thunk
       case val of
-        VNull -> pure Nothing
+        VNull | ignoreNulls -> pure Nothing
         _ -> do
-          result <- catchEvalError (coerceToStoreString val)
-          case result of
-            Right (s, ctx) -> pure (Just (key, s, ctx))
-            Left _ -> pure Nothing
+          (s, ctx) <- coerceToStoreString val
+          pure (Just (key, s, ctx))
 
 -- ---------------------------------------------------------------------------
 -- Builtin implementations - hashFile, readFileType
@@ -3751,13 +3841,94 @@ parseTOMLDoc lns = go lns [] Map.empty
               keys = parseDottedKey keyStr
            in go rest keys (ensureTable keys root)
       | otherwise =
-          -- Key = value pair
-          case parseKVLine stripped of
-            Right (keys, val) ->
-              go rest currentPath (insertNested (currentPath ++ keys) val root)
-            Left err -> Left err
+          -- Key = value pair.  The value may span physical lines (arrays
+          -- and multi-line strings - the Cargo.lock shapes), so join
+          -- until brackets and multi-line string delimiters balance.
+          let (logical, remaining) = joinLogicalLine stripped rest
+           in case parseKVLine logical of
+                Right (keys, val) ->
+                  go remaining currentPath (insertNested (currentPath ++ keys) val root)
+                Left err -> Left err
       where
         stripped = T.strip line
+
+-- | Which TOML string form a scan position is inside.
+data TomlStringState = TSNone | TSBasic | TSLiteral | TSMultiBasic | TSMultiLiteral
+  deriving (Eq)
+
+-- | Scanner state for joining physical lines into one logical
+-- key = value line: array-bracket depth outside strings, plus the
+-- string form currently open.
+data TomlScan = TomlScan
+  { tsBracketDepth :: !Int,
+    tsString :: !TomlStringState
+  }
+
+emptyTomlScan :: TomlScan
+emptyTomlScan = TomlScan 0 TSNone
+
+-- | Whether a logical value is still open at end of line: inside a
+-- multi-line string, or under an unclosed array bracket.  A single-line
+-- string left open is NOT continuable (TOML basic\/literal strings
+-- cannot span lines) - the value parser reports that case.
+tomlNeedsMoreLines :: TomlScan -> Bool
+tomlNeedsMoreLines st =
+  tsBracketDepth st > 0
+    || tsString st == TSMultiBasic
+    || tsString st == TSMultiLiteral
+
+-- | Scan one physical line, returning the state at end of line and the
+-- line's visible text: a comment outside strings is cut here, where the
+-- string context is still known ('#' inside any string form is content).
+scanTomlLine :: TomlScan -> Text -> (TomlScan, Text)
+scanTomlLine st0 line = go st0 line 0
+  where
+    go st t !seen = case T.uncons t of
+      Nothing -> (st, line)
+      Just (c, rest) ->
+        let one newSt = go newSt rest (seen + 1)
+            jump n newSt = go newSt (T.drop (n - 1) rest) (seen + n)
+         in case tsString st of
+              TSBasic
+                | c == '\\' -> jump 2 st
+                | c == '"' -> one st {tsString = TSNone}
+                | otherwise -> one st
+              TSLiteral
+                | c == '\'' -> one st {tsString = TSNone}
+                | otherwise -> one st
+              TSMultiBasic
+                | c == '\\' -> jump 2 st
+                | c == '"', Just _ <- T.stripPrefix "\"\"" rest -> jump 3 st {tsString = TSNone}
+                | otherwise -> one st
+              TSMultiLiteral
+                | c == '\'', Just _ <- T.stripPrefix "''" rest -> jump 3 st {tsString = TSNone}
+                | otherwise -> one st
+              TSNone
+                | c == '#' -> (st, T.take seen line)
+                | c == '"', Just _ <- T.stripPrefix "\"\"" rest -> jump 3 st {tsString = TSMultiBasic}
+                | c == '"' -> one st {tsString = TSBasic}
+                | c == '\'', Just _ <- T.stripPrefix "''" rest -> jump 3 st {tsString = TSMultiLiteral}
+                | c == '\'' -> one st {tsString = TSLiteral}
+                | c == '[' -> one st {tsBracketDepth = tsBracketDepth st + 1}
+                | c == ']' -> one st {tsBracketDepth = max 0 (tsBracketDepth st - 1)}
+                | otherwise -> one st
+
+-- | Join physical lines into one logical key = value line, returning it
+-- with the unconsumed lines.  An unterminated construct at end of input
+-- hands what accumulated to the value parser, which reports the specific
+-- failure.
+joinLogicalLine :: Text -> [Text] -> (Text, [Text])
+joinLogicalLine firstLine rest0 =
+  let (st0, visible0) = scanTomlLine emptyTomlScan firstLine
+   in go st0 visible0 rest0
+  where
+    go st acc remaining
+      | not (tomlNeedsMoreLines st) = (acc, remaining)
+      | otherwise = case remaining of
+          [] -> (acc, [])
+          (next : more) ->
+            let (advanced, visible) = scanTomlLine st next
+             in go advanced (acc <> "\n" <> visible) more
 
 -- | Parse a key = value line.
 parseKVLine :: Text -> Either Text ([Text], TOMLValue)
@@ -4069,11 +4240,14 @@ splitCommas = go (0 :: Int) []
 insertNested :: [Text] -> TOMLValue -> Map Text TOMLValue -> Map Text TOMLValue
 insertNested [] _ m = m
 insertNested [k] v m = Map.insert k v m
-insertNested (k : ks) v m =
-  let sub = case Map.lookup k m of
-        Just (TOMLTable inner) -> inner
-        _ -> Map.empty
-   in Map.insert k (TOMLTable (insertNested ks v sub)) m
+insertNested (k : ks) v m = case Map.lookup k m of
+  -- Under a [[table]] header the path crosses an array of tables: keys
+  -- belong to its LAST element, not to a table replacing the array.
+  Just (TOMLArray xs)
+    | (TOMLTable lastInner : prev) <- reverse xs ->
+        Map.insert k (TOMLArray (reverse prev ++ [TOMLTable (insertNested ks v lastInner)])) m
+  Just (TOMLTable inner) -> Map.insert k (TOMLTable (insertNested ks v inner)) m
+  _ -> Map.insert k (TOMLTable (insertNested ks v Map.empty)) m
 
 -- | Ensure a table path exists (for @[table]@ headers).
 ensureTable :: [Text] -> Map Text TOMLValue -> Map Text TOMLValue
@@ -4188,14 +4362,82 @@ builtinPath :: (MonadEval m) => NixValue -> m NixValue
 builtinPath (VAttrs attrs) = do
   pathStr <- forceAttrStr "builtins.path" "path" attrs
   nameOverride <- forceOptionalAttrStr attrs "name"
+  expectedDigest <- case attrSetLookup "sha256" attrs of
+    Nothing -> pure Nothing
+    Just thunk -> do
+      pinVal <- force thunk
+      case pinVal of
+        VStr pin _ -> Just <$> decodeSha256Pin "builtins.path" pin
+        other -> throwEvalError ("builtins.path: 'sha256' must be a string, got " <> typeName other)
   let name = fromMaybe (extractBaseName pathStr) nameOverride
-  storePathText <- copyPathToStore pathStr name
-  -- Parse the store path to construct proper SCPlain context
-  case parseStorePath defaultStoreDir storePathText of
-    Just sp -> pure (VStr storePathText (plainContext sp))
-    Nothing -> pure (VStr storePathText emptyContext)
+      pinSubject = "builtins.path: " <> pathStr
+  storePathText <- case attrSetLookup "filter" attrs of
+    Nothing -> copyPathToStore pathStr name (fmap (pinSubject,) expectedDigest)
+    Just filterThunk -> do
+      filterFn <- force filterThunk
+      narBytes <- filteredSourceNar filterFn pathStr
+      -- The sha256 pin applies to the FILTERED tree, as upstream.
+      let filteredDigest = sha256Digest narBytes
+      case expectedDigest of
+        Just expected
+          | expected /= filteredDigest ->
+              throwEvalError
+                ( pinSubject
+                    <> ": hash mismatch: expected sha256:"
+                    <> bytesToHexText expected
+                    <> ", got sha256:"
+                    <> bytesToHexText filteredDigest
+                )
+        _ -> pure ()
+      addSourceNar name narBytes
+  pure (sourceResultString storePathText)
 builtinPath other =
   throwEvalError ("builtins.path: expected an attribute set, got " <> typeName other)
+
+-- | The result value both source importers return: the store path as a
+-- string carrying itself as context.
+sourceResultString :: Text -> NixValue
+sourceResultString storePathText =
+  case parseStorePath defaultStoreDir storePathText of
+    Just sp -> VStr storePathText (plainContext sp)
+    Nothing -> VStr storePathText emptyContext
+
+-- | Serialise a source tree to a NAR, keeping only entries the Nix filter
+-- function accepts - upstream's addToStore filtering: the filter receives
+-- @(path, type)@ for every entry BELOW the root (the root itself is never
+-- filtered), and rejecting a directory prunes its whole subtree.  Child
+-- paths hand the filter @parent/name@ with a forward slash; both path
+-- styles reach Nix code only through separator-agnostic helpers like
+-- @baseNameOf@.
+filteredSourceNar :: (MonadEval m) => NixValue -> Text -> m BS.ByteString
+filteredSourceNar filterFn rootPath = do
+  rootType <- getFileType rootPath
+  entry <- buildEntry rootPath rootType
+  pure (NAR.serialise entry)
+  where
+    buildEntry path fileType = case fileType of
+      "regular" -> do
+        executable <- isExecutableFile path
+        bytes <- readFileBytes path
+        pure (NAR.NarRegular executable bytes)
+      "symlink" -> NAR.NarSymlink <$> readSymlinkTarget path
+      "directory" -> do
+        children <- listDirectory path
+        kept <- mapM (keepChild path) children
+        pure (NAR.NarDirectory (catMaybes kept))
+      other -> throwEvalError ("builtins.path: unsupported file type '" <> other <> "' at " <> path)
+    keepChild parent (name, childType) = do
+      let childPath = parent <> "/" <> name
+      keep <- filterAccepts childPath childType
+      if keep
+        then Just . (,) name <$> buildEntry childPath childType
+        else pure Nothing
+    filterAccepts path fileType = do
+      partial <- applyValue filterFn (mkStr path)
+      result <- applyValue partial (mkStr fileType)
+      case result of
+        VBool b -> pure b
+        other -> throwEvalError ("builtins.path: the filter function must return a Boolean, got " <> typeName other)
 
 -- | Extract the last path component from a path string.
 extractBaseName :: Text -> Text
@@ -4214,14 +4456,19 @@ extractBaseName path =
 -- | @builtins.filterSource filter path@ - copy a path to the store,
 -- filtering entries via a predicate.  The filter function receives
 -- @(path, type)@ where type is @"regular"@, @"directory"@, @"symlink"@,
--- or @"unknown"@.
+-- or @"unknown"@.  Equivalent to @builtins.path@ with a filter and the
+-- source's basename as the store name.
 builtinFilterSource :: (MonadEval m) => NixValue -> NixValue -> m NixValue
-builtinFilterSource _filterFn (VPath _path) =
-  throwEvalError "builtins.filterSource: not yet implemented (requires store integration)"
-builtinFilterSource _filterFn (VStr _path _) =
-  throwEvalError "builtins.filterSource: not yet implemented (requires store integration)"
+builtinFilterSource filterFn (VPath path) = filterSourceInto filterFn path
+builtinFilterSource filterFn (VStr path _) = filterSourceInto filterFn path
 builtinFilterSource _ other =
   throwEvalError ("builtins.filterSource: expected a path, got " <> typeName other)
+
+filterSourceInto :: (MonadEval m) => NixValue -> Text -> m NixValue
+filterSourceInto filterFn path = do
+  narBytes <- filteredSourceNar filterFn path
+  storePathText <- addSourceNar (extractBaseName path) narBytes
+  pure (sourceResultString storePathText)
 
 -- ---------------------------------------------------------------------------
 -- Builtin stubs - experimental features

--- a/src/Nix/Eval/Compile.hs
+++ b/src/Nix/Eval/Compile.hs
@@ -181,7 +181,8 @@ compileExpr = go
     compileStringParts op parts = do
       compiled <- mapM compileOnePart parts
       dataOff <- emitPairs compiled
-      cbcEmit op 0 (fi (length parts)) dataOff 0 0
+      partCount <- countArg "string with parts" (length parts)
+      cbcEmit op 0 partCount dataOff 0 0
 
     compileOnePart :: StringPart -> IO (Word32, Word32)
     compileOnePart (StrLit t) = do
@@ -199,7 +200,8 @@ compileExpr = go
     compileAttrs isRec bindings captureInfo = do
       dataOff <- compileBindings bindings
       capOff <- compileCaptureInfo captureInfo
-      cbcEmit OpAttrs (if isRec then 1 else 0) (fi (length bindings)) dataOff capOff 0
+      bindingCount <- countArg "attribute set with bindings" (length bindings)
+      cbcEmit OpAttrs (if isRec then 1 else 0) bindingCount dataOff capOff 0
 
     -- -----------------------------------------------------------------
     -- Lists (EList)
@@ -209,7 +211,8 @@ compileExpr = go
     compileList exprs = do
       childIndices <- mapM go exprs
       dataOff <- emitWordList childIndices
-      cbcEmit OpList 0 (fi (length exprs)) dataOff 0 0
+      elemCount <- countArg "list with elements" (length exprs)
+      cbcEmit OpList 0 elemCount dataOff 0 0
 
     -- -----------------------------------------------------------------
     -- Select / HasAttr
@@ -235,7 +238,8 @@ compileExpr = go
     compileAttrPath path = do
       compiled <- mapM compileAttrKey path
       off <- emitPairs compiled
-      pure (off, fi (length path))
+      pathLen <- countArg "attribute path with segments" (length path)
+      pure (off, pathLen)
 
     compileAttrKey :: AttrKey -> IO (Word32, Word32)
     compileAttrKey (StaticKey name) = do
@@ -293,7 +297,8 @@ compileExpr = go
       bodyIdx <- go body
       dataOff <- compileBindings bindings
       capOff <- compileCaptureInfo captureInfo
-      cbcEmit OpLet 0 (fi (length bindings)) dataOff bodyIdx capOff
+      bindingCount <- countArg "let with bindings" (length bindings)
+      cbcEmit OpLet 0 bindingCount dataOff bodyIdx capOff
 
     -- -----------------------------------------------------------------
     -- Bindings (shared by EAttrs and ELet)
@@ -410,6 +415,15 @@ compileExpr = go
       off <- cbcEmitData x
       mapM_ cbcEmitData xs
       pure off
+
+    -- \| Convert an element count into the bytecode's 16-bit short_arg,
+    -- failing loudly on overflow: a silent Word16 truncation once made a
+    -- 70000-element list literal report length 4464.
+    countArg :: String -> Int -> IO Word16
+    countArg what n
+      | n > fromIntegral (maxBound :: Word16) =
+          ioError (userError ("compile: " <> what <> " exceeding the bytecode limit of 65535 (got " <> show n <> ")"))
+      | otherwise = pure (fromIntegral n)
 
     -- \| @fromIntegral@ shorthand.
     fi :: (Integral a, Num b) => a -> b

--- a/src/Nix/Eval/IO.hs
+++ b/src/Nix/Eval/IO.hs
@@ -23,6 +23,7 @@ module Nix.Eval.IO
     newEvalState,
 
     -- * Errors
+    EvalErrorKind (..),
     NixEvalError (..),
     NixAbortError (..),
   )
@@ -40,7 +41,6 @@ import qualified Data.Map.Strict as Map
 import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Text.Encoding (encodeUtf8)
-import qualified Data.Text.IO as TIO
 import Data.Time.Clock.POSIX (getPOSIXTime)
 import Foreign.Ptr (Ptr, castPtr, nullPtr)
 import Foreign.StablePtr (castPtrToStablePtr, castStablePtrToPtr, deRefStablePtr, freeStablePtr, newStablePtr)
@@ -51,7 +51,7 @@ import Nix.Eval.CThunk (CThunkPtr, cthunkGetAttrs, cthunkGetBcIdx, cthunkGetBool
 import Nix.Eval.Symbol (Symbol (..), symbolIntern, symbolText)
 import Nix.Eval.Types (AttrSet (..), Env (..), MonadEval (..), NixValue (..), Thunk (..), attrSetSize, emptyContext, marshalLambda, marshalStringContext, unmarshalLambdaValue, unmarshalStringContext, pattern ValueAttrs, pattern ValueBool, pattern ValueCtxStr, pattern ValueFloat, pattern ValueInt, pattern ValueLambda, pattern ValueList, pattern ValueNull, pattern ValuePath, pattern ValueStr)
 import Nix.Expr.Types (AttrKey (..), Binding (..), Expr (..), Formal (..), Formals (..), NixAtom (..), StringPart (..))
-import Nix.Hash (makeFixedOutputPath, sha256Digest, sha256Hex, truncatedBase32)
+import Nix.Hash (bytesToHexText, makeFixedOutputPath, makeTextPath, sha256Digest)
 import Nix.Parser (parseNix, readFileAutoEncoding)
 import qualified Nix.Store.Path as SP
 import qualified NovaCache.NAR as NAR
@@ -66,8 +66,16 @@ import qualified System.Process as Proc
 -- Error type
 -- ---------------------------------------------------------------------------
 
--- | Evaluation error surfaced as an IO exception (catchable by tryEval).
-newtype NixEvalError = NixEvalError Text
+-- | How an eval-time failure interacts with @builtins.tryEval@:
+-- 'ErrorThrown' (@builtins.throw@, a failed @assert@) is catchable,
+-- matching upstream's ThrownError\/AssertionError; 'ErrorUncatchable'
+-- (type errors, missing attributes, IO failures) escapes tryEval like
+-- every other upstream EvalError.
+data EvalErrorKind = ErrorThrown | ErrorUncatchable
+  deriving (Eq, Show)
+
+-- | Evaluation error surfaced as an IO exception.
+data NixEvalError = NixEvalError !EvalErrorKind !Text
   deriving (Show)
 
 instance Exception NixEvalError
@@ -107,7 +115,6 @@ data EvalState = EvalState
     -- literal used across many derivations is hashed only once.
     esSourcePathCache :: !(IORef (Map Text Text)),
     esBaseDir :: !FilePath,
-    esStoreDir :: !FilePath,
     esTimestamp :: !Int64,
     esSearchPaths :: ![Thunk]
   }
@@ -132,7 +139,6 @@ newEvalState baseDir = do
         esDrvClosure = drvClosure,
         esSourcePathCache = srcCache,
         esBaseDir = baseDir,
-        esStoreDir = T.unpack SP.platformStoreDirText,
         esTimestamp = now,
         esSearchPaths = searchPaths
       }
@@ -150,13 +156,20 @@ newtype EvalIO a = EvalIO {unEvalIO :: ReaderT EvalState IO a}
 -- ---------------------------------------------------------------------------
 
 instance MonadEval EvalIO where
-  throwEvalError msg = EvalIO (liftIO (throwIO (NixEvalError msg)))
+  throwEvalError msg = EvalIO (liftIO (throwIO (NixEvalError ErrorUncatchable msg)))
+  throwCatchableError msg = EvalIO (liftIO (throwIO (NixEvalError ErrorThrown msg)))
   abortEvaluation msg = EvalIO (liftIO (throwIO (NixAbortError msg)))
 
+  -- tryEval semantics: recover from a throw/assert only; an uncatchable
+  -- eval error is rethrown (aborts are a separate exception type and
+  -- never enter the 'try').
   catchEvalError (EvalIO action) = EvalIO $ do
     st <- ask
     result <- liftIO (try (runReaderT action st))
-    pure (case result of Left (NixEvalError msg) -> Left msg; Right val -> Right val)
+    case result of
+      Left (NixEvalError ErrorThrown msg) -> pure (Left msg)
+      Left err@(NixEvalError ErrorUncatchable _) -> liftIO (throwIO err)
+      Right val -> pure (Right val)
 
   readFileText path = wrapIO (readFileAutoEncoding (T.unpack path))
 
@@ -246,7 +259,7 @@ instance MonadEval EvalIO where
 
   getCurrentTime = EvalIO (asks esTimestamp)
 
-  writeToStore name contents = do
+  writeToStore name contents refs = do
     -- Validate name to prevent path traversal
     when (T.any (== '/') name) $
       throwEvalError ("writeToStore: name must not contain '/': " <> name)
@@ -256,23 +269,17 @@ instance MonadEval EvalIO where
       throwEvalError ("writeToStore: name must not contain '..': " <> name)
     when (T.any (== '\0') name) $
       throwEvalError ("writeToStore: name must not contain null bytes: " <> name)
-    storeDir <- EvalIO (asks esStoreDir)
-    -- The preimage is built inline against the LIVE storeDir (esStoreDir), not
-    -- via Nix.Hash.makeStorePath which pins the canonical defaultStoreDir for
-    -- cross-platform .drv-hash parity.  toFile outputs are host-local, so they
-    -- must use the running store dir - keep this format in sync with
-    -- makeStorePath's preimage (type:sha256:hex:storeDir:name).
-    let contentHash = sha256Hex (encodeUtf8 contents)
-        inner = "nix-store:sha256:" <> contentHash <> ":" <> T.pack storeDir <> ":" <> name
-        pathHash = truncatedBase32 (encodeUtf8 inner)
-        basename = pathHash <> "-" <> name
-        -- File path uses platform separator for I/O
-        filePath = storeDir </> T.unpack basename
-        -- Store path text always uses forward slash (Nix convention)
-        storePath = T.pack storeDir <> "/" <> basename
+    -- Upstream's text-path scheme via makeTextPath - the same scheme .drv
+    -- paths use, so it is parity-validated: type @text:<refs>@, flat
+    -- sha256 of the contents, canonical store dir.  Written as UTF-8
+    -- BYTES: text-mode IO would CRLF-translate on Windows and the stored
+    -- bytes would no longer match the hash that named the path.
+    let sp = makeTextPath name (sha256Digest (encodeUtf8 contents)) refs
+        filePath = SP.storePathToFilePath SP.defaultStoreDir sp
+        storePath = SP.storePathToText SP.defaultStoreDir sp
     wrapIO $ do
-      Dir.createDirectoryIfMissing True storeDir
-      TIO.writeFile filePath contents
+      Dir.createDirectoryIfMissing True (takeDirectory filePath)
+      BS.writeFile filePath (encodeUtf8 contents)
     pure storePath
 
   scopedImportFile scope rawPath = do
@@ -320,7 +327,7 @@ instance MonadEval EvalIO where
           ExitFailure n -> n
     pure (code, T.pack stdoutStr, T.pack stderrStr)
 
-  copyPathToStore srcPath name = do
+  copyPathToStore srcPath name expectedSha256 = do
     -- Validate name to prevent path traversal (matches writeToStore)
     when (T.any (== '/') name) $
       throwEvalError ("copyPathToStore: name must not contain '/': " <> name)
@@ -330,19 +337,50 @@ instance MonadEval EvalIO where
       throwEvalError ("copyPathToStore: name must not contain '..': " <> name)
     when (T.any (== '\0') name) $
       throwEvalError ("copyPathToStore: name must not contain null bytes: " <> name)
-    storeDir <- EvalIO (asks esStoreDir)
-    -- Inline host-local store-path preimage (see writeToStore's note): uses the
-    -- live esStoreDir, not makeStorePath's pinned defaultStoreDir.
-    let contentHash = sha256Hex (encodeUtf8 ("source:" <> srcPath <> ":" <> name))
-        inner = "nix-store:sha256:" <> contentHash <> ":" <> T.pack storeDir <> ":" <> name
-        pathHash = truncatedBase32 (encodeUtf8 inner)
-        basename = pathHash <> "-" <> name
-        -- File path uses platform separator for I/O
-        destFilePath = storeDir </> T.unpack basename
-        -- Store path text always uses forward slash (Nix convention)
-        destPath = T.pack storeDir <> "/" <> basename
-    wrapIO (copyToStoreIfMissing (T.unpack srcPath) destFilePath storeDir)
+    -- Content-addressed like upstream addToStore: recursive NAR sha256
+    -- under the caller's name.  Same content means same path, so the
+    -- existence check in copyToStoreIfMissing is sound - changed source
+    -- content can never serve stale bytes from an earlier copy (the old
+    -- scheme hashed the path STRING, so it did exactly that).
+    entry <- wrapIO (NAR.serialiseFromPath (T.unpack srcPath))
+    let narDigest = sha256Digest (NAR.serialise entry)
+    case expectedSha256 of
+      Just (subject, expected)
+        | expected /= narDigest ->
+            throwEvalError
+              ( subject
+                  <> ": hash mismatch: expected sha256:"
+                  <> bytesToHexText expected
+                  <> ", got sha256:"
+                  <> bytesToHexText narDigest
+              )
+      _ -> pure ()
+    let sp = makeFixedOutputPath name "sha256" "recursive" narDigest
+        destFilePath = SP.storePathToFilePath SP.defaultStoreDir sp
+        destPath = SP.storePathToText SP.defaultStoreDir sp
+    wrapIO (copyToStoreIfMissing (T.unpack srcPath) destFilePath (takeDirectory destFilePath))
     pure destPath
+
+  isExecutableFile path = wrapIO (Dir.executable <$> Dir.getPermissions (T.unpack path))
+
+  readSymlinkTarget path = wrapIO (T.pack <$> Dir.getSymbolicLinkTarget (T.unpack path))
+
+  addSourceNar name narBytes =
+    case NAR.deserialise narBytes of
+      -- Unreachable in practice: the bytes come from NAR.serialise of a
+      -- tree this process just built.  Kept total for the FFI-adjacent
+      -- boundary rather than trusting the round trip.
+      Left err -> throwEvalError ("builtins.path: internal NAR round-trip error: " <> T.pack err)
+      Right entry -> do
+        let sp = makeFixedOutputPath name "sha256" "recursive" (sha256Digest narBytes)
+            destFilePath = SP.storePathToFilePath SP.defaultStoreDir sp
+            destPath = SP.storePathToText SP.defaultStoreDir sp
+        wrapIO $ do
+          alreadyThere <- Dir.doesPathExist destFilePath
+          unless alreadyThere $ do
+            Dir.createDirectoryIfMissing True (takeDirectory destFilePath)
+            materializeNarEntry destFilePath entry
+        pure destPath
 
   addFixedOutputFile name bytes = do
     -- Canonical fixed-output path: a sha256-pinned fetch must land at the same
@@ -519,7 +557,7 @@ wrapIO action = EvalIO $ liftIO $ do
       | Just (_ :: SomeAsyncException) <- fromException err -> throwIO err
       | Just abortErr <- fromException err -> throwIO (abortErr :: NixAbortError)
       | Just nixErr <- fromException err -> throwIO (nixErr :: NixEvalError)
-      | otherwise -> throwIO (NixEvalError (T.pack (displayException err)))
+      | otherwise -> throwIO (NixEvalError ErrorUncatchable (T.pack (displayException err)))
 
 -- | Run an IO evaluation, returning @Left@ on error.
 --
@@ -532,7 +570,7 @@ runEvalIO st (EvalIO action) = do
     Right val -> pure (Right val)
     Left (err :: SomeException)
       | Just (_ :: SomeAsyncException) <- fromException err -> throwIO err
-      | Just (NixEvalError msg) <- fromException err -> pure (Left msg)
+      | Just (NixEvalError _ msg) <- fromException err -> pure (Left msg)
       | Just (NixAbortError msg) <- fromException err -> pure (Left msg)
       | otherwise -> pure (Left (T.pack (displayException err)))
 
@@ -621,3 +659,22 @@ copyPath src dest = do
       entries <- Dir.listDirectory src
       mapM_ (\entry -> copyPath (src </> entry) (dest </> entry)) entries
     else Dir.copyFile src dest
+
+-- | Write a NAR entry tree to disk: files with their executable bit,
+-- directories recursively, symlinks as symlinks (directory links when the
+-- target resolves to a directory, matching how the tree was serialized).
+materializeNarEntry :: FilePath -> NAR.NarEntry -> IO ()
+materializeNarEntry dest (NAR.NarRegular isExec contents) = do
+  BS.writeFile dest contents
+  when isExec $ do
+    perms <- Dir.getPermissions dest
+    Dir.setPermissions dest (Dir.setOwnerExecutable True perms)
+materializeNarEntry dest (NAR.NarSymlink target) = do
+  let resolved = takeDirectory dest </> T.unpack target
+  targetIsDir <- Dir.doesDirectoryExist resolved
+  if targetIsDir
+    then Dir.createDirectoryLink (T.unpack target) dest
+    else Dir.createFileLink (T.unpack target) dest
+materializeNarEntry dest (NAR.NarDirectory entries) = do
+  Dir.createDirectoryIfMissing True dest
+  mapM_ (\(name, entry) -> materializeNarEntry (dest </> T.unpack name) entry) entries

--- a/src/Nix/Eval/Operator.hs
+++ b/src/Nix/Eval/Operator.hs
@@ -22,6 +22,7 @@ import Nix.Eval.Types
     Thunk (..),
     attrSetElems,
     attrSetKeys,
+    attrSetLookup,
     thunkSameRef,
     typeName,
   )
@@ -72,16 +73,16 @@ evalUnary OpNegate val = case val of
   VFloat n -> pure (VFloat (negate n))
   other -> throwEvalError ("cannot negate " <> typeName other)
 
--- | Addition: int/float arithmetic, string concatenation, path append.
+-- | Addition: int/float arithmetic and string concatenation.  Path
+-- operands never reach here - @Nix.Eval.evalAddWithCoercion@ handles them
+-- (store-copy coercion for @string + path@, context checks for
+-- @path + string@) before delegating.
 evalAdd :: (MonadEval m) => NixValue -> NixValue -> m NixValue
 evalAdd (VInt a) (VInt b) = pure (VInt (a + b))
 evalAdd (VInt a) (VFloat b) = pure (VFloat (fromIntegral a + b))
 evalAdd (VFloat a) (VInt b) = pure (VFloat (a + fromIntegral b))
 evalAdd (VFloat a) (VFloat b) = pure (VFloat (a + b))
 evalAdd (VStr a ctxA) (VStr b ctxB) = pure (VStr (a <> b) (ctxA <> ctxB))
-evalAdd (VPath a) (VStr b _) = pure (VPath (a <> b))
-evalAdd (VPath a) (VPath b) = pure (VPath (a <> b))
-evalAdd (VStr a ctxA) (VPath b) = pure (VStr (a <> b) ctxA)
 evalAdd left right =
   throwEvalError ("cannot add " <> typeName left <> " and " <> typeName right)
 
@@ -194,13 +195,57 @@ nixEqual _ (VPath a) (VPath b) = pure (a == b)
 nixEqual forceFn (VList clA) (VList clB)
   | clistLen clA /= clistLen clB = pure False
   | otherwise = listEqual forceFn (map Thunk (clistThunks clA)) (map Thunk (clistThunks clB))
-nixEqual forceFn (VAttrs as) (VAttrs bs)
-  | attrSetKeys as /= attrSetKeys bs = pure False
-  | otherwise = do
-      let pairs = zip (attrSetElems as) (attrSetElems bs)
-      results <- mapM (thunkPairEqual forceFn) pairs
-      pure (and results)
+nixEqual forceFn (VAttrs as) (VAttrs bs) = do
+  drvOutPaths <- derivationOutPathPair forceFn as bs
+  case drvOutPaths of
+    Just outPathPair -> thunkPairEqual forceFn outPathPair
+    Nothing
+      | attrSetKeys as /= attrSetKeys bs -> pure False
+      | otherwise ->
+          -- Short-circuit on the first mismatch: later pairs are never
+          -- forced, so errors past the deciding pair cannot surface
+          -- (upstream stops comparing there too).
+          allPairsEqual (zip (attrSetElems as) (attrSetElems bs))
+  where
+    allPairsEqual [] = pure True
+    allPairsEqual (pair : rest) = do
+      eq <- thunkPairEqual forceFn pair
+      if eq then allPairsEqual rest else pure False
 nixEqual _ _ _ = pure False
+
+-- | When both attr sets are derivations (a @type@ attr forcing to the string
+-- @"derivation"@) and both carry an @outPath@, the pair of outPath thunks.
+--
+-- C++ Nix's eqValues compares derivations by outPath ALONE, before any
+-- key-set comparison: two mkDerivation results with the same outPath are
+-- equal even though their lambda attrs (override, overrideAttrs) never are,
+-- and distinct self-referential finalAttrs packages would otherwise recurse
+-- forever.  If either set lacks an outPath, fall through to deep comparison,
+-- exactly as upstream does.
+derivationOutPathPair :: (MonadEval m) => Force m -> AttrSet -> AttrSet -> m (Maybe (Thunk, Thunk))
+derivationOutPathPair forceFn as bs = do
+  leftIsDrv <- isDerivationSet forceFn as
+  if not leftIsDrv
+    then pure Nothing
+    else do
+      rightIsDrv <- isDerivationSet forceFn bs
+      pure $
+        if rightIsDrv
+          then (,) <$> attrSetLookup "outPath" as <*> attrSetLookup "outPath" bs
+          else Nothing
+
+-- | Does the set carry @type = "derivation"@?  Forces only the @type@ attr
+-- (as upstream's isDerivation does); a non-string type is simply not a
+-- derivation, not an error.
+isDerivationSet :: (MonadEval m) => Force m -> AttrSet -> m Bool
+isDerivationSet forceFn attrs =
+  case attrSetLookup "type" attrs of
+    Nothing -> pure False
+    Just typeThunk -> do
+      typeVal <- forceFn typeThunk
+      case typeVal of
+        VStr tag _ -> pure (tag == "derivation")
+        _ -> pure False
 
 -- | Pairwise equality of two thunk lists (for list comparison).
 listEqual :: (MonadEval m) => Force m -> [Thunk] -> [Thunk] -> m Bool

--- a/src/Nix/Eval/StringInterp.hs
+++ b/src/Nix/Eval/StringInterp.hs
@@ -88,7 +88,7 @@ coerceToString :: (MonadEval m) => Bool -> Force m -> Apply m -> NixValue -> m (
 coerceToString _ _ _ (VStr s ctx) = pure (s, ctx)
 coerceToString _ _ _ (VPath p) = pure (p, emptyContext)
 coerceToString True _ _ (VInt n) = pure (T.pack (show n), emptyContext)
-coerceToString True _ _ (VFloat n) = pure (formatNixFloat n, emptyContext)
+coerceToString True _ _ (VFloat n) = pure (formatNixFloatFixed n, emptyContext)
 coerceToString True _ _ VNull = pure ("", emptyContext)
 coerceToString True _ _ (VBool True) = pure ("1", emptyContext)
 coerceToString True _ _ (VBool False) = pure ("", emptyContext)
@@ -108,9 +108,19 @@ coerceToString coerceMore forceFn applyFn (VAttrs attrs) =
 coerceToString _ _ _ other =
   throwEvalError ("cannot coerce " <> typeName other <> " to a string")
 
--- | Format a float the way C++ Nix does: 6 fixed decimal places
--- (@std::to_string@), then strip trailing zeros and unnecessary
--- decimal point.  E.g. @1.0@ becomes @"1"@, @3.14@ becomes @"3.14"@.
+-- | Format a float the way C++ Nix's coerceToString does -
+-- @std::to_string@, i.e. FIXED 6 decimal places with no trimming:
+-- @toString 1.5@ is @"1.500000"@.  Derivation env values and
+-- @builtins.toString@ both see this form, so it is hash-relevant.
+formatNixFloatFixed :: Double -> Text
+formatNixFloatFixed n
+  | isNaN n = "nan"
+  | isInfinite n = if n > 0 then "inf" else "-inf"
+  | otherwise = T.pack (showFFloat (Just 6) n "")
+
+-- | Format a float for value display and JSON: 6 fixed decimal places,
+-- then strip trailing zeros and an unnecessary decimal point.  E.g.
+-- @1.0@ becomes @"1"@, @3.14@ becomes @"3.14"@.
 formatNixFloat :: Double -> Text
 formatNixFloat n
   | isNaN n = "nan"

--- a/src/Nix/Eval/Types.hs
+++ b/src/Nix/Eval/Types.hs
@@ -57,6 +57,7 @@ module Nix.Eval.Types
     lookupWithScopes,
     withScopesForCapture,
     envWithScopesRaw,
+    checkedEnvPtr,
     newCEnv,
     newMinimalEnv,
 
@@ -485,28 +486,38 @@ instance Show Env where
 emptyEnv :: Env
 emptyEnv = Env (unsafePerformIO cenvEmpty)
 
+-- | Fail loudly when a C env constructor returns NULL (arena OOM or the
+-- with-scope count limit).  The C side signals failure deliberately;
+-- deferring the NULL to the next lookup would be undefined behavior in a
+-- release build, so convert it into a clean Haskell exception here.
+checkedEnvPtr :: String -> Ptr NnEnv -> Ptr NnEnv
+checkedEnvPtr site ptr
+  | ptr == nullPtr = error (site ++ ": C env allocation failed (arena OOM or with-scope limit)")
+  | otherwise = ptr
+
 -- | General C-backed env constructor.
 -- Takes Haskell-level types; converts Maybe to nullPtr internally.
 {-# NOINLINE newCEnv #-}
 newCEnv :: Ptr CThunkPtr -> Int -> Maybe AttrSet -> Maybe Env -> Ptr (Ptr ()) -> Word16 -> Env
 newCEnv slots slotCount lazyScope parent withs withCount =
   Env
-    ( unsafePerformIO
-        ( cenvNew
-            slots
-            (fromIntegral slotCount)
-            (case lazyScope of Nothing -> nullPtr; Just (AttrSet cset) -> castPtr cset)
-            (case parent of Nothing -> nullPtr; Just (Env p) -> p)
-            withs
-            withCount
-        )
+    ( checkedEnvPtr "newCEnv" $
+        unsafePerformIO
+          ( cenvNew
+              slots
+              (fromIntegral slotCount)
+              (case lazyScope of Nothing -> nullPtr; Just (AttrSet cset) -> castPtr cset)
+              (case parent of Nothing -> nullPtr; Just (Env p) -> p)
+              withs
+              withCount
+          )
     )
 
 -- | Minimal env: slots only, no parent, no with-scopes, no lazy scope.
 {-# NOINLINE newMinimalEnv #-}
 newMinimalEnv :: Ptr CThunkPtr -> Int -> Env
 newMinimalEnv slots n =
-  Env (unsafePerformIO (cenvNewMinimal slots (fromIntegral n)))
+  Env (checkedEnvPtr "newMinimalEnv" (unsafePerformIO (cenvNewMinimal slots (fromIntegral n))))
 
 -- | Look up a resolved variable by level and index.  Single C call:
 -- O(level) parent hops in C, then O(1) array read.
@@ -542,9 +553,10 @@ envLookup name (Env envPtr) = lexicalLookup envPtr
 -- | Walk with-scopes (C array) innermost to outermost.
 -- Skips tagged lazy entries (bit 0 set) - those are thunk pointers
 -- that can only be resolved by 'evalWithVarScopes' which has monadic
--- 'force'.  This is a safety guard: currently unreachable because
--- 'resolveVars' ensures EVar behind a with-scope always becomes
--- EWithVar, but protects against future changes.
+-- 'force'.  Defensive: an 'EVar' under a with is either a lexical
+-- (barrier) binding or a static global, both found on the parent chain
+-- before this fallback fires ('EVar' also blocks closure trimming, so
+-- the chain is always intact) - but keep it for safety.
 lookupWithScopesC :: Text -> Ptr (Ptr ()) -> Word16 -> Maybe Thunk
 lookupWithScopesC _ _ 0 = Nothing
 lookupWithScopesC name withArr count = unsafePerformIO $ go 0
@@ -572,14 +584,14 @@ lookupWithScopes name (scope : rest) =
 {-# NOINLINE envFromSlots #-}
 envFromSlots :: Ptr CThunkPtr -> Int -> Env -> Env
 envFromSlots slotsPtr slotCount (Env parentPtr) =
-  Env (unsafePerformIO (cenvFromSlots slotsPtr (fromIntegral slotCount) parentPtr))
+  Env (checkedEnvPtr "envFromSlots" (unsafePerformIO (cenvFromSlots slotsPtr (fromIntegral slotCount) parentPtr)))
 
 -- | Push a with-scope onto the scope chain (innermost position).
 -- Allocates a new C env struct with extended with-scopes array.
 {-# NOINLINE pushWithScope #-}
 pushWithScope :: AttrSet -> Env -> Env
 pushWithScope (AttrSet cset) (Env envPtr) =
-  Env (unsafePerformIO (cenvPushWith envPtr (castPtr cset)))
+  Env (checkedEnvPtr "pushWithScope" (unsafePerformIO (cenvPushWith envPtr (castPtr cset))))
 
 -- | Read with-scopes array pointer and count from a C env.
 {-# NOINLINE envWithScopesRaw #-}
@@ -1042,12 +1054,22 @@ typeName val = case val of
 -- so the same evaluator composes into 'PureEval' for tests or @IO@ for
 -- real file-system access (e.g. @import@, @readFile@).
 class (Monad m) => MonadEval m where
+  -- | Raise an evaluation error (type error, missing attribute, IO
+  -- failure).  NOT caught by @builtins.tryEval@: upstream Nix catches only
+  -- ThrownError\/AssertionError there, and every other EvalError escapes.
   throwEvalError :: Text -> m a
+
+  -- | Raise a catchable error - @builtins.throw@ and a failed @assert@.
+  -- These are the only errors 'catchEvalError' (tryEval) recovers from.
+  throwCatchableError :: Text -> m a
 
   -- | Abort evaluation (uncatchable by tryEval, matching real Nix).
   abortEvaluation :: Text -> m a
 
+  -- | tryEval semantics: recover from a 'throwCatchableError'
+  -- (throw\/assert); eval errors and aborts propagate.
   catchEvalError :: m a -> m (Either Text a)
+
   readFileText :: Text -> m Text
   doesPathExist :: Text -> m Bool
 
@@ -1064,8 +1086,12 @@ class (Monad m) => MonadEval m where
   -- | Get the current epoch time (seconds since 1970-01-01).
   getCurrentTime :: m Int64
 
-  -- | Write a named file to the store, returning the store path.
-  writeToStore :: Text -> Text -> m Text
+  -- | Write a named text file to the store at upstream's text-path
+  -- (@text:\<refs\>@ scheme, flat sha256 of the contents), returning the
+  -- canonical store path.  The refs are the contents' plain store-path
+  -- references; they participate in the path computation exactly as
+  -- upstream's addTextToStore.
+  writeToStore :: Text -> Text -> [StorePath] -> m Text
 
   -- | Import a file with a custom scope overlaid on builtins.
   scopedImportFile :: [(Text, Thunk)] -> Text -> m NixValue
@@ -1087,9 +1113,26 @@ class (Monad m) => MonadEval m where
   -- closures remain valid after the import scope ends.
   resolvePathLiteral :: Text -> m Text
 
-  -- | Copy a path (file or directory) to the store, returning the store path.
-  -- First argument is the source path, second is the store name.
-  copyPathToStore :: Text -> Text -> m Text
+  -- | Copy a path (file or directory) to the store, returning the store
+  -- path.  Content-addressed like upstream addToStore: recursive NAR
+  -- sha256 under the given name.  Arguments: source path, store name,
+  -- and an optional sha256 pin as (error subject, expected digest): a
+  -- digest mismatch fails the copy with the subject heading the message.
+  -- @builtins.path@ and @builtins.fetchTarball@ share this pin.
+  copyPathToStore :: Text -> Text -> Maybe (Text, ByteString) -> m Text
+
+  -- | Whether a regular file carries the executable bit (NAR encodes it).
+  isExecutableFile :: Text -> m Bool
+
+  -- | Read a symlink's target WITHOUT following it.
+  readSymlinkTarget :: Text -> m Text
+
+  -- | Unpack a serialized NAR into the store under the given name at its
+  -- canonical recursive fixed-output path (sha256 of the bytes),
+  -- returning the store path text.  Used by @builtins.path@ and
+  -- @builtins.filterSource@ with a filter, whose filtered tree exists
+  -- only as a NAR value and never on the source filesystem.
+  addSourceNar :: Text -> ByteString -> m Text
 
   -- | Write raw bytes to the store at a canonical flat fixed-output path
   -- (@makeFixedOutputPath name "sha256" "flat"@), so a hash-pinned fetch lands
@@ -1130,9 +1173,11 @@ class (Monad m) => MonadEval m where
   -- argument or environment value.  Unavailable in pure evaluation.
   storeSourcePath :: Text -> m Text
 
--- | Error raised during pure evaluation.  'PAbort' (from @abort@ and infinite
--- recursion) must escape 'tryEval' exactly as in C++ Nix; 'PThrow' is catchable.
-data PureError = PThrow !Text | PAbort !Text
+-- | Error raised during pure evaluation.  'PThrow' (@builtins.throw@, a
+-- failed @assert@) is the only kind 'tryEval' catches; 'PError' (type
+-- errors, missing attributes) and 'PAbort' (@abort@, infinite recursion)
+-- escape it, exactly as in C++ Nix.
+data PureError = PThrow !Text | PError !Text | PAbort !Text
 
 -- | Pure evaluation monad - wraps @Either PureError@.
 -- IO builtins ('readFile', 'import') are unavailable;
@@ -1145,18 +1190,20 @@ newtype PureEval a = PureEval (Either PureError a)
 runPureEval :: PureEval a -> Either Text a
 runPureEval (PureEval (Right a)) = Right a
 runPureEval (PureEval (Left (PThrow t))) = Left t
+runPureEval (PureEval (Left (PError t))) = Left t
 runPureEval (PureEval (Left (PAbort t))) = Left ("evaluation aborted: " <> t)
 
 instance MonadEval PureEval where
-  throwEvalError msg = PureEval (Left (PThrow msg))
+  throwEvalError msg = PureEval (Left (PError msg))
+  throwCatchableError msg = PureEval (Left (PThrow msg))
   abortEvaluation msg = PureEval (Left (PAbort msg))
 
-  -- Catch a throw (tryEval sees the error), but let an abort / infinite
-  -- recursion propagate past tryEval, matching EvalIO and C++ Nix.
+  -- Catch only a throw/assert (tryEval sees the error); eval errors,
+  -- aborts, and infinite recursion propagate, matching EvalIO and C++ Nix.
   catchEvalError (PureEval action) =
     PureEval $ case action of
       Left (PThrow t) -> Right (Left t)
-      Left (PAbort t) -> Left (PAbort t)
+      Left other -> Left other
       Right a -> Right (Right a)
   readFileText _ = throwEvalError "readFile: not available in pure evaluation"
   doesPathExist _ = pure False
@@ -1164,12 +1211,15 @@ instance MonadEval PureEval where
   importFile _ = throwEvalError "import: not available in pure evaluation"
   getEnvVar _ = pure ""
   getCurrentTime = pure 0
-  writeToStore _ _ = throwEvalError "toFile: not available in pure evaluation"
+  writeToStore _ _ _ = throwEvalError "toFile: not available in pure evaluation"
   scopedImportFile _ _ = throwEvalError "scopedImport: not available in pure evaluation"
   readFileBytes _ = throwEvalError "hashFile: not available in pure evaluation"
   getFileType _ = throwEvalError "readFileType: not available in pure evaluation"
   runProcess _ _ _ = throwEvalError "runProcess: not available in pure evaluation"
-  copyPathToStore _ _ = throwEvalError "builtins.path: not available in pure evaluation"
+  copyPathToStore _ _ _ = throwEvalError "builtins.path: not available in pure evaluation"
+  isExecutableFile _ = throwEvalError "builtins.path: not available in pure evaluation"
+  readSymlinkTarget _ = throwEvalError "builtins.path: not available in pure evaluation"
+  addSourceNar _ _ = throwEvalError "builtins.path: not available in pure evaluation"
   addFixedOutputFile _ _ = throwEvalError "builtins.fetchurl: not available in pure evaluation"
   traceMessage _ = pure ()
   lookupDrvHash _ = pure Nothing

--- a/src/Nix/Expr/Resolve.hs
+++ b/src/Nix/Expr/Resolve.hs
@@ -9,6 +9,9 @@
 -- Called once at parse time ('Nix.Parser.parseNix').
 module Nix.Expr.Resolve
   ( resolveVars,
+
+    -- * Static global names (exported for the sync test)
+    staticGlobalNames,
   )
 where
 
@@ -28,8 +31,10 @@ data ScopeEntry
     NameBarrier !(Set Text)
   | -- | Marks a with-scope boundary on the stack.
     -- Does NOT increment the de Bruijn level (with doesn't create a
-    -- parent env level at runtime).  Variables not found in any lexical
-    -- scope below a WithBarrier are upgraded to 'EWithVar'.
+    -- parent env level at runtime).  Variables bound by no 'LexicalScope'
+    -- or 'NameBarrier' anywhere on the stack - and not static globals -
+    -- are upgraded to 'EWithVar' when at least one WithBarrier encloses
+    -- them; lexical bindings and globals always win over with-scopes.
     WithBarrier
 
 -- | Resolve variables in an expression.  Replaces 'EVar' with
@@ -113,28 +118,74 @@ resolve stack expr = case expr of
 -- | Resolve a variable by walking the scope stack.
 --
 -- @level@ counts how many scope entries we've crossed (each corresponds
--- to one parent hop at runtime).  If the name hits a 'LexicalScope',
--- we return 'EResolvedVar'.  If it hits a 'NameBarrier', we stop and
--- leave it as 'EVar' (name-based lookup at runtime).  If not found,
--- 'EVar' is returned unchanged (looked up via with-scopes or builtins).
+-- to one parent hop at runtime).  A 'LexicalScope' hit yields
+-- 'EResolvedVar'; a 'NameBarrier' hit yields 'EVar' (name-based lookup at
+-- runtime).  Both are LEXICAL bindings, so a hit ends the walk no matter
+-- how many 'WithBarrier's were crossed on the way out - in Nix a
+-- with-scope never shadows a binding introduced by other means.
+--
+-- Only a name bound by NEITHER becomes a with-variable, and then only if
+-- it is not a static global: like C++ Nix's staticBaseEnv, a global
+-- (@map@, @toString@, @builtins@, ...) binds at parse time, so
+-- @with { map = 42; }; map@ is the builtin upstream and here.
 resolveVar :: [ScopeEntry] -> Int -> Text -> Expr
-resolveVar [] _ name = EVar name
-resolveVar (LexicalScope scope : rest) level name =
-  case Map.lookup name scope of
-    Just idx -> EResolvedVar level idx
-    Nothing -> resolveVar rest (level + 1) name
-resolveVar (NameBarrier names : rest) level name =
-  if Set.member name names
-    then EVar name
-    else resolveVar rest (level + 1) name
-resolveVar (WithBarrier : rest) level name =
-  -- WithBarrier does NOT increment level (with doesn't create an env level).
-  -- Continue searching lexical scopes below.  If the name is found in a
-  -- lower LexicalScope, use that.  If it reaches the bottom as EVar
-  -- (not found lexically), upgrade to EWithVar.
-  case resolveVar rest level name of
-    EVar _ -> EWithVar name
-    resolved -> resolved
+resolveVar fullStack startLevel name = go fullStack startLevel False
+  where
+    go [] _ crossedWith
+      | crossedWith && not (Set.member name staticGlobalNames) = EWithVar name
+      | otherwise = EVar name
+    go (LexicalScope scope : rest) level crossedWith =
+      case Map.lookup name scope of
+        Just idx -> EResolvedVar level idx
+        Nothing -> go rest (level + 1) crossedWith
+    go (NameBarrier names : rest) level crossedWith
+      | Set.member name names = EVar name
+      | otherwise = go rest (level + 1) crossedWith
+    -- WithBarrier does NOT increment level (with doesn't create an env
+    -- level at runtime); it only records that an enclosing with exists.
+    go (WithBarrier : rest) level _ = go rest level True
+
+-- | Names statically bound in the root environment
+-- ('Nix.Builtins.builtinEnv'): the value constants, @builtins@, the
+-- search-path plumbing, and the top-level builtins that upstream Nix also
+-- exposes unprefixed (its staticBaseEnv).  A name in this set is never a
+-- with-variable - the global binds at parse time and an enclosing @with@
+-- cannot shadow it.
+--
+-- @fetchurl@ and @toFile@ are absent on purpose: upstream exposes them
+-- only under @builtins.@, and nixpkgs relies on @with pkgs; fetchurl@
+-- binding @pkgs.fetchurl@.  The root env matches (they are not bound
+-- there either).
+--
+-- Layering keeps this module from importing 'Nix.Builtins'; a test
+-- asserts this set stays in sync with the root env's actual bindings.
+staticGlobalNames :: Set Text
+staticGlobalNames =
+  Set.fromList
+    [ "true",
+      "false",
+      "null",
+      "builtins",
+      "__findFile",
+      "__nixPath",
+      "abort",
+      "baseNameOf",
+      "break",
+      "derivation",
+      "derivationStrict",
+      "dirOf",
+      "fetchGit",
+      "fetchTarball",
+      "fromTOML",
+      "import",
+      "isNull",
+      "map",
+      "placeholder",
+      "removeAttrs",
+      "scopedImport",
+      "throw",
+      "toString"
+    ]
 
 -- | Build a 'LexicalScope' from lambda formals.
 --

--- a/src/Nix/Parser/Expr.hs
+++ b/src/Nix/Parser/Expr.hs
@@ -22,6 +22,10 @@ module Nix.Parser.Expr
   )
 where
 
+import Control.Monad (foldM)
+import Data.List (foldl')
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
 import Data.Text (Text)
 import Nix.Expr.Types
 import Nix.Parser.Internal
@@ -472,7 +476,7 @@ parseAttrSet isRec =
   (\bs -> EAttrs isRec bs NoCaptureInfo) <$> parseBindings
 
 parseBindings :: Parser [Binding]
-parseBindings = go []
+parseBindings = go [] >>= normalizeBindings
   where
     go acc = do
       tok <- peek
@@ -486,6 +490,98 @@ parseBindings = go []
         _ -> do
           binding <- parseNamedBinding
           go (binding : acc)
+
+-- ---------------------------------------------------------------------------
+-- Binding normalization (upstream parser.y addAttr semantics)
+-- ---------------------------------------------------------------------------
+
+-- | Accumulated definition while normalizing one binding list.
+data NormEntry
+  = -- | @name = value@ - mergeable when the value is a plain attrset literal.
+    StaticEntry !Text !Expr
+  | -- | An @inherit@ - its names are never mergeable.
+    InheritEntry !Binding
+  | -- | A dynamic-key binding - collisions surface at eval time.
+    DynamicEntry !Binding
+
+-- | How a name was defined, for duplicate checking.
+data DefKind = DefStatic | DefInherit
+
+-- | Normalize a binding list the way upstream's parser (@addAttr@) does:
+--
+-- * a nested attrpath (@a.b.c = v@) hoists into nested attrset literals
+--   under its first key (@a = { b = { c = v; }; }@);
+-- * two definitions of one key merge recursively when BOTH values are
+--   attrset literals - so @a.b = 1; a.c = 2;@ and @a = { b = 1; }; a.c = 2;@
+--   both work, with inner duplicates checked recursively.  A @rec@ marker
+--   on the existing set governs the merged result; one on the new set is
+--   discarded, exactly as upstream;
+-- * any other duplicate definition is a parse error, as upstream
+--   (@a = 1; a = 2;@, an @inherit@ name reused, merging into a
+--   non-literal value).
+--
+-- After normalization every static top-level key appears exactly once -
+-- which also makes the positional (slot-based) eval path applicable to
+-- sets and lets that use nested attrpaths.
+normalizeBindings :: [Binding] -> Parser [Binding]
+normalizeBindings bindings =
+  case normalizeBindingList bindings of
+    Left err -> parseError err
+    Right normalized -> pure normalized
+
+-- | Pure core of 'normalizeBindings'; recurses into merged literals.
+normalizeBindingList :: [Binding] -> Either Text [Binding]
+normalizeBindingList bindings = do
+  (entriesRev, _defined) <- foldM step ([], Map.empty) (map canonicalBinding bindings)
+  pure (map renderEntry (reverse entriesRev))
+  where
+    step :: ([NormEntry], Map Text DefKind) -> Binding -> Either Text ([NormEntry], Map Text DefKind)
+    step (entries, defined) binding = case binding of
+      NamedBinding [StaticKey key] value ->
+        case Map.lookup key defined of
+          Nothing ->
+            Right (StaticEntry key value : entries, Map.insert key DefStatic defined)
+          Just DefStatic -> do
+            updated <- mergeIntoEntries key value entries
+            Right (updated, defined)
+          Just DefInherit -> Left (duplicateAttr key)
+      b@(NamedBinding _ _) -> Right (DynamicEntry b : entries, defined)
+      b@(Inherit _ names) -> do
+        mapM_ (\name -> if Map.member name defined then Left (duplicateAttr name) else Right ()) names
+        Right (InheritEntry b : entries, foldl' (\m name -> Map.insert name DefInherit m) defined names)
+
+    -- Replace the existing entry for @key@ with the merged value.
+    mergeIntoEntries key newValue entries = case entries of
+      [] -> Left (duplicateAttr key)
+      (StaticEntry existingKey existingValue : rest)
+        | existingKey == key -> do
+            merged <- mergeAttrValues key existingValue newValue
+            Right (StaticEntry existingKey merged : rest)
+      (entry : rest) -> (entry :) <$> mergeIntoEntries key newValue rest
+
+    -- Upstream's addAttr (parser-state.hh) merges ANY two attrset
+    -- literals without consulting ->recursive on either side: the
+    -- EXISTING set's rec marker governs the merged result and the new
+    -- set's marker is DISCARDED (upstream's own comment documents the
+    -- discard).  The merged binding list is re-normalized so inner
+    -- duplicates are caught.
+    mergeAttrValues _ (EAttrs existingRec existingBindings _) (EAttrs _ newBindings _) =
+      (\merged -> EAttrs existingRec merged NoCaptureInfo)
+        <$> normalizeBindingList (existingBindings ++ newBindings)
+    mergeAttrValues key _ _ = Left (duplicateAttr key)
+
+    renderEntry (StaticEntry key value) = NamedBinding [StaticKey key] value
+    renderEntry (InheritEntry b) = b
+    renderEntry (DynamicEntry b) = b
+
+    duplicateAttr key = "attribute '" <> key <> "' already defined"
+
+-- | Hoist a nested attrpath under its first key: @a.b.c = v@ becomes
+-- @a = { b = { c = v; }; }@, one literal per level.
+canonicalBinding :: Binding -> Binding
+canonicalBinding (NamedBinding (firstKey : rest@(_ : _)) value) =
+  NamedBinding [firstKey] (EAttrs False [canonicalBinding (NamedBinding rest value)] NoCaptureInfo)
+canonicalBinding b = b
 
 parseNamedBinding :: Parser Binding
 parseNamedBinding = do
@@ -561,8 +657,12 @@ parseAttrKey = do
     -- Keywords are valid as attribute names in Nix:
     -- { if = 1; }, a.then, { else = 2; }, etc.
     _ | Just name <- keywordToText tok -> advance >> pure (StaticKey name)
-    TokStringOpen ->
-      DynamicKey <$> parseString
+    TokStringOpen -> do
+      strExpr <- parseString
+      -- A string key with no interpolation is static, as in upstream Nix's
+      -- parser (the string becomes a symbol at parse time) - which is also
+      -- what makes @let "x" = 1; in x@ legal.
+      pure (maybe (DynamicKey strExpr) StaticKey (literalStringKey strExpr))
     TokInterpOpen -> do
       _ <- advance
       expr <- parseExpr
@@ -571,6 +671,16 @@ parseAttrKey = do
       expect TokRBrace
       pure (DynamicKey expr)
     _ -> parseError ("expected attribute key, got " <> showToken tok)
+
+-- | The literal text of a string expression that contains no interpolation.
+-- Escape handling can split a literal into several 'StrLit' chunks, so the
+-- parts are concatenated; any 'StrInterp' makes the key dynamic.
+literalStringKey :: Expr -> Maybe Text
+literalStringKey (EStr parts) = mconcat <$> traverse literalPart parts
+  where
+    literalPart (StrLit t) = Just t
+    literalPart (StrInterp _) = Nothing
+literalStringKey _ = Nothing
 
 -- | Convert keyword tokens to their text for use as attribute names.
 -- All Nix keywords are valid as attr keys in binding and select position.
@@ -597,7 +707,7 @@ parseLet = do
   (\body -> ELet bindings body NoCaptureInfo) <$> parseExpr
 
 parseLetBindings :: Parser [Binding]
-parseLetBindings = go []
+parseLetBindings = go [] >>= normalizeBindings
   where
     go acc = do
       tok <- peek
@@ -608,7 +718,13 @@ parseLetBindings = go []
           go (binding : acc)
         _ -> do
           binding <- parseNamedBinding
-          go (binding : acc)
+          -- Upstream rejects a dynamic TOP-LEVEL key in a let at parse time;
+          -- nested dynamic keys (let a.${k} = 1) live in a nested attrset
+          -- and are fine.
+          case binding of
+            NamedBinding (DynamicKey _ : _) _ ->
+              parseError "dynamic attributes not allowed in let"
+            _ -> go (binding : acc)
 
 parseIf :: Parser Expr
 parseIf = do

--- a/src/Nix/Parser/Lexer.hs
+++ b/src/Nix/Parser/Lexer.hs
@@ -107,13 +107,21 @@ data LexMode
   deriving (Eq, Show)
 
 -- | Internal lexer state.
+--
+-- @lsBraceDepth@ counts unmatched @{@ in the CURRENT normal-mode context;
+-- a @}@ at depth 0 closes the current interpolation.  Entering @${@ from a
+-- string pushes the enclosing context's count onto @lsBraceStack@ and
+-- starts a fresh count; the matching interpolation close pops it back.
+-- Without the stack, a nested interpolated string inside braces zeroes the
+-- enclosing count and the outer attrset's @}@ mislexes as TokInterpClose.
 data LexState = LexState
   { lsInput :: !Text,
     lsFile :: !Text,
     lsLine :: !Int,
     lsCol :: !Int,
     lsModes :: ![LexMode],
-    lsBraceDepth :: !Int
+    lsBraceDepth :: !Int,
+    lsBraceStack :: ![Int]
   }
 
 -- ---------------------------------------------------------------------------
@@ -130,7 +138,8 @@ tokenize fileName source =
             lsLine = 1,
             lsCol = 1,
             lsModes = [ModeNormal],
-            lsBraceDepth = 0
+            lsBraceDepth = 0,
+            lsBraceStack = []
           }
    in lexLoop initialState []
 
@@ -169,12 +178,11 @@ lexNormalMode st acc = case T.uncons (lsInput st) of
         Just '.' <- safeHead (T.drop 1 rest) ->
           emit3 st TokEllipsis acc
     '.'
-      | Just '/' <- safeHead rest ->
-          lexPath st acc
-      | Just '.' <- safeHead rest,
-        Just c2 <- safeHead (T.drop 1 rest),
-        c2 == '/' ->
-          lexPath st acc
+      -- Maximal munch, as upstream's PATH regex: a dot-led path-char run
+      -- containing a /-segment is ONE path token (./x, ../x, .github/x,
+      -- even .5/x) - the path reading beats the float and TokDot readings.
+      -- A dot-run with no slash falls through: .5 is a float, x.y selects.
+      | looksLikePath (lsInput st) -> lexPath st acc
       | Just d <- safeHead rest,
         isDigit d ->
           lexLeadingDotFloat st acc
@@ -194,12 +202,24 @@ lexNormalMode st acc = case T.uncons (lsInput st) of
        in lexNormalMode newSt (tok : acc)
     '}' ->
       case lsModes st of
-        -- closing an interpolation: pop back to string/indstring mode
+        -- closing an interpolation: pop back to string/indstring mode and
+        -- restore the enclosing normal-mode context's brace count.
         (ModeNormal : outerMode : restModes)
           | lsBraceDepth st == 0,
             outerMode == ModeString || outerMode == ModeIndString ->
               let tok = Located (lsLine st) (lsCol st) TokInterpClose
-                  newSt = advanceCol 1 st {lsInput = rest, lsModes = outerMode : restModes}
+                  (restoredDepth, restoredStack) = case lsBraceStack st of
+                    (saved : outerSaved) -> (saved, outerSaved)
+                    [] -> (0, [])
+                  newSt =
+                    advanceCol
+                      1
+                      st
+                        { lsInput = rest,
+                          lsModes = outerMode : restModes,
+                          lsBraceDepth = restoredDepth,
+                          lsBraceStack = restoredStack
+                        }
                in lexLoop newSt (tok : acc)
         _ ->
           let depth = lsBraceDepth st
@@ -287,7 +307,11 @@ lexStringMode st acc = case T.uncons (lsInput st) of
                   st
                     { lsInput = T.drop 1 rest,
                       lsModes = ModeNormal : lsModes st,
-                      lsBraceDepth = 0
+                      -- Fresh count for the interpolation body; the
+                      -- enclosing context's count is restored at the
+                      -- matching TokInterpClose.
+                      lsBraceDepth = 0,
+                      lsBraceStack = lsBraceDepth st : lsBraceStack st
                     }
            in lexLoop newSt (tok : acc)
     _ -> lexStringLiteral st acc
@@ -362,7 +386,10 @@ lexIndStringMode st acc
                           st
                             { lsInput = rest2,
                               lsModes = ModeNormal : lsModes st,
-                              lsBraceDepth = 0
+                              -- Fresh count; enclosing context restored at
+                              -- the matching TokInterpClose.
+                              lsBraceDepth = 0,
+                              lsBraceStack = lsBraceDepth st : lsBraceStack st
                             }
                    in lexLoop newSt (tok : acc)
             _ -> lexIndStringLiteral st acc
@@ -413,6 +440,17 @@ lexStringLiteral st0 acc = go st0 mempty
         '\n' ->
           let newSt = st {lsInput = rest, lsLine = lsLine st + 1, lsCol = 1}
            in go newSt (builder <> TB.singleton '\n')
+        -- Raw CR and CRLF normalize to LF, matching upstream unescapeStr
+        -- (lexer.l).  Only double-quoted strings do this: indented-string
+        -- chunks bypass unescapeStr upstream and keep CR verbatim.  An
+        -- ESCAPED CR (backslash before it) stays literal via the escape
+        -- branch above, also matching upstream.
+        '\r' ->
+          let afterEol = case T.uncons rest of
+                Just ('\n', afterCrlf) -> afterCrlf
+                _ -> rest
+              newSt = st {lsInput = afterEol, lsLine = lsLine st + 1, lsCol = 1}
+           in go newSt (builder <> TB.singleton '\n')
         _ ->
           let newSt = advanceCol 1 st {lsInput = rest}
            in go newSt (builder <> TB.singleton c)
@@ -429,6 +467,11 @@ lexStringLiteral st0 acc = go st0 mempty
 -- No escape sequences here (those are handled by 'lexIndStringMode'),
 -- so the chunk is identical to the source text - count chars, then slice
 -- once at the end.  This avoids O(n^2) 'T.snoc' allocation.
+--
+-- Raw CR\/CRLF is deliberately NOT normalized here: upstream's indented
+-- string chunks bypass unescapeStr (lexer.l), and stripIndentation treats
+-- CR as ordinary content, so only double-quoted strings normalize line
+-- endings.
 lexIndStringLiteral :: LexState -> [Located] -> Either ParseError [Located]
 lexIndStringLiteral st0 acc = go st0 0
   where
@@ -581,21 +624,38 @@ zeroOrd = fromEnum '0'
 
 lexIdentOrKeyword :: LexState -> [Located] -> Either ParseError [Located]
 lexIdentOrKeyword st acc =
-  let (ident, after) = T.span isIdentChar (lsInput st)
-      len = T.length ident
-   in -- Check for URI: identifier followed by ://
-      case T.stripPrefix "://" after of
-        Just afterScheme ->
-          let (uriRest, afterUri) = T.span isUriChar afterScheme
-              full = ident <> "://" <> uriRest
-              fullLen = T.length full
-              tok = Located (lsLine st) (lsCol st) (TokUri full)
-              newSt = advanceCol fullLen st {lsInput = afterUri}
-           in lexNormalMode newSt (tok : acc)
-        Nothing ->
+  let input = lsInput st
+      (ident, after) = T.span isIdentChar input
+   in case uriSpan input of
+        -- Flex maximal munch: the URI rule beats identifiers AND keywords
+        -- whenever it matches more characters, so @x:y@ is the URI "x:y"
+        -- (the classic reason the identity function must be written
+        -- @x: x@) and @mailto:a\@b.com@ needs no @//@.
+        Just (uri, afterUri)
+          | T.length uri > T.length ident ->
+              let tok = Located (lsLine st) (lsCol st) (TokUri uri)
+                  newSt = advanceCol (T.length uri) st {lsInput = afterUri}
+               in lexNormalMode newSt (tok : acc)
+        _ ->
           let tok = Located (lsLine st) (lsCol st) (identToToken ident)
-              newSt = advanceCol len st {lsInput = after}
+              newSt = advanceCol (T.length ident) st {lsInput = after}
            in lexNormalMode newSt (tok : acc)
+
+-- | Match upstream's URI token at the start of the input:
+-- @[a-zA-Z][a-zA-Z0-9+.-]*:[uri-char]+@ (lexer.l).  The scheme starts
+-- with a letter (never @_@), and one URI char after the colon suffices -
+-- scheme-only URIs like @mailto:x@ count.  Returns the URI text and the
+-- remaining input.
+uriSpan :: Text -> Maybe (Text, Text)
+uriSpan input = case T.uncons input of
+  Just (schemeStart, _)
+    | isAlpha schemeStart,
+      (scheme, afterScheme) <- T.span isSchemeChar input,
+      Just afterColon <- T.stripPrefix ":" afterScheme,
+      (body, afterUri) <- T.span isUriChar afterColon,
+      not (T.null body) ->
+        Just (scheme <> ":" <> body, afterUri)
+  _ -> Nothing
 
 identToToken :: Text -> Token
 identToToken "if" = TokIf
@@ -701,8 +761,16 @@ looksLikePath input =
 isSearchPathChar :: Char -> Bool
 isSearchPathChar c = isAlphaNum c || c `elem` ("/.~_-+" :: [Char])
 
+-- | Chars allowed in a URI scheme after the leading letter, per upstream
+-- lexer.l: @[a-zA-Z][a-zA-Z0-9+.-]*@.
+isSchemeChar :: Char -> Bool
+isSchemeChar c = isAlphaNum c || c `elem` ("+.-" :: [Char])
+
+-- | Chars allowed after the scheme colon, exactly upstream lexer.l's URI
+-- class @[a-zA-Z0-9%\/?:\@&=+$,-_.!~*']@.  Notably @#@ is NOT a URI char
+-- (it starts a comment mid-URI upstream), while @*@ and @'@ are.
 isUriChar :: Char -> Bool
-isUriChar c = isAlphaNum c || c `elem` ("%/?:@&=+$,#._~!-" :: [Char])
+isUriChar c = isAlphaNum c || c `elem` ("%/?:@&=+$,-_.!~*'" :: [Char])
 
 -- ---------------------------------------------------------------------------
 -- Emit helpers

--- a/src/Nix/Push.hs
+++ b/src/Nix/Push.hs
@@ -45,6 +45,7 @@ module Nix.Push
     narFileName,
     stripHashPrefix,
     storePathBasename,
+    checkRecordedNarHash,
   )
 where
 
@@ -280,21 +281,8 @@ uploadNar manager cfg store sp = do
   let narBytes = NAR.serialise narEntry
       narHash = Hash.formatNixHash (Hash.hashBytes narBytes)
       narSize = BS.length narBytes
-  -- The database recorded this path's NAR hash at registration; a mismatch
-  -- now means the path changed on disk - refuse to publish corruption.
   recorded <- liftIO (queryPathInfo (stDB store) sp)
-  case recorded of
-    Just info
-      | DB.piNarHash info /= narHash ->
-          throwError
-            ( "store integrity: "
-                <> storePathBasename sp
-                <> " hashes to "
-                <> narHash
-                <> " but the DB recorded "
-                <> DB.piNarHash info
-            )
-    _ -> pure ()
+  liftEither (checkRecordedNarHash recorded narHash sp)
   refTexts <- liftIO (queryReferences (stDB store) sp)
   refs <- liftEither (traverse (parseRefText store) refTexts)
   deriverText <- liftIO (queryDeriver (stDB store) sp)
@@ -311,6 +299,32 @@ uploadNar manager cfg store sp = do
   response <- httpRequest manager "PUT" url (authHeaders cfg) (Just narBytes)
   expectOk ("PUT " <> niUrl narInfo) response
   pure narInfo
+
+-- | Pre-upload integrity gate.  The store DB recorded the path's NAR hash
+-- at registration; a mismatch now means the path changed on disk - refuse
+-- to publish corruption.  An on-disk path with NO registration (an
+-- interrupted build) is refused too: its references are unknown, so
+-- publishing would fabricate an empty-reference narinfo and serve a
+-- closure with holes.
+checkRecordedNarHash :: Maybe DB.PathInfo -> Text -> StorePath -> Either Text ()
+checkRecordedNarHash recorded narHash sp = case recorded of
+  Nothing ->
+    Left
+      ( "store integrity: "
+          <> storePathBasename sp
+          <> " is on disk but not registered as valid; refusing to publish it with unknown references"
+      )
+  Just info
+    | DB.piNarHash info /= narHash ->
+        Left
+          ( "store integrity: "
+              <> storePathBasename sp
+              <> " hashes to "
+              <> narHash
+              <> " but the DB recorded "
+              <> DB.piNarHash info
+          )
+    | otherwise -> Right ()
 
 -- | Upload a rendered narinfo (the server validates and signs it).
 uploadNarInfo :: HTTP.Manager -> PushConfig -> StorePath -> NarInfo -> ExceptT Text IO ()

--- a/src/Nix/Store.hs
+++ b/src/Nix/Store.hs
@@ -63,7 +63,6 @@ import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
-import qualified Data.Text.IO as TIO
 import Nix.Derivation (Derivation, toATerm)
 import Nix.Store.DB
 import Nix.Store.Path
@@ -259,11 +258,14 @@ collectRegularFiles path = do
           isFile <- doesFileExist fullPath
           pure [fullPath | isFile]
 
--- | Strict left fold over a list in IO.
+-- | Strict left fold over a list in IO.  The accumulator is forced to
+-- WHNF each step - without it, the scan retains every scanned file's
+-- bytes in Set.union thunks until the end (peak memory ~ total tree
+-- size).  Set's spine-strict nodes make WHNF force the whole union.
 foldlIO :: a -> [b] -> (a -> b -> IO a) -> IO a
 foldlIO z [] _ = pure z
 foldlIO z (x : xs) f = do
-  acc <- f z x
+  !acc <- f z x
   foldlIO acc xs f
 
 -- | Recursively mark a store path and its contents read-only after a build.
@@ -296,7 +298,10 @@ writeDrvAterm :: Store -> StorePath -> Text -> IO ()
 writeDrvAterm store sp aterm = do
   let destPath = storePathToFilePath (stDir store) sp
   createDirectoryIfMissing True (unStoreDir (stDir store))
-  TIO.writeFile destPath aterm
+  -- UTF-8 bytes, not text-mode IO: the path was computed from the
+  -- UTF-8 serialization, and a locale-dependent or newline-translating
+  -- write would store bytes that no longer match their content address.
+  BS.writeFile destPath (TE.encodeUtf8 aterm)
 
 -- | Serialize a derivation to ATerm and write it to the store at the given path.
 writeDrv :: Store -> Derivation -> StorePath -> IO ()

--- a/src/Nix/Substituter.hs
+++ b/src/Nix/Substituter.hs
@@ -41,19 +41,22 @@ module Nix.Substituter
 
     -- * Pure helpers (exported for testing)
     sortCaches,
+    tryCachesWith,
     verifySigs,
     verifyNarHash,
     narInfoMatchesPath,
     decompressNar,
     unpackNarEntry,
+    clearStaleDestination,
     parseReferences,
     parseDeriver,
   )
 where
 
+import Control.Applicative ((<|>))
 import Control.Concurrent (threadDelay)
 import Control.Exception (SomeException, try)
-import Control.Monad (when)
+import Control.Monad (filterM, when)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LBS
 import Data.List (sortBy)
@@ -115,23 +118,33 @@ data SubstResult
 
 -- | Try to substitute a store path from configured caches.
 --
--- Checks each cache in priority order.  Returns on first success.
--- Uses nova-cache library for narinfo parsing, NAR unpacking,
--- and signature verification.
+-- Checks each cache in priority order.  Returns on first success; a
+-- failing cache falls through to the remaining ones.  Uses nova-cache
+-- library for narinfo parsing, NAR unpacking, and signature verification.
 trySubstitute :: Store -> [CacheConfig] -> StorePath -> IO SubstResult
 trySubstitute _ [] _ = pure SubstNotFound
 trySubstitute store caches sp = do
   -- Reuse the process-global TLS manager (connection pooling / keep-alive)
   -- rather than creating a fresh one per call and per output.
   manager <- HTTPS.getGlobalManager
-  tryCaches manager (sortCaches caches) sp
+  tryCachesWith (\cache -> tryOneCache manager store cache sp) (sortCaches caches)
+
+-- | Fold per-cache attempts in priority order.  The first success wins and
+-- stops the scan.  An erroring cache falls through to the remaining ones -
+-- a transient failure (DNS, TLS, HTTP 500, unsupported compression) from a
+-- higher-priority cache must not mask a hit in the next - and the first
+-- error, tagged with its cache URL, is reported only when no cache has the
+-- path.
+tryCachesWith :: (Monad m) => (CacheConfig -> m SubstResult) -> [CacheConfig] -> m SubstResult
+tryCachesWith attempt = go Nothing
   where
-    tryCaches _ [] _ = pure SubstNotFound
-    tryCaches mgr (cache : rest) storePath = do
-      result <- tryOneCache mgr store cache storePath
+    go firstErr [] = pure (maybe SubstNotFound SubstError firstErr)
+    go firstErr (cache : rest) = do
+      result <- attempt cache
       case result of
-        SubstNotFound -> tryCaches mgr rest storePath
-        other -> pure other
+        SubstSuccess found -> pure (SubstSuccess found)
+        SubstNotFound -> go firstErr rest
+        SubstError err -> go (firstErr <|> Just (ccUrl cache <> ": " <> err)) rest
 
 -- | Attempt substitution from a single cache, catching all exceptions.
 tryOneCache :: HTTP.Manager -> Store -> CacheConfig -> StorePath -> IO SubstResult
@@ -205,7 +218,9 @@ unpackAndRegister store sp narInfo rawNar =
       Left err -> pure (SubstError ("NAR deserialisation failed: " <> T.pack err))
       Right narEntry -> do
         let destPath = storePathToFilePath (stDir store) sp
-        unpackResult <- try (unpackNarEntry destPath narEntry)
+        unpackResult <- try $ do
+          clearStaleDestination destPath
+          unpackNarEntry destPath narEntry
         case (unpackResult :: Either SomeException (Either Text ())) of
           Left err -> pure (SubstError ("unpack failed: " <> T.pack (show err)))
           Right (Left err) -> pure (SubstError ("unpack failed: " <> err))
@@ -403,44 +418,119 @@ parseDeriver storeDir (Just txt)
 -- NAR unpacking
 -- ---------------------------------------------------------------------------
 
+-- | Remove a leftover destination tree before unpacking.  A crash (or a
+-- failed registration) between 'setReadOnly' and 'registerPath' leaves a
+-- read-only, unregistered tree; unpacking over it would then fail with
+-- permission-denied on every retry, permanently wedging substitution of
+-- that path.  'Dir.removePathForcibly' clears read-only marks and accepts
+-- a missing path, so the fresh unpack always starts from a clean slate.
+clearStaleDestination :: FilePath -> IO ()
+clearStaleDestination = Dir.removePathForcibly
+
 -- | Unpack a NarEntry tree to a filesystem destination.  Returns @Left@ on an
 -- unsafe entry name (path traversal); these come from untrusted cache data, so
 -- a typed failure is used instead of a partial 'error'.
+--
+-- Regular files and directories are written in one pass; symlinks are
+-- created in a second pass, after their targets are materialized.  Windows
+-- symlinks are typed (file vs directory) and the NAR format does not record
+-- the target's kind, so the only reliable way to pick the flavor is to look
+-- at the target on disk - which may sort after the link within the tree.
 unpackNarEntry :: FilePath -> NAR.NarEntry -> IO (Either Text ())
-unpackNarEntry path entry = case entry of
+unpackNarEntry path entry = do
+  walked <- unpackTree path entry
+  case walked of
+    Left err -> pure (Left err)
+    Right links -> createSymlinks links
+
+-- | First unpack pass: write regular files and directories, recording
+-- symlinks as (link path, target) for the second pass.
+unpackTree :: FilePath -> NAR.NarEntry -> IO (Either Text [(FilePath, Text)])
+unpackTree path entry = case entry of
   NAR.NarRegular isExec contents -> do
     createDirectoryIfMissing True (takeDirectory path)
     BS.writeFile path contents
     when isExec $ do
       perms <- Dir.getPermissions path
       setPermissions path (Dir.setOwnerExecutable True perms)
-    pure (Right ())
-  NAR.NarSymlink target -> do
-    createDirectoryIfMissing True (takeDirectory path)
-    -- On Windows, symlinks require elevated permissions.
-    -- Fall back to writing the target as a text file.
-    result <- try (Dir.createFileLink (T.unpack target) path)
-    case result of
-      Right () -> pure (Right ())
-      Left (_ :: SomeException) -> do
-        writeFile path (T.unpack target)
-        pure (Right ())
+    pure (Right [])
+  NAR.NarSymlink target -> pure (Right [(path, target)])
   NAR.NarDirectory entries -> do
     createDirectoryIfMissing True path
     unpackChildren path entries
 
 -- | Unpack directory children, short-circuiting with a typed failure on the
 -- first unsafe entry name rather than crashing on untrusted input.
-unpackChildren :: FilePath -> [(Text, NAR.NarEntry)] -> IO (Either Text ())
-unpackChildren _ [] = pure (Right ())
+unpackChildren :: FilePath -> [(Text, NAR.NarEntry)] -> IO (Either Text [(FilePath, Text)])
+unpackChildren _ [] = pure (Right [])
 unpackChildren path ((name, child) : rest)
   | not (isSafeNarName name) =
       pure (Left ("unsafe NAR directory entry name: " <> name))
   | otherwise = do
-      result <- unpackNarEntry (path </> T.unpack name) child
+      result <- unpackTree (path </> T.unpack name) child
       case result of
         Left err -> pure (Left err)
-        Right () -> unpackChildren path rest
+        Right links -> do
+          restResult <- unpackChildren path rest
+          case restResult of
+            Left err -> pure (Left err)
+            Right moreLinks -> pure (Right (links <> moreLinks))
+
+-- | Second unpack pass: create the recorded symlinks.  Links whose targets
+-- already exist are created first - possibly unblocking link-to-link
+-- chains - so the Windows link flavor (file vs directory) is read off the
+-- real target.  When no pending link's target exists, the remainder are
+-- dangling and their kind is unknowable: they default to file links.
+createSymlinks :: [(FilePath, Text)] -> IO (Either Text ())
+createSymlinks [] = pure (Right ())
+createSymlinks pending = do
+  ready <- filterM targetExists pending
+  case ready of
+    [] -> createAll pending
+    _ -> do
+      made <- createAll ready
+      case made of
+        Left err -> pure (Left err)
+        Right () -> createSymlinks (filter (`notElem` ready) pending)
+  where
+    targetExists (linkPath, target) =
+      Dir.doesPathExist (takeDirectory linkPath </> T.unpack target)
+    createAll [] = pure (Right ())
+    createAll (link : rest) = do
+      made <- uncurry createSymlink link
+      case made of
+        Left err -> pure (Left err)
+        Right () -> createAll rest
+
+-- | Create one symlink, choosing the Windows flavor from the target's kind.
+-- A creation failure is loud: the old fallback of writing the target text
+-- as a regular file registered a tree whose NAR hash differed from the
+-- signed narinfo's - silent store corruption that a later push refuses to
+-- publish.  Failing lets the caller fall back to a local build.
+createSymlink :: FilePath -> Text -> IO (Either Text ())
+createSymlink linkPath target = do
+  createDirectoryIfMissing True (takeDirectory linkPath)
+  let targetStr = T.unpack target
+  targetIsDir <- Dir.doesDirectoryExist (takeDirectory linkPath </> targetStr)
+  result <-
+    try $
+      if targetIsDir
+        then Dir.createDirectoryLink targetStr linkPath
+        else Dir.createFileLink targetStr linkPath
+  case result of
+    Right () -> pure (Right ())
+    Left (e :: SomeException) ->
+      pure
+        ( Left
+            ( "cannot create symlink "
+                <> T.pack linkPath
+                <> " -> "
+                <> target
+                <> ": "
+                <> T.pack (show e)
+                <> " (on Windows this needs Developer Mode or elevation)"
+            )
+        )
 
 -- | Validate that a NAR entry name is safe (no path traversal).
 isSafeNarName :: Text -> Bool

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,15 +1,18 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 module Main (main) where
 
 import qualified Codec.Archive.Tar as Tar
 import qualified Codec.Archive.Tar.Entry as TarEntry
 import qualified Codec.Compression.Zstd.Lazy as ZstdL
-import Control.Exception (bracket_)
+import Control.Exception (SomeException, bracket_, try)
 import Control.Monad (filterM, void, when)
+import Data.Bits (shiftR, (.&.))
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BL
+import Data.IORef (atomicModifyIORef', newIORef, readIORef)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe, isJust)
 import qualified Data.Set as Set
@@ -19,7 +22,7 @@ import qualified Data.Text.Encoding as TE
 import qualified Data.Text.IO as TIO
 import Foreign.Ptr (castPtr)
 import Foreign.StablePtr (StablePtr, castPtrToStablePtr, castStablePtrToPtr, deRefStablePtr, freeStablePtr, newStablePtr)
-import Nix.Builder (BuildConfig (..), BuildResult (..), buildDerivation, buildWithDeps, defaultBuildConfig)
+import Nix.Builder (BuildConfig (..), BuildResult (..), buildDerivation, buildWithDeps, defaultBuildConfig, verifyFetchHash)
 import Nix.Builder.Unpack (builtinUnpackBuilder, entryComponents, envSrcs, resolveLinkTarget)
 import Nix.Builtins (builtinEnv, parseNixPath)
 import qualified Nix.DependencyGraph as DepGraph
@@ -34,17 +37,21 @@ import qualified Nix.Eval.Context as Context
 import Nix.Eval.IO (EvalState (..), newEvalState, runEvalIO)
 import Nix.Eval.Symbol (Symbol (..), symbolCount, symbolIntern, symbolLen, symbolText)
 import Nix.Eval.Types (emptyCList)
+import Nix.Expr.Resolve (staticGlobalNames)
 import Nix.Expr.Types
 import qualified Nix.Hash as Hash
 import Nix.Parser (parseNix)
 import Nix.Parser.Lexer (Located (..), Token (..), tokenize)
-import Nix.Push (computeClosure, mkNarInfo, narFileName, planMissing, storePathBasename, stripHashPrefix)
-import Nix.Store (Store (..), addToStore, closeStore, isValid, openStore, pathExists, scanReferences, setReadOnly, writeDrv)
+import Nix.Push (checkRecordedNarHash, computeClosure, loadApiKeyFile, mkNarInfo, narFileName, planMissing, storePathBasename, stripHashPrefix)
+import Nix.Store (Store (..), addToStore, closeStore, isValid, openStore, pathExists, scanReferences, scanTempReferences, setReadOnly, writeDrv)
 import Nix.Store.DB (PathInfo (..), PathRegistration (..), closeStoreDB, isValidPath, openStoreDB, queryDeriver, queryPathInfo, queryReferences, registerPath, registerPaths)
 import Nix.Store.Path (StoreDir (..), StorePath (..), defaultStoreDir, parseStorePath, platformStoreDirText, storePathToFilePath, storePathToText, windowsStoreDir)
 import qualified Nix.Substituter as Subst
+import qualified NovaCache.Base64 as B64
 import qualified NovaCache.Hash as CHash
+import qualified NovaCache.NAR as NAR
 import qualified NovaCache.NarInfo as NarInfo
+import qualified NovaCache.Signing as Signing
 import System.Directory (createDirectoryIfMissing, doesDirectoryExist, getPermissions, getTemporaryDirectory, removeDirectoryRecursive, writable)
 import qualified System.Directory as Dir
 import System.Exit (ExitCode (..), exitFailure, exitSuccess)
@@ -69,10 +76,15 @@ runTest name result = case result of
     pure False
 
 -- | Like 'runTest' but for tests that need IO to produce their result.
+-- An exception escaping the action becomes one FAIL line instead of
+-- aborting the whole suite (which would skip every later group and its
+-- cleanup).
 runTestM :: Text -> IO TestResult -> IO Bool
 runTestM name action = do
-  result <- action
-  runTest name result
+  outcome <- try action
+  runTest name $ case outcome of
+    Left (e :: SomeException) -> Fail ("uncaught exception: " <> T.pack (show e))
+    Right result -> result
 
 assertEqual :: (Eq a, Show a) => Text -> a -> a -> TestResult
 assertEqual label expected actual
@@ -104,11 +116,16 @@ assertParse label source expected =
 tokenTypes :: [Located] -> [Token]
 tokenTypes = filter (/= TokEOF) . map locToken
 
--- | Helper: parse Nix source and evaluate with builtinEnv.
+-- | Helper: parse Nix source and evaluate with builtinEnv.  Parse errors
+-- are tagged so failure assertions can tell them apart from eval errors.
 evalNix :: Text -> Either Text NixValue
 evalNix source = case parseNix "<test>" source of
-  Left err -> Left (T.pack (show err))
+  Left err -> Left (parseErrorTag <> T.pack (show err))
   Right expr -> runPureEval (eval (builtinEnv 0 []) expr)
+
+-- | Prefix marking a parse (not eval) failure in 'evalNix' results.
+parseErrorTag :: Text
+parseErrorTag = "parse error: "
 
 -- | Assert that a Nix expression evaluates to the expected value.
 assertEval :: Text -> Text -> NixValue -> TestResult
@@ -116,10 +133,25 @@ assertEval label source expected =
   assertRight label (evalNix source) $ \actual ->
     assertEqual label expected actual
 
--- | Assert that a Nix expression fails to evaluate.
+-- | Assert that a Nix expression parses but fails to EVALUATE.  A parse
+-- failure fails the assertion: a test documenting a runtime error must
+-- not keep passing after a regression stops the construct from parsing.
 assertEvalFail :: Text -> Text -> TestResult
-assertEvalFail label source =
-  assertLeft label (evalNix source)
+assertEvalFail label source = case evalNix source of
+  Left err
+    | parseErrorTag `T.isPrefixOf` err ->
+        Fail (label <> ": expected an eval error but the source did not parse: " <> err)
+    | otherwise -> Pass
+  Right val -> Fail (label <> ": expected eval failure but got: " <> T.pack (show val))
+
+-- | Assert that a Nix expression fails at PARSE time.
+assertParseFail :: Text -> Text -> TestResult
+assertParseFail label source = case evalNix source of
+  Left err
+    | parseErrorTag `T.isPrefixOf` err -> Pass
+    | otherwise ->
+        Fail (label <> ": expected a parse error but evaluation failed instead: " <> err)
+  Right val -> Fail (label <> ": expected parse failure but got: " <> T.pack (show val))
 
 -- ---------------------------------------------------------------------------
 -- Shell discovery for builder tests
@@ -523,6 +555,31 @@ testEvalWith = do
           "let-shadows-with"
           "with { a = 1; }; let a = 2; in a"
           (VInt 2),
+      -- A fallback (nested-path) let/rec binding shadows with too: the
+      -- NameBarrier must not be upgraded to a with-variable.
+      runTest "barrier let shadows with" $
+        assertEval
+          "barrier-shadows-with"
+          "let a.b = 1; x = 42; in with { x = 99; }; x"
+          (VInt 42),
+      runTest "barrier rec binding shadows with" $
+        assertEval
+          "barrier-rec-shadows-with"
+          "with { q = 99; }; (rec { c.d = 1; q = 5; b = q; }).b"
+          (VInt 5),
+      -- Static globals bind at parse time; with never shadows them.
+      runTest "with cannot shadow global map" $
+        assertEval
+          "with-global-map"
+          "builtins.typeOf (with { map = 42; }; map)"
+          (mkStr "lambda"),
+      -- fetchurl is NOT an upstream global: the with-scope must win, or
+      -- nixpkgs-style 'with pkgs; fetchurl' would bind the builtin.
+      runTest "with shadows non-global fetchurl" $
+        assertEval
+          "with-fetchurl"
+          "with { fetchurl = 42; }; fetchurl"
+          (VInt 42),
       -- Builtin fallback: builtins still accessible inside with
       runTest "with builtin fallback" $
         assertEval
@@ -752,6 +809,14 @@ testLexer = do
       runTest "trailing-dot float lexes as one float token" $
         assertRight "lex trailing-dot" (tokenize "<test>" "12.") $ \toks ->
           assertEqual "tokens" [TokFloat 12.0] (tokenTypes toks),
+      -- Maximal munch: a dot-led run with a /-segment is one PATH token
+      -- (upstream's PATH regex), while a slashless dot-run is not.
+      runTest "dot-relative path lexes as one token" $
+        assertRight "lex dot-path" (tokenize "<test>" ".github/x") $ \toks ->
+          assertEqual "tokens" [TokPath ".github/x"] (tokenTypes toks),
+      runTest "leading-dot float still lexes as float" $
+        assertRight "lex dot-float" (tokenize "<test>" ".5") $ \toks ->
+          assertEqual "tokens" [TokFloat 0.5] (tokenTypes toks),
       runTest "trailing-dot float with exponent lexes as one float token" $
         assertRight "lex trailing-dot-exp" (tokenize "<test>" "12.e2") $ \toks ->
           assertEqual "tokens" [TokFloat 1200.0] (tokenTypes toks),
@@ -782,6 +847,48 @@ testLexer = do
       runTest "URI" $
         assertRight "lex uri" (tokenize "<test>" "https://example.com") $ \toks ->
           assertEqual "tokens" [TokUri "https://example.com"] (tokenTypes toks),
+      -- Upstream URI = [a-zA-Z][a-zA-Z0-9+.-]*:[uri-char]+ with flex
+      -- maximal munch: no // required, and the URI beats identifiers,
+      -- keywords, and the lambda colon when it matches more characters.
+      runTest "scheme-only URI x:y" $
+        assertRight "lex uri x:y" (tokenize "<test>" "x:y") $ \toks ->
+          assertEqual "tokens" [TokUri "x:y"] (tokenTypes toks),
+      runTest "scheme-only URI mailto" $
+        assertRight "lex uri mailto" (tokenize "<test>" "mailto:foo@example.com") $ \toks ->
+          assertEqual "tokens" [TokUri "mailto:foo@example.com"] (tokenTypes toks),
+      runTest "URI scheme allows + . -" $
+        assertRight "lex uri scheme" (tokenize "<test>" "a+b.c:d") $ \toks ->
+          assertEqual "tokens" [TokUri "a+b.c:d"] (tokenTypes toks),
+      runTest "URI beats keyword by maximal munch" $
+        assertRight "lex uri keyword" (tokenize "<test>" "then:x") $ \toks ->
+          assertEqual "tokens" [TokUri "then:x"] (tokenTypes toks),
+      runTest "hash is not a URI char (starts a comment)" $
+        assertRight "lex uri hash" (tokenize "<test>" "http://a#frag") $ \toks ->
+          assertEqual "tokens" [TokUri "http://a"] (tokenTypes toks),
+      runTest "apostrophe and star are URI chars" $
+        assertRight "lex uri quote star" (tokenize "<test>" "http://e.com/a'b*c") $ \toks ->
+          assertEqual "tokens" [TokUri "http://e.com/a'b*c"] (tokenTypes toks),
+      runTest "lambda colon needs the space" $
+        assertRight "lex lambda colon" (tokenize "<test>" "x: y") $ \toks ->
+          assertEqual "tokens" [TokIdent "x", TokColon, TokIdent "y"] (tokenTypes toks),
+      runTest "underscore cannot start a URI scheme" $
+        assertRight "lex underscore colon" (tokenize "<test>" "_a:b") $ \toks ->
+          assertEqual "tokens" [TokIdent "_a", TokColon, TokIdent "b"] (tokenTypes toks),
+      -- Raw CR/CRLF normalizes to LF in double-quoted strings (upstream
+      -- unescapeStr); an escaped CR survives; indented strings keep CR
+      -- verbatim because upstream's IND_STRING chunks skip unescapeStr.
+      runTest "CRLF in double-quoted string normalizes to LF" $
+        assertRight "lex crlf string" (tokenize "<test>" "\"a\r\nb\"") $ \toks ->
+          assertEqual "tokens" [TokStringOpen, TokStringLit "a\nb", TokStringClose] (tokenTypes toks),
+      runTest "lone CR in double-quoted string normalizes to LF" $
+        assertRight "lex cr string" (tokenize "<test>" "\"a\rb\"") $ \toks ->
+          assertEqual "tokens" [TokStringOpen, TokStringLit "a\nb", TokStringClose] (tokenTypes toks),
+      runTest "escaped CR stays a literal CR" $
+        assertRight "lex escaped cr" (tokenize "<test>" "\"a\\\rb\"") $ \toks ->
+          assertEqual "tokens" [TokStringOpen, TokStringLit "a\rb", TokStringClose] (tokenTypes toks),
+      runTest "indented string keeps CRLF verbatim" $
+        assertRight "lex ind crlf" (tokenize "<test>" "''a\r\nb''") $ \toks ->
+          assertEqual "tokens" [TokIndStringOpen, TokStringLit "a\r\nb", TokIndStringClose] (tokenTypes toks),
       runTest "multi-char operators" $
         assertRight "lex ops" (tokenize "<test>" "++ // -> == != && || <= >=") $ \toks ->
           assertEqual
@@ -1130,12 +1237,24 @@ testParserIntegration = do
               NoCaptureInfo
           ),
       runTest "nested attr set" $
+        -- Normalization hoists a nested attrpath into nested literal sets
+        -- (upstream parser.y addAttr), so a.b.c = 1 parses like
+        -- a = { b = { c = 1; }; }.
         assertParse
           "nested attrs"
           "{ a.b.c = 1; d = { e = 2; }; }"
           ( EAttrs
               False
-              [ NamedBinding [StaticKey "a", StaticKey "b", StaticKey "c"] (ELit (NixInt 1)),
+              [ NamedBinding
+                  [StaticKey "a"]
+                  ( EAttrs
+                      False
+                      [ NamedBinding
+                          [StaticKey "b"]
+                          (EAttrs False [NamedBinding [StaticKey "c"] (ELit (NixInt 1))] NoCaptureInfo)
+                      ]
+                      NoCaptureInfo
+                  ),
                 NamedBinding [StaticKey "d"] (EAttrs False [NamedBinding [StaticKey "e"] (ELit (NixInt 2))] NoCaptureInfo)
               ]
               NoCaptureInfo
@@ -1453,9 +1572,16 @@ testBatch6 = do
         assertEval "tryEval-throw" "(builtins.tryEval (builtins.throw \"boom\")).success" (VBool False),
       runTest "tryEval failure value" $
         assertEval "tryEval-fval" "(builtins.tryEval (builtins.throw \"boom\")).value" (VBool False),
-      -- tryEval catches coercion error (+ on attrset without outPath)
-      runTest "tryEval catches coercion error" $
-        assertEval "tryEval-tyerr" "(builtins.tryEval ({} + [])).success" (VBool False),
+      -- tryEval catches ONLY throw/assert (upstream ThrownError/
+      -- AssertionError); type errors and missing attrs escape it.
+      runTest "tryEval catches failed assert" $
+        assertEval "tryEval-assert" "(builtins.tryEval (assert false; 1)).success" (VBool False),
+      runTest "tryEval does not catch a type error" $
+        assertEvalFail "tryEval-tyerr" "(builtins.tryEval ({} + [])).success",
+      runTest "tryEval does not catch a missing attribute" $
+        assertEvalFail "tryEval-noattr" "(builtins.tryEval ({ a = 1; }.b)).success",
+      runTest "tryEval catches a throw nested under forcing" $
+        assertEval "tryEval-deep-throw" "(builtins.tryEval (builtins.deepSeq [ (builtins.throw \"x\") ] 1)).success" (VBool False),
       -- deepSeq
       runTest "deepSeq returns second" $
         assertEval "deepSeq" "builtins.deepSeq [ 1 2 3 ] 42" (VInt 42),
@@ -1561,6 +1687,68 @@ testBlackholeRecoveryIO = do
         "genuine infinite recursion still escapes tryEval"
         "."
         "builtins.tryEval (let y = y; in y)"
+    ]
+
+-- | builtins.path/filterSource with a filter: the tree is serialized with
+-- rejected entries removed (a rejected directory prunes its subtree),
+-- content-addressed over the FILTERED NAR, and materialized to the store.
+testPathFilterIO :: IO [Bool]
+testPathFilterIO = do
+  putStrLn "eval/path-filter-io"
+  tmpBase <- getTemporaryDirectory
+  let srcDir = tmpBase </> "nova-nix-test-path-filter"
+  removeIfExists srcDir
+  createDirectoryIfMissing True (srcDir </> "sub")
+  createDirectoryIfMissing True (srcDir </> "dropdir")
+  BS.writeFile (srcDir </> "keep.txt") "keep"
+  BS.writeFile (srcDir </> "drop.log") "drop"
+  BS.writeFile (srcDir </> "sub" </> "inner.txt") "inner"
+  BS.writeFile (srcDir </> "dropdir" </> "x.txt") "gone"
+  let quoted = nixQuotedPath srcDir
+      filterExpr = "(p: t: builtins.match \".*[.]log\" p == null && baseNameOf p != \"dropdir\")"
+      filteredPath = "(builtins.path { path = " <> quoted <> "; name = \"src\"; filter = " <> filterExpr <> "; })"
+      unfilteredPath = "(builtins.path { path = " <> quoted <> "; name = \"src\"; })"
+  sequence
+    [ runTestIO
+        "kept file survives with its content"
+        "."
+        ("builtins.readFile (" <> filteredPath <> " + \"/keep.txt\")")
+        (mkStr "keep"),
+      runTestIO
+        "kept subtree survives"
+        "."
+        ("builtins.readFile (" <> filteredPath <> " + \"/sub/inner.txt\")")
+        (mkStr "inner"),
+      runTestIO
+        "rejected file is dropped"
+        "."
+        ("builtins.pathExists (" <> filteredPath <> " + \"/drop.log\")")
+        (VBool False),
+      runTestIO
+        "rejected directory prunes its subtree"
+        "."
+        ("builtins.pathExists (" <> filteredPath <> " + \"/dropdir\")")
+        (VBool False),
+      runTestIO
+        "filtered and unfiltered store paths differ"
+        "."
+        (filteredPath <> " == " <> unfilteredPath)
+        (VBool False),
+      runTestIO
+        "same filter yields the same store path"
+        "."
+        (filteredPath <> " == " <> filteredPath)
+        (VBool True),
+      runTestIO
+        "filterSource is path-with-filter under the source basename"
+        "."
+        ( "builtins.filterSource (p: t: true) "
+            <> quoted
+            <> " == builtins.path { path = "
+            <> quoted
+            <> "; filter = (p: t: true); }"
+        )
+        (VBool True)
     ]
 
 testImportIO :: IO [Bool]
@@ -2314,12 +2502,15 @@ testDepGraph = do
       -- buildDepGraph with mock for cycle detection
       -- (Cycle detection happens at topoSort level, not buildDepGraph)
       runTest "cycle detection" $ case DepGraph.buildDepGraph readCycle drvACycle spA of
-        Right graph ->
-          -- Graph builds but topo should detect the cycle or return partial
-          case DepGraph.topoSort graph of
-            DepGraph.TopoSorted _ -> Pass -- Kahn's returns what it can
-            DepGraph.TopoCycle _ -> Pass
-        Left _ -> Pass -- Also acceptable if buildDepGraph fails
+        Right graph -> case DepGraph.topoSort graph of
+          DepGraph.TopoCycle _ -> Pass
+          -- A "sorted" cyclic graph means Kahn's silently dropped the
+          -- cycle: buildWithDeps would then loop or build with unbuilt
+          -- inputs.
+          DepGraph.TopoSorted order ->
+            Fail ("cyclic graph topo-sorted as " <> T.pack (show (length order)) <> " nodes")
+        -- A loud rejection at graph-build time also counts as detection.
+        Left _ -> Pass
     ]
 
 -- ---------------------------------------------------------------------------
@@ -2427,9 +2618,125 @@ testSubstituter = do
       runTest "narInfoMatchesPath rejects mismatched identity" $
         if Subst.narInfoMatchesPath (StorePath (T.replicate 32 "b") "hello") (sampleNarInfo sampleNarHash)
           then Fail "expected identity mismatch"
-          else Pass
+          else Pass,
+      -- tryCachesWith: the first success stops the scan (later caches
+      -- are never contacted)
+      runTestM "tryCachesWith success stops scan" $ do
+        calls <- newIORef (0 :: Int)
+        let hit = StorePath (T.replicate 32 "d") "hit"
+            attempt cache = do
+              atomicModifyIORef' calls (\n -> (n + 1, ()))
+              pure $
+                if Subst.ccUrl cache == "https://b"
+                  then Subst.SubstSuccess hit
+                  else Subst.SubstNotFound
+        result <- Subst.tryCachesWith attempt [chainCache "https://a", chainCache "https://b", chainCache "https://c"]
+        made <- readIORef calls
+        pure $
+          if result == Subst.SubstSuccess hit && made == 2
+            then Pass
+            else Fail ("got " <> T.pack (show result) <> " after " <> T.pack (show made) <> " attempts"),
+      -- tryCachesWith: an erroring cache falls through to a later hit
+      -- instead of aborting the chain
+      runTestM "tryCachesWith error falls through to next cache" $ do
+        let hit = StorePath (T.replicate 32 "e") "hit"
+            attempt cache
+              | Subst.ccUrl cache == "https://a" = pure (Subst.SubstError "transient 500")
+              | otherwise = pure (Subst.SubstSuccess hit)
+        result <- Subst.tryCachesWith attempt [chainCache "https://a", chainCache "https://b"]
+        pure (assertEqual "fallthrough" (Subst.SubstSuccess hit) result),
+      -- tryCachesWith: all misses stay SubstNotFound
+      runTestM "tryCachesWith all misses" $ do
+        result <- Subst.tryCachesWith (\_ -> pure Subst.SubstNotFound) [chainCache "https://a", chainCache "https://b"]
+        pure (assertEqual "misses" Subst.SubstNotFound result),
+      -- tryCachesWith: with no hit anywhere, the FIRST error is reported,
+      -- tagged with the URL of the cache that produced it
+      runTestM "tryCachesWith reports first error tagged with cache" $ do
+        let attempt cache
+              | Subst.ccUrl cache == "https://a" = pure Subst.SubstNotFound
+              | Subst.ccUrl cache == "https://b" = pure (Subst.SubstError "first")
+              | otherwise = pure (Subst.SubstError "second")
+        result <- Subst.tryCachesWith attempt [chainCache "https://a", chainCache "https://b", chainCache "https://c"]
+        pure $ case result of
+          Subst.SubstError err
+            | "https://b" `T.isPrefixOf` err && "first" `T.isSuffixOf` err -> Pass
+          other -> Fail ("expected tagged first error, got " <> T.pack (show other)),
+      -- clearStaleDestination: removes a read-only leftover tree (the
+      -- crash-between-unpack-and-register wedge)
+      runTestM "clearStaleDestination removes read-only leftovers" $ do
+        tmpBase <- getTemporaryDirectory
+        let staleRoot = tmpBase </> "nova-nix-test-stale-dest"
+            staleFile = staleRoot </> "bin" </> "tool"
+        createDirectoryIfMissing True (staleRoot </> "bin")
+        writeFile staleFile "leftover"
+        perms <- getPermissions staleFile
+        Dir.setPermissions staleFile (Dir.setOwnerWritable False perms)
+        Subst.clearStaleDestination staleRoot
+        gone <- Dir.doesPathExist staleRoot
+        pure (if gone then Fail "stale tree survived" else Pass),
+      -- clearStaleDestination: a missing destination is a no-op
+      runTestM "clearStaleDestination missing path no-op" $ do
+        tmpBase <- getTemporaryDirectory
+        outcome <- try (Subst.clearStaleDestination (tmpBase </> "nova-nix-test-no-such-dir"))
+        pure $ case (outcome :: Either SomeException ()) of
+          Right () -> Pass
+          Left e -> Fail ("threw: " <> T.pack (show e)),
+      -- unpackNarEntry: traversal-shaped entry names from an untrusted
+      -- cache are rejected before anything is written
+      runTestM "unpackNarEntry rejects unsafe entry names" $ do
+        tmpBase <- getTemporaryDirectory
+        let dest = tmpBase </> "nova-nix-test-unpack-unsafe"
+            evil name = NAR.NarDirectory [(name, NAR.NarRegular False "x")]
+        results <- mapM (Subst.unpackNarEntry dest . evil) ["..", ".", "", "a/b", "a\\b"]
+        Subst.clearStaleDestination dest
+        pure $
+          if all (\case Left _ -> True; Right () -> False) results
+            then Pass
+            else Fail ("accepted an unsafe name: " <> T.pack (show results)),
+      -- unpackNarEntry: a NAR symlink materializes as a REAL link or fails
+      -- loudly - never as a regular file holding the target text, which
+      -- would silently diverge from the signed NAR hash
+      runTestM "unpackNarEntry symlink is real or loud" $ do
+        tmpBase <- getTemporaryDirectory
+        let dest = tmpBase </> "nova-nix-test-unpack-symlink"
+            tree =
+              NAR.NarDirectory
+                [ ("real", NAR.NarRegular False "contents"),
+                  ("link", NAR.NarSymlink "real")
+                ]
+        Subst.clearStaleDestination dest
+        result <- Subst.unpackNarEntry dest tree
+        outcome <- case result of
+          Right () -> do
+            isLink <- Dir.pathIsSymbolicLink (dest </> "link")
+            pure (if isLink then Pass else Fail "symlink materialized as a non-link")
+          Left _ -> do
+            leftBehind <- Dir.doesFileExist (dest </> "link")
+            pure (if leftBehind then Fail "failed loudly but left a regular file behind" else Pass)
+        Subst.clearStaleDestination dest
+        pure outcome,
+      -- unpackNarEntry: a directory-target symlink that sorts BEFORE its
+      -- target still gets the directory link flavor (second-pass typing)
+      runTestM "unpackNarEntry types forward dir symlink" $ do
+        tmpBase <- getTemporaryDirectory
+        let dest = tmpBase </> "nova-nix-test-unpack-dirlink"
+            tree =
+              NAR.NarDirectory
+                [ ("alink", NAR.NarSymlink "zdir"),
+                  ("zdir", NAR.NarDirectory [("f", NAR.NarRegular False "x")])
+                ]
+        Subst.clearStaleDestination dest
+        result <- Subst.unpackNarEntry dest tree
+        outcome <- case result of
+          Left _ -> pure Pass -- symlinks unavailable here; the loud failure is the contract
+          Right () -> do
+            throughLink <- doesDirectoryExist (dest </> "alink")
+            pure (if throughLink then Pass else Fail "dir symlink not traversable (wrong flavor)")
+        Subst.clearStaleDestination dest
+        pure outcome
     ]
   where
+    chainCache url = Subst.CacheConfig url "unused-key" 10
     sampleNarBytes = "nova-nix nar sample bytes" :: BS.ByteString
     sampleNarHash = CHash.formatNixHash (CHash.hashBytes sampleNarBytes)
     wrongNarHash = CHash.formatNixHash (CHash.hashBytes ("different bytes" :: BS.ByteString))
@@ -2495,9 +2802,13 @@ testBuildOrchestrator = do
         result <- buildWithDeps config store drv drvSP
         closeStore store
         forceRemoveIfExists tmpStore
-        -- Builder will fail (nonexistent) but the graph should resolve correctly
+        -- Builder will fail (nonexistent) but the graph should resolve
+        -- correctly: the failure must come from SPAWNING THE BUILDER, not
+        -- from graph resolution or drv reading upstream of it.
         pure $ case result of
-          BuildFailure _ _ -> Pass
+          BuildFailure msg _
+            | "nonexistent-builder" `T.isInfixOf` msg -> Pass
+            | otherwise -> Fail ("failed before reaching the builder: " <> msg)
           BuildSuccess _ -> Fail "expected build failure for nonexistent builder",
       -- buildWithDeps with cycle detection (mocked through malformed graph)
       runTest "cycle detection returns failure" $
@@ -2725,7 +3036,14 @@ testParseStorePath = do
         assertEqual
           "windows"
           (Just (StorePath "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" "pkg"))
-          (parseStorePath windowsStoreDir "C:\\nix\\store/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-pkg")
+          (parseStorePath windowsStoreDir "C:\\nix\\store/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-pkg"),
+      -- The backslash separator is the form storePathToFilePath actually
+      -- produces on Windows (what %out% and DB rows look like there).
+      runTest "parse windows store path with backslash separator" $
+        assertEqual
+          "windows-backslash"
+          (Just (StorePath "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" "pkg"))
+          (parseStorePath windowsStoreDir "C:\\nix\\store\\bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-pkg")
     ]
 
 -- ---------------------------------------------------------------------------
@@ -2775,8 +3093,35 @@ testPushPure = do
       runTest "storePathBasename joins hash and name" $
         assertEqual "basename" (hashA <> "-hello-1.0") (storePathBasename spA),
       runTest "narFileName appends .nar" $
-        assertEqual "file" "0123abcdef.nar" (narFileName narHash)
+        assertEqual "file" "0123abcdef.nar" (narFileName narHash),
+      -- checkRecordedNarHash: the pre-upload integrity gate
+      runTest "push gate accepts a registered matching path" $
+        assertEqual
+          "gate ok"
+          (Right ())
+          (checkRecordedNarHash (Just (pathInfoFor narHash)) narHash spA),
+      runTest "push gate refuses an unregistered path" $
+        case checkRecordedNarHash Nothing narHash spA of
+          Left err
+            | "not registered" `T.isInfixOf` err -> Pass
+            | otherwise -> Fail ("wrong error: " <> err)
+          Right () -> Fail "unregistered path must not be publishable",
+      runTest "push gate refuses a changed-on-disk path" $
+        case checkRecordedNarHash (Just (pathInfoFor "sha256:other")) narHash spA of
+          Left err
+            | "DB recorded" `T.isInfixOf` err -> Pass
+            | otherwise -> Fail ("wrong error: " <> err)
+          Right () -> Fail "hash mismatch must not be publishable"
     ]
+  where
+    pathInfoFor recordedHash =
+      PathInfo
+        { piPath = "/nix/store/" <> T.replicate 32 "a" <> "-hello-1.0",
+          piNarHash = recordedHash,
+          piNarSize = 1234,
+          piDeriver = Nothing,
+          piRegTime = 0
+        }
 
 -- | Closure computation against a real (temp) store database.
 testPushClosureIO :: IO [Bool]
@@ -2806,7 +3151,32 @@ testPushClosureIO = do
               (Set.fromList (map spHash closure)),
         runTest "closure deduplicates across roots" $
           assertRight "fromBoth" fromBoth $ \closure ->
-            assertEqual "count" (3 :: Int) (length closure)
+            assertEqual "count" (3 :: Int) (length closure),
+        -- loadApiKeyFile: keys copied through Windows editors arrive with
+        -- a BOM and CRLF; skipping the normalization turns every push
+        -- into an auth rejection with no visible cause.
+        runTestM "loadApiKeyFile strips BOM and CRLF" $ do
+          tmpBase <- getTemporaryDirectory
+          let keyFile = tmpBase </> "nova-nix-test-api-key"
+          BS.writeFile keyFile (BS.pack [0xEF, 0xBB, 0xBF] <> "the-secret-key\r\n")
+          loaded <- loadApiKeyFile keyFile
+          Dir.removeFile keyFile
+          pure (assertEqual "normalized key" (Right "the-secret-key") loaded),
+        runTestM "loadApiKeyFile rejects an effectively-empty key file" $ do
+          tmpBase <- getTemporaryDirectory
+          let keyFile = tmpBase </> "nova-nix-test-api-key-empty"
+          BS.writeFile keyFile (BS.pack [0xEF, 0xBB, 0xBF] <> "  \r\n")
+          loaded <- loadApiKeyFile keyFile
+          Dir.removeFile keyFile
+          pure $ case loaded of
+            Left err | "empty" `T.isInfixOf` err -> Pass
+            other -> Fail ("expected empty-key rejection, got: " <> T.pack (show other)),
+        runTestM "loadApiKeyFile reports a missing file" $ do
+          tmpBase <- getTemporaryDirectory
+          loaded <- loadApiKeyFile (tmpBase </> "nova-nix-test-no-such-key-file")
+          pure $ case loaded of
+            Left err | "cannot read key file" `T.isInfixOf` err -> Pass
+            other -> Fail ("expected read error, got: " <> T.pack (show other))
       ]
 
 -- | Helper: create a fresh temp store for IO tests.
@@ -3009,180 +3379,188 @@ tarSymLink p target =
 testUnpackBuildIO :: IO [Bool]
 testUnpackBuildIO = do
   putStrLn "builder/unpack-seed-archives"
-  withTempStore $ \store -> do
-    let storeDir = stDir store
-    tmpBase <- getTemporaryDirectory
-    let workDir = tmpBase </> "nova-nix-test-unpack-src"
-    forceRemoveIfExists workDir
-    createDirectoryIfMissing True workDir
-    let archiveTools = workDir </> "pkg-tools.tar.zst"
-        archiveData = workDir </> "pkg-data.tar.zst"
-        archiveCollide = workDir </> "pkg-collide.tar.zst"
-        archiveEscape = workDir </> "pkg-escape.tar.zst"
-        archiveRootFile = workDir </> "pkg-root-file.tar.zst"
-        archiveEscapeSymlink = workDir </> "pkg-escape-symlink.tar.zst"
-        archiveEscapeHardlink = workDir </> "pkg-escape-hardlink.tar.zst"
-    BL.writeFile archiveTools $
-      compressArchive
-        [ tarDir "pkg",
-          tarDir "pkg/bin",
-          tarExecFile "pkg/bin/tool.exe" "tool-payload",
-          tarHardLink "pkg/bin/tool-link.exe" "pkg/bin/tool.exe",
-          tarSymLink "pkg/bin/sh.exe" "tool.exe",
-          tarFile ".PKGINFO" "pkgname = tools"
-        ]
-    BL.writeFile archiveData $
-      compressArchive
-        [ tarDir "pkg",
-          tarDir "pkg/share",
-          tarFile "pkg/share/data.txt" "shared-data",
-          tarFile ".MTREE" "mtree-bytes"
-        ]
-    BL.writeFile archiveCollide $
-      compressArchive [tarFile "pkg/bin/tool.exe" "conflicting"]
-    BL.writeFile archiveEscape $
-      compressArchive [tarFile "../evil.txt" "escape"]
-    -- A leading '/' entry: rooted at the current drive.  tar stores paths with
-    -- '/', so this is the on-disk form even of a Windows-native "\..." name.
-    BL.writeFile archiveRootFile $
-      compressArchive [tarFile "/planted-abs.txt" "rooted-file"]
-    -- Escaping link targets: '..' climbs above the archive root.  Unlike a
-    -- rooted ('/') target, this builds portably - tar's toLinkTarget accepts a
-    -- relative path on every host - so the real unpacker is exercised end to end.
-    BL.writeFile archiveEscapeSymlink $
-      compressArchive [tarSymLink "sneaky-link.txt" "../escape-link-target.txt"]
-    BL.writeFile archiveEscapeHardlink $
-      compressArchive [tarHardLink "sneaky-hardlink.txt" "../escape-hardlink-target.txt"]
-    let mkUnpackDrv outP srcFiles =
-          Derivation
-            { drvOutputs =
-                [ DerivationOutput
-                    { doName = "out",
-                      doPath = outP,
-                      doHashAlgo = "",
-                      doHash = ""
-                    }
-                ],
-              drvInputDrvs = Map.empty,
-              drvInputSrcs = [],
-              drvPlatform = currentPlatform,
-              drvBuilder = builtinUnpackBuilder,
-              drvArgs = [],
-              drvEnv =
-                Map.fromList
-                  [(envSrcs, T.intercalate " " (map T.pack srcFiles))]
-            }
-        seedOut = StorePath (T.replicate 31 "0" <> "2") "unpack-seed"
-        collideOut = StorePath (T.replicate 31 "0" <> "3") "unpack-collide"
-        escapeOut = StorePath (T.replicate 31 "0" <> "4") "unpack-escape"
-        rootFileOut = StorePath (T.replicate 31 "0" <> "5") "unpack-root-file"
-        escapeSymlinkOut = StorePath (T.replicate 31 "0" <> "6") "unpack-escape-symlink"
-        escapeHardlinkOut = StorePath (T.replicate 31 "0" <> "7") "unpack-escape-hardlink"
-    buildTmp <- (</> "nova-nix-test-unpack-build-tmp") <$> getTemporaryDirectory
-    forceRemoveIfExists buildTmp
-    createDirectoryIfMissing True buildTmp
-    let config = (defaultBuildConfig storeDir) {bcTmpDir = buildTmp}
-    seedResult <- buildDerivation config store (mkUnpackDrv seedOut [archiveTools, archiveData])
-    collideResult <- buildDerivation config store (mkUnpackDrv collideOut [archiveTools, archiveCollide])
-    escapeResult <- buildDerivation config store (mkUnpackDrv escapeOut [archiveEscape])
-    rootFileResult <- buildDerivation config store (mkUnpackDrv rootFileOut [archiveRootFile])
-    escapeSymlinkResult <- buildDerivation config store (mkUnpackDrv escapeSymlinkOut [archiveEscapeSymlink])
-    escapeHardlinkResult <- buildDerivation config store (mkUnpackDrv escapeHardlinkOut [archiveEscapeHardlink])
-    forceRemoveIfExists buildTmp
-    forceRemoveIfExists workDir
-    seedChecks <- case seedResult of
-      BuildFailure msg code ->
-        sequence
-          [ runTest "unpack seed build succeeds" $
-              Fail ("build failed (exit " <> T.pack (show code) <> "): " <> msg)
+  tmpBase0 <- getTemporaryDirectory
+  if ' ' `elem` tmpBase0
+    then do
+      -- The srcs env is space-separated by the derivation contract (store
+      -- paths never contain spaces), but these test archives live under
+      -- TEMP: a spaced TEMP would fragment the paths and fail spuriously.
+      putStrLn "  SKIP  unpack archive tests need a space-free TEMP dir"
+      pure []
+    else withTempStore $ \store -> do
+      let storeDir = stDir store
+      tmpBase <- getTemporaryDirectory
+      let workDir = tmpBase </> "nova-nix-test-unpack-src"
+      forceRemoveIfExists workDir
+      createDirectoryIfMissing True workDir
+      let archiveTools = workDir </> "pkg-tools.tar.zst"
+          archiveData = workDir </> "pkg-data.tar.zst"
+          archiveCollide = workDir </> "pkg-collide.tar.zst"
+          archiveEscape = workDir </> "pkg-escape.tar.zst"
+          archiveRootFile = workDir </> "pkg-root-file.tar.zst"
+          archiveEscapeSymlink = workDir </> "pkg-escape-symlink.tar.zst"
+          archiveEscapeHardlink = workDir </> "pkg-escape-hardlink.tar.zst"
+      BL.writeFile archiveTools $
+        compressArchive
+          [ tarDir "pkg",
+            tarDir "pkg/bin",
+            tarExecFile "pkg/bin/tool.exe" "tool-payload",
+            tarHardLink "pkg/bin/tool-link.exe" "pkg/bin/tool.exe",
+            tarSymLink "pkg/bin/sh.exe" "tool.exe",
+            tarFile ".PKGINFO" "pkgname = tools"
           ]
-      BuildSuccess sp -> do
-        let outRoot = storePathToFilePath storeDir sp
-            readOut rel = do
-              let path = outRoot </> rel
-              exists <- Dir.doesFileExist path
-              if exists then Just <$> TIO.readFile path else pure Nothing
-        tool <- readOut ("pkg" </> "bin" </> "tool.exe")
-        toolLink <- readOut ("pkg" </> "bin" </> "tool-link.exe")
-        shLink <- readOut ("pkg" </> "bin" </> "sh.exe")
-        dataFile <- readOut ("pkg" </> "share" </> "data.txt")
-        pkgInfo <- Dir.doesFileExist (outRoot </> ".PKGINFO")
-        mtree <- Dir.doesFileExist (outRoot </> ".MTREE")
-        execBitOk <-
-          if SI.os == "mingw32"
-            then pure True -- NTFS has no exec bit; PATHEXT decides
-            else Dir.executable <$> getPermissions (outRoot </> "pkg" </> "bin" </> "tool.exe")
-        narInfo <- queryPathInfo (stDB store) sp
-        let realNarHash = case narInfo of
-              Just info ->
-                piNarSize info > 0 && T.isPrefixOf "sha256:" (piNarHash info)
-              Nothing -> False
-        sequence
-          [ runTest "unpack seed build succeeds" Pass,
-            runTest "unpack: file extracted with content" $
-              assertEqual "tool.exe" (Just "tool-payload") tool,
-            runTest "unpack: hardlink materialized as copy" $
-              assertEqual "tool-link.exe" (Just "tool-payload") toolLink,
-            runTest "unpack: relative symlink materialized as copy" $
-              assertEqual "sh.exe" (Just "tool-payload") shLink,
-            runTest "unpack: second archive merged into shared prefix" $
-              assertEqual "data.txt" (Just "shared-data") dataFile,
-            runTest "unpack: pacman metadata skipped" $
-              if pkgInfo || mtree
-                then Fail ".PKGINFO/.MTREE leaked into the output"
-                else Pass,
-            runTest "unpack: executable bit materialized (unix)" $
-              if execBitOk then Pass else Fail "tool.exe not executable",
-            runTest "unpack: real NAR hash registered" $
-              if realNarHash then Pass else Fail (T.pack (show narInfo))
+      BL.writeFile archiveData $
+        compressArchive
+          [ tarDir "pkg",
+            tarDir "pkg/share",
+            tarFile "pkg/share/data.txt" "shared-data",
+            tarFile ".MTREE" "mtree-bytes"
           ]
-    collideChecks <-
-      sequence
-        [ runTest "unpack: cross-archive file collision fails loudly" $
-            case collideResult of
-              BuildFailure msg _
-                | "file collision" `T.isInfixOf` msg -> Pass
-                | otherwise -> Fail ("wrong failure: " <> msg)
-              BuildSuccess _ -> Fail "collision build unexpectedly succeeded"
-        ]
-    escapeChecks <-
-      sequence
-        [ runTest "unpack: path traversal rejected" $
-            case escapeResult of
-              BuildFailure msg _
-                | "escapes archive root" `T.isInfixOf` msg -> Pass
-                | otherwise -> Fail ("wrong failure: " <> msg)
-              BuildSuccess _ -> Fail "escape build unexpectedly succeeded"
-        ]
-    let rejectedWith needle res = case res of
-          BuildFailure msg _
-            | needle `T.isInfixOf` msg -> Pass
-            | otherwise -> Fail ("wrong failure: " <> msg)
-          BuildSuccess _ -> Fail "malicious entry unexpectedly built"
-    -- Integration: the real unpacker rejects a rooted entry path and an
-    -- escaping ('..') symlink/hardlink target, end to end.
-    maliciousChecks <-
-      sequence
-        [ runTest "unpack: rooted file entry rejected" $
-            rejectedWith "planted-abs.txt" rootFileResult,
-          runTest "unpack: escaping symlink target rejected" $
-            rejectedWith "escape-link-target.txt" escapeSymlinkResult,
-          runTest "unpack: escaping hardlink target rejected" $
-            rejectedWith "escape-hardlink-target.txt" escapeHardlinkResult
-        ]
-    -- Unit: the rooted (drive-relative) case is the Blocker-4 Windows vuln.
-    -- tar's toLinkTarget refuses an absolute payload on POSIX, so exercise the
-    -- guard predicate directly - portable and exact on every host.
-    guardChecks <-
-      sequence
-        [ runTest "unpack guard: rooted entry path rejected" $
-            assertLeft "rooted entry" (entryComponents "/planted-abs.txt"),
-          runTest "unpack guard: rooted symlink target rejected" $
-            assertLeft "rooted symlink" (resolveLinkTarget [] "/planted-link-target.txt"),
-          runTest "unpack guard: rooted hardlink target rejected" $
-            assertLeft "rooted hardlink" (entryComponents "/planted-hardlink-target.txt")
-        ]
-    pure (seedChecks ++ collideChecks ++ escapeChecks ++ maliciousChecks ++ guardChecks)
+      BL.writeFile archiveCollide $
+        compressArchive [tarFile "pkg/bin/tool.exe" "conflicting"]
+      BL.writeFile archiveEscape $
+        compressArchive [tarFile "../evil.txt" "escape"]
+      -- A leading '/' entry: rooted at the current drive.  tar stores paths with
+      -- '/', so this is the on-disk form even of a Windows-native "\..." name.
+      BL.writeFile archiveRootFile $
+        compressArchive [tarFile "/planted-abs.txt" "rooted-file"]
+      -- Escaping link targets: '..' climbs above the archive root.  Unlike a
+      -- rooted ('/') target, this builds portably - tar's toLinkTarget accepts a
+      -- relative path on every host - so the real unpacker is exercised end to end.
+      BL.writeFile archiveEscapeSymlink $
+        compressArchive [tarSymLink "sneaky-link.txt" "../escape-link-target.txt"]
+      BL.writeFile archiveEscapeHardlink $
+        compressArchive [tarHardLink "sneaky-hardlink.txt" "../escape-hardlink-target.txt"]
+      let mkUnpackDrv outP srcFiles =
+            Derivation
+              { drvOutputs =
+                  [ DerivationOutput
+                      { doName = "out",
+                        doPath = outP,
+                        doHashAlgo = "",
+                        doHash = ""
+                      }
+                  ],
+                drvInputDrvs = Map.empty,
+                drvInputSrcs = [],
+                drvPlatform = currentPlatform,
+                drvBuilder = builtinUnpackBuilder,
+                drvArgs = [],
+                drvEnv =
+                  Map.fromList
+                    [(envSrcs, T.intercalate " " (map T.pack srcFiles))]
+              }
+          seedOut = StorePath (T.replicate 31 "0" <> "2") "unpack-seed"
+          collideOut = StorePath (T.replicate 31 "0" <> "3") "unpack-collide"
+          escapeOut = StorePath (T.replicate 31 "0" <> "4") "unpack-escape"
+          rootFileOut = StorePath (T.replicate 31 "0" <> "5") "unpack-root-file"
+          escapeSymlinkOut = StorePath (T.replicate 31 "0" <> "6") "unpack-escape-symlink"
+          escapeHardlinkOut = StorePath (T.replicate 31 "0" <> "7") "unpack-escape-hardlink"
+      buildTmp <- (</> "nova-nix-test-unpack-build-tmp") <$> getTemporaryDirectory
+      forceRemoveIfExists buildTmp
+      createDirectoryIfMissing True buildTmp
+      let config = (defaultBuildConfig storeDir) {bcTmpDir = buildTmp}
+      seedResult <- buildDerivation config store (mkUnpackDrv seedOut [archiveTools, archiveData])
+      collideResult <- buildDerivation config store (mkUnpackDrv collideOut [archiveTools, archiveCollide])
+      escapeResult <- buildDerivation config store (mkUnpackDrv escapeOut [archiveEscape])
+      rootFileResult <- buildDerivation config store (mkUnpackDrv rootFileOut [archiveRootFile])
+      escapeSymlinkResult <- buildDerivation config store (mkUnpackDrv escapeSymlinkOut [archiveEscapeSymlink])
+      escapeHardlinkResult <- buildDerivation config store (mkUnpackDrv escapeHardlinkOut [archiveEscapeHardlink])
+      forceRemoveIfExists buildTmp
+      forceRemoveIfExists workDir
+      seedChecks <- case seedResult of
+        BuildFailure msg code ->
+          sequence
+            [ runTest "unpack seed build succeeds" $
+                Fail ("build failed (exit " <> T.pack (show code) <> "): " <> msg)
+            ]
+        BuildSuccess sp -> do
+          let outRoot = storePathToFilePath storeDir sp
+              readOut rel = do
+                let path = outRoot </> rel
+                exists <- Dir.doesFileExist path
+                if exists then Just <$> TIO.readFile path else pure Nothing
+          tool <- readOut ("pkg" </> "bin" </> "tool.exe")
+          toolLink <- readOut ("pkg" </> "bin" </> "tool-link.exe")
+          shLink <- readOut ("pkg" </> "bin" </> "sh.exe")
+          dataFile <- readOut ("pkg" </> "share" </> "data.txt")
+          pkgInfo <- Dir.doesFileExist (outRoot </> ".PKGINFO")
+          mtree <- Dir.doesFileExist (outRoot </> ".MTREE")
+          execBitOk <-
+            if SI.os == "mingw32"
+              then pure True -- NTFS has no exec bit; PATHEXT decides
+              else Dir.executable <$> getPermissions (outRoot </> "pkg" </> "bin" </> "tool.exe")
+          narInfo <- queryPathInfo (stDB store) sp
+          let realNarHash = case narInfo of
+                Just info ->
+                  piNarSize info > 0 && T.isPrefixOf "sha256:" (piNarHash info)
+                Nothing -> False
+          sequence
+            [ runTest "unpack seed build succeeds" Pass,
+              runTest "unpack: file extracted with content" $
+                assertEqual "tool.exe" (Just "tool-payload") tool,
+              runTest "unpack: hardlink materialized as copy" $
+                assertEqual "tool-link.exe" (Just "tool-payload") toolLink,
+              runTest "unpack: relative symlink materialized as copy" $
+                assertEqual "sh.exe" (Just "tool-payload") shLink,
+              runTest "unpack: second archive merged into shared prefix" $
+                assertEqual "data.txt" (Just "shared-data") dataFile,
+              runTest "unpack: pacman metadata skipped" $
+                if pkgInfo || mtree
+                  then Fail ".PKGINFO/.MTREE leaked into the output"
+                  else Pass,
+              runTest "unpack: executable bit materialized (unix)" $
+                if execBitOk then Pass else Fail "tool.exe not executable",
+              runTest "unpack: real NAR hash registered" $
+                if realNarHash then Pass else Fail (T.pack (show narInfo))
+            ]
+      collideChecks <-
+        sequence
+          [ runTest "unpack: cross-archive file collision fails loudly" $
+              case collideResult of
+                BuildFailure msg _
+                  | "file collision" `T.isInfixOf` msg -> Pass
+                  | otherwise -> Fail ("wrong failure: " <> msg)
+                BuildSuccess _ -> Fail "collision build unexpectedly succeeded"
+          ]
+      escapeChecks <-
+        sequence
+          [ runTest "unpack: path traversal rejected" $
+              case escapeResult of
+                BuildFailure msg _
+                  | "escapes archive root" `T.isInfixOf` msg -> Pass
+                  | otherwise -> Fail ("wrong failure: " <> msg)
+                BuildSuccess _ -> Fail "escape build unexpectedly succeeded"
+          ]
+      let rejectedWith needle res = case res of
+            BuildFailure msg _
+              | needle `T.isInfixOf` msg -> Pass
+              | otherwise -> Fail ("wrong failure: " <> msg)
+            BuildSuccess _ -> Fail "malicious entry unexpectedly built"
+      -- Integration: the real unpacker rejects a rooted entry path and an
+      -- escaping ('..') symlink/hardlink target, end to end.
+      maliciousChecks <-
+        sequence
+          [ runTest "unpack: rooted file entry rejected" $
+              rejectedWith "planted-abs.txt" rootFileResult,
+            runTest "unpack: escaping symlink target rejected" $
+              rejectedWith "escape-link-target.txt" escapeSymlinkResult,
+            runTest "unpack: escaping hardlink target rejected" $
+              rejectedWith "escape-hardlink-target.txt" escapeHardlinkResult
+          ]
+      -- Unit: the rooted (drive-relative) case is the Blocker-4 Windows vuln.
+      -- tar's toLinkTarget refuses an absolute payload on POSIX, so exercise the
+      -- guard predicate directly - portable and exact on every host.
+      guardChecks <-
+        sequence
+          [ runTest "unpack guard: rooted entry path rejected" $
+              assertLeft "rooted entry" (entryComponents "/planted-abs.txt"),
+            runTest "unpack guard: rooted symlink target rejected" $
+              assertLeft "rooted symlink" (resolveLinkTarget [] "/planted-link-target.txt"),
+            runTest "unpack guard: rooted hardlink target rejected" $
+              assertLeft "rooted hardlink" (entryComponents "/planted-hardlink-target.txt")
+          ]
+      pure (seedChecks ++ collideChecks ++ escapeChecks ++ maliciousChecks ++ guardChecks)
 
 -- | Step 2 of the ladder: a dependency-aware build end-to-end.  A root
 -- derivation depends on a leaf; both @.drv@ files are pre-written to the store
@@ -3269,6 +3647,124 @@ testEvalFidelity = do
       -- builtins.split: a non-participating group is null too
       runTest "split null capture group" $
         assertEval "split-null" "builtins.isNull (builtins.elemAt (builtins.elemAt (builtins.split \"(a)|(b)\" \"a\") 1) 1)" (VBool True),
+      -- builtins.match is whole-string like regex_match: top-level
+      -- alternation must not decay into a prefix/suffix match.
+      runTest "match alternation is whole-string" $
+        assertEval "match-alt" "builtins.match \"a|b\" \"ab\"" VNull,
+      runTest "match alternation positive" $
+        assertEval "match-alt-pos" "builtins.match \"a|b\" \"a\" == [ ]" (VBool True),
+      -- No multiline mode: ^/$ anchor only at the string boundaries and
+      -- '.' matches a newline, as POSIX ERE whole-string matching does.
+      runTest "match does not anchor at inner newlines" $
+        assertEval "match-nl" "builtins.match \"foo\" \"bar\\nfoo\"" VNull,
+      runTest "match dot spans newline" $
+        assertEval "match-dot-nl" "builtins.match \"(.*)\" \"a\\nb\" == [ \"a\\nb\" ]" (VBool True),
+      runTest "split dot spans newline" $
+        assertEval "split-dot-nl" "builtins.split \"a.b\" \"xa\\nby\" == [ \"x\" [ ] \"y\" ]" (VBool True),
+      -- Derivations compare by outPath alone (C++ eqValues special case) -
+      -- even when the rest of the attrs (or the key sets) differ.
+      runTest "derivation eq by outPath" $
+        assertEval
+          "drv-eq"
+          "{ type = \"derivation\"; outPath = \"/nix/store/a\"; f = (x: x); } == { type = \"derivation\"; outPath = \"/nix/store/a\"; f = (y: y); extra = 1; }"
+          (VBool True),
+      runTest "derivation neq by outPath" $
+        assertEval
+          "drv-neq"
+          "{ type = \"derivation\"; outPath = \"/a\"; } == { type = \"derivation\"; outPath = \"/b\"; }"
+          (VBool False),
+      runTest "derivation-tagged sets without outPath deep-compare" $
+        assertEval
+          "drv-no-outpath"
+          "{ type = \"derivation\"; n = 1; } == { type = \"derivation\"; n = 1; }"
+          (VBool True),
+      -- A throwing derivation attr fails evaluation - never a silent drop
+      -- (a dropped attr once produced an empty no-input .drv that "built").
+      runTest "derivation attr throw propagates" $
+        assertEvalFail "drv-throw" "(derivation { name = \"x\"; system = \"s\"; builder = \"/b\"; src = throw \"boom\"; }).drvPath",
+      -- __ignoreNulls drops null attrs; without it null coerces to "".
+      runTest "derivation ignoreNulls drops null" $
+        assertEval "drv-ignore-nulls" "builtins.isString (derivation { name = \"x\"; system = \"s\"; builder = \"/b\"; src = null; __ignoreNulls = true; }).drvPath" (VBool True),
+      runTest "derivation null coerces without ignoreNulls" $
+        assertEval "drv-null-empty" "builtins.isString (derivation { name = \"x\"; system = \"s\"; builder = \"/b\"; foo = null; }).drvPath" (VBool True),
+      -- A literal string key is static, as in upstream's parser: legal in
+      -- let, referenceable as a rec sibling.
+      runTest "let with literal string key" $
+        assertEval "let-string-key" "let \"x\" = 1; in x" (VInt 1),
+      runTest "rec string key is a referenceable sibling" $
+        assertEval "rec-string-key" "(rec { \"a\" = 1; b = a; }).b" (VInt 1),
+      -- A dynamic TOP-LEVEL key in let is a parse error upstream; nested
+      -- dynamic keys live in a nested attrset and stay legal.
+      runTest "dynamic key in let rejected" $
+        assertParseFail "let-dyn-key" "let k = \"y\"; in let ${k} = 1; in y",
+      runTest "interpolated string key in let rejected" $
+        assertParseFail "let-interp-key" "let k = \"y\"; in let \"${k}\" = 1; in y",
+      runTest "nested dynamic key in let allowed" $
+        assertEval "let-nested-dyn" "let k = \"q\"; in let a.${k} = 1; in a.q" (VInt 1),
+      -- Nested interpolated strings inside braces: the lexer's brace-depth
+      -- stack must restore the enclosing count when an interpolation
+      -- closes, or the outer attrset's '}' mislexes as TokInterpClose.
+      runTest "nested interpolated string inside attrset braces" $
+        assertEval "nested-interp" "let y = \"v\"; in \"${ { a = \"${y}\"; }.a }\"" (mkStr "v"),
+      runTest "nested interpolation in indented string" $
+        assertEval "nested-interp-ind" "let y = \"w\"; in ''pre ${ { a = ''${y}''; }.a } post''" (mkStr "pre w post"),
+      runTest "doubly nested interpolated strings" $
+        assertEval "nested-interp-2" "let y = \"z\"; in \"${ { a = \"${ { b = \"${y}\"; }.b }\"; }.a }\"" (mkStr "z"),
+      -- Attrpath merging (upstream parser.y addAttr): a literal set and a
+      -- nested path under the same key merge; genuine duplicates error.
+      runTest "literal set merges with attrpath (kept attr)" $
+        assertEval "merge-keep" "{ a = { b = 1; }; a.c = 2; }.a.b" (VInt 1),
+      runTest "literal set merges with attrpath (added attr)" $
+        assertEval "merge-add" "{ a = { b = 1; }; a.c = 2; }.a.c" (VInt 2),
+      runTest "duplicate plain key is a parse error" $
+        assertParseFail "dup-key" "{ a = 1; a = 2; }",
+      runTest "duplicate inner key on merge is an error" $
+        assertParseFail "dup-inner" "{ a.b = 1; a = { b = 2; }; }",
+      runTest "inherit conflicting with a definition is an error" $
+        assertParseFail "dup-inherit" "let q = 1; in { inherit q; q = 2; }",
+      runTest "attrpath into a non-set is an error" $
+        assertParseFail "merge-non-set" "{ a = 1; a.b = 2; }",
+      -- rec markers in attrpath merging follow upstream's addAttr: the
+      -- existing set's marker governs the result; the new set's marker is
+      -- discarded.
+      runTest "merge into rec literal keeps rec (sibling visible)" $
+        assertEval "merge-rec-keep" "{ a = rec { b = 1; }; a.c = b; }.a.c" (VInt 1),
+      runTest "merged-in rec marker is discarded (outer binding wins)" $
+        assertEval "merge-rec-discard" "let d = 7; in { a = { x = 1; }; a = rec { c = d; }; }.a.c" (VInt 7),
+      -- Exactly upstream's unprefixed global surface: fetchurl and toFile
+      -- exist only under builtins.
+      runTest "bare fetchurl is not a global" $
+        assertEvalFail "no-bare-fetchurl" "fetchurl",
+      runTest "bare toFile is not a global" $
+        assertEvalFail "no-bare-tofile" "toFile",
+      -- Dynamic keys colliding with an existing attr are an eval error,
+      -- never a silent last-win merge.
+      runTest "dynamic key colliding with static errors" $
+        assertEvalFail "dyn-collide" "{ b = 1; ${\"b\"} = 2; }",
+      runTest "rec dynamic key colliding with static errors" $
+        assertEvalFail "dyn-collide-rec" "rec { b = 1; p.q = 1; ${\"b\"} = 2; }",
+      -- Higher-order list builtins pass elements as unforced thunks: an
+      -- element the function never inspects may throw without failing.
+      runTest "filter does not force elements" $
+        assertEval "filter-lazy" "builtins.length (builtins.filter (x: true) [ (builtins.throw \"never\") ])" (VInt 1),
+      runTest "any does not force undecided elements" $
+        assertEval "any-lazy" "builtins.any (x: x) [ true (builtins.throw \"never\") ]" (VBool True),
+      runTest "foldl' passes elements unforced" $
+        assertEval "foldl-lazy" "builtins.foldl' (a: b: a) 0 [ (builtins.throw \"never\") ]" (VInt 0),
+      -- Attrset equality stops at the first mismatch; later pairs are
+      -- never forced.
+      runTest "attrset eq short-circuits" $
+        assertEval "eq-short" "{ a = 1; b = builtins.throw \"never\"; } == { a = 2; b = builtins.throw \"never\"; }" (VBool False),
+      -- toString of a float is std::to_string's fixed 6 decimals; value
+      -- printing and toJSON keep the trimmed form.
+      runTest "toString float has fixed 6 decimals" $
+        assertEval "tostr-float" "builtins.toString 1.5" (mkStr "1.500000"),
+      runTest "toJSON float stays trimmed" $
+        assertEval "tojson-float" "builtins.toJSON 1.5" (mkStr "1.5"),
+      -- path + string-with-context is an error (a store-path reference
+      -- cannot survive inside a path value).
+      runTest "path plus string with context errors" $
+        assertEvalFail "path-ctx" "./x + (derivation { name = \"q\"; system = \"s\"; builder = \"/b\"; }).drvPath",
       -- builtins.toJSON honors __toString, preferring it over outPath
       runTest "toJSON __toString" $
         assertEval "tojson-tostr" "builtins.toJSON { __toString = self: \"x\"; }" (mkStr "\"x\""),
@@ -3295,7 +3791,7 @@ testEvalFidelity = do
         assertEvalFail "substr-neg" "builtins.substring (0 - 1) 3 \"hello\"",
       -- an integer literal that overflows Int64 is a parse error, not a wrap
       runTest "integer literal overflow errors" $
-        assertEvalFail "int-overflow" "99999999999999999999",
+        assertParseFail "int-overflow" "99999999999999999999",
       -- float exponents and leading-dot floats lex per the Nix grammar
       runTest "float exponent lexes as float" $
         assertEval "float-exp-type" "builtins.typeOf 6.022e23" (mkStr "float"),
@@ -3337,7 +3833,241 @@ testHashHelpers = do
           (Hash.hexToBytes "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
           (Hash.rawHashWithAlgo "sha256" BS.empty),
       runTest "rawHashWithAlgo unknown algo rejected" $
-        assertEqual "unknown" Nothing (Hash.rawHashWithAlgo "sha3-256" (BS.pack [1, 2, 3]))
+        assertEqual "unknown" Nothing (Hash.rawHashWithAlgo "sha3-256" (BS.pack [1, 2, 3])),
+      -- verifyFetchHash: the composed builtin:fetchurl integrity gate that
+      -- guards every fixed-output seed fetch
+      runTest "verifyFetchHash accepts a matching flat hash" $
+        assertEqual
+          "fetch-hash-ok"
+          (Right ())
+          (verifyFetchHash "https://x/f.tar.gz" (fetchOut "sha256" sha256Hello) "hello"),
+      runTest "verifyFetchHash rejects mismatched bytes" $
+        case verifyFetchHash "https://x/f.tar.gz" (fetchOut "sha256" sha256Hello) "world" of
+          Left (_, msg) | "hash mismatch" `T.isInfixOf` msg -> Pass
+          other -> Fail ("expected mismatch rejection, got: " <> T.pack (show other)),
+      runTest "verifyFetchHash rejects a malformed expected hash" $
+        case verifyFetchHash "https://x/f" (fetchOut "sha256" "zz-not-hex") "hello" of
+          Left (_, msg) | "malformed expected hash" `T.isInfixOf` msg -> Pass
+          other -> Fail ("expected malformed-hash rejection, got: " <> T.pack (show other)),
+      runTest "verifyFetchHash rejects an unsupported algorithm" $
+        case verifyFetchHash "https://x/f" (fetchOut "sha3-256" "00") "hello" of
+          Left (_, msg) | "unsupported hash algorithm" `T.isInfixOf` msg -> Pass
+          other -> Fail ("expected unsupported-algo rejection, got: " <> T.pack (show other)),
+      runTest "verifyFetchHash rejects recursive mode rather than comparing flat" $
+        case verifyFetchHash "https://x/f" (fetchOut "r:sha256" sha256Hello) "hello" of
+          Left (_, msg) | "recursive" `T.isInfixOf` msg -> Pass
+          other -> Fail ("expected recursive-mode rejection, got: " <> T.pack (show other))
+    ]
+  where
+    -- sha256 of the ASCII bytes "hello".
+    sha256Hello = "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+    fetchOut algo hash =
+      DerivationOutput
+        { doName = "out",
+          doPath = StorePath (T.replicate 32 "f") "fetched",
+          doHashAlgo = algo,
+          doHash = hash
+        }
+
+-- ---------------------------------------------------------------------------
+-- Tests: NAR and hash known-answer vectors
+-- ---------------------------------------------------------------------------
+
+-- | Encode one NAR string per the spec: little-endian u64 length, the
+-- bytes, zero-padding to the next 8-byte boundary.  Written here from the
+-- format definition, deliberately independent of nova-cache's encoder, so
+-- these vectors pin the wire layout rather than the library against
+-- itself.
+narSpecStr :: BS.ByteString -> BS.ByteString
+narSpecStr s = lenLE <> s <> padding
+  where
+    n = BS.length s
+    lenLE = BS.pack [fromIntegral ((n `shiftR` (8 * i)) .&. 0xff) | i <- [0 .. 7]]
+    padding = BS.replicate ((8 - n `mod` 8) `mod` 8) 0
+
+-- | Hand-encoded NAR of a directory holding an executable, a plain file,
+-- and a symlink - covering entry ordering, the executable marker, content
+-- padding, and all node kinds.
+narSpecVector :: BS.ByteString
+narSpecVector =
+  BS.concat $
+    map
+      narSpecStr
+      [ "nix-archive-1",
+        "(",
+        "type",
+        "directory",
+        "entry",
+        "(",
+        "name",
+        "bin",
+        "node",
+        "(",
+        "type",
+        "directory",
+        "entry",
+        "(",
+        "name",
+        "tool",
+        "node",
+        "(",
+        "type",
+        "regular",
+        "executable",
+        "",
+        "contents",
+        "#!x",
+        ")",
+        ")",
+        ")",
+        ")",
+        "entry",
+        "(",
+        "name",
+        "data.txt",
+        "node",
+        "(",
+        "type",
+        "regular",
+        "contents",
+        "hello\n",
+        ")",
+        ")",
+        "entry",
+        "(",
+        "name",
+        "link",
+        "node",
+        "(",
+        "type",
+        "symlink",
+        "target",
+        "data.txt",
+        ")",
+        ")",
+        ")"
+      ]
+
+-- | The in-memory tree 'narSpecVector' encodes.
+narSpecTree :: NAR.NarEntry
+narSpecTree =
+  NAR.NarDirectory
+    [ ("bin", NAR.NarDirectory [("tool", NAR.NarRegular True "#!x")]),
+      ("data.txt", NAR.NarRegular False "hello\n"),
+      ("link", NAR.NarSymlink "data.txt")
+    ]
+
+-- | Hand-encoded NAR of just @data.txt@, for the on-disk addToStore vector
+-- (no executable entry: Windows has no exec bit to round-trip from disk).
+narSpecFileVector :: BS.ByteString
+narSpecFileVector =
+  BS.concat $
+    map
+      narSpecStr
+      [ "nix-archive-1",
+        "(",
+        "type",
+        "directory",
+        "entry",
+        "(",
+        "name",
+        "data.txt",
+        "node",
+        "(",
+        "type",
+        "regular",
+        "contents",
+        "hello\n",
+        ")",
+        ")",
+        ")"
+      ]
+
+-- | fromTOML: multi-line values (the Cargo.lock shapes) and comment
+-- placement relative to strings.
+testFromTOML :: IO [Bool]
+testFromTOML = do
+  putStrLn "eval/fromTOML"
+  sequence
+    [ runTest "multi-line array" $
+        assertEval
+          "toml-ml-array"
+          "builtins.concatStringsSep \",\" (builtins.fromTOML \"deps = [\\n \\\"bar\\\",\\n \\\"baz\\\",\\n]\\n\").deps"
+          (mkStr "bar,baz"),
+      runTest "Cargo.lock package shape" $
+        assertEval
+          "toml-cargo-lock"
+          "(builtins.elemAt (builtins.fromTOML \"[[package]]\\nname = \\\"foo\\\"\\ndependencies = [\\n \\\"bar\\\",\\n]\\n\").package 0).name"
+          (mkStr "foo"),
+      runTest "multi-line basic string" $
+        assertEval
+          "toml-ml-string"
+          "(builtins.fromTOML \"s = \\\"\\\"\\\"\\nline1\\nline2\\\"\\\"\\\"\").s"
+          (mkStr "line1\nline2"),
+      runTest "multi-line literal string" $
+        assertEval
+          "toml-ml-literal"
+          "(builtins.fromTOML \"s = '''\\nkeep'''\").s"
+          (mkStr "keep"),
+      runTest "comment inside a multi-line array" $
+        assertEval
+          "toml-ml-comment"
+          "builtins.concatStringsSep \",\" (builtins.fromTOML \"deps = [ # opening\\n \\\"bar\\\", # trailing\\n]\").deps"
+          (mkStr "bar"),
+      runTest "hash inside a string is content" $
+        assertEval
+          "toml-hash-content"
+          "(builtins.fromTOML \"s = \\\"\\\"\\\"a#b\\\"\\\"\\\"\").s"
+          (mkStr "a#b"),
+      runTest "single-line values still parse" $
+        assertEval
+          "toml-single-line"
+          "(builtins.fromTOML \"x = 4\\ny = \\\"z\\\" # cmt\").y"
+          (mkStr "z")
+    ]
+
+testNarKnownAnswer :: IO [Bool]
+testNarKnownAnswer = do
+  putStrLn "nar/known-answer"
+  sequence
+    [ runTest "serialise matches the hand-written spec vector" $
+        if NAR.serialise narSpecTree == narSpecVector
+          then Pass
+          else Fail "NAR encoder no longer matches the spec byte layout",
+      runTest "deserialise reads the spec vector back" $
+        case NAR.deserialise narSpecVector of
+          Right entry
+            | NAR.serialise entry == narSpecVector -> Pass
+            | otherwise -> Fail "spec vector round-trips to different bytes"
+          Left err -> Fail ("spec vector rejected: " <> T.pack err),
+      -- The empty-input SHA-256 in nix-base32: pins digest, alphabet, and
+      -- bit order against the value real Nix computes.
+      runTest "sha256 empty formats to the known nix-base32 vector" $
+        assertEqual
+          "nix32-empty"
+          "sha256:0mdqa9w1p6cmli6976v4wi0sw9r4p5prkj7lzfd1877wk11c9c73"
+          (CHash.formatNixHash (CHash.hashBytes BS.empty)),
+      -- addToStore must record exactly the hash of the spec bytes for the
+      -- same tree, or interop with every real cache silently breaks.
+      runTestM "addToStore records the externally-computed NAR hash" $ do
+        tmpBase <- getTemporaryDirectory
+        let srcDir = tmpBase </> "nova-nix-test-nar-vector-src"
+            tmpStore = tmpBase </> "nova-nix-test-nar-vector-store"
+        forceRemoveIfExists srcDir
+        forceRemoveIfExists tmpStore
+        createDirectoryIfMissing True srcDir
+        createDirectoryIfMissing True tmpStore
+        BS.writeFile (srcDir </> "data.txt") "hello\n"
+        store <- openStore (StoreDir tmpStore)
+        let sp = StorePath (T.replicate 32 "e") "nar-vector"
+        addToStore store srcDir sp Nothing []
+        recorded <- queryPathInfo (stDB store) sp
+        closeStore store
+        forceRemoveIfExists tmpStore
+        let expected = CHash.formatNixHash (CHash.hashBytes narSpecFileVector)
+        pure $ case recorded of
+          Just info -> assertEqual "recorded NarHash" expected (piNarHash info)
+          Nothing -> Fail "path not registered"
     ]
 
 testStoreOps :: IO [Bool]
@@ -3402,6 +4132,31 @@ testStoreOps = do
           refs <- scanReferences [candidate] scanDir
           removeIfExists scanDir
           pure (assertEqual "no partial refs" [] refs),
+        -- scanTempReferences records the self/cross-output edges that the
+        -- store-prefix scan cannot see (outputs embedding their TEMP path)
+        runTestM "scanTempReferences finds temp-dir embedding" $ do
+          tmpBase <- getTemporaryDirectory
+          let scanDir = tmpBase </> "nova-nix-test-scan-temp"
+              fakeTempOut = tmpBase </> "nova-nix-build" </> "fake-out"
+          removeIfExists scanDir
+          createDirectoryIfMissing True scanDir
+          let selfSp = StorePath "cccccccccccccccccccccccccccccccc" "self"
+          BS.writeFile
+            (scanDir </> "wrapper.sh")
+            (TE.encodeUtf8 (T.pack ("exec " <> fakeTempOut <> "/bin/tool")))
+          found <- scanTempReferences [(fakeTempOut, selfSp)] scanDir
+          removeIfExists scanDir
+          pure (assertEqual "self-ref found" [selfSp] found),
+        runTestM "scanTempReferences negative" $ do
+          tmpBase <- getTemporaryDirectory
+          let scanDir = tmpBase </> "nova-nix-test-scan-temp-neg"
+          removeIfExists scanDir
+          createDirectoryIfMissing True scanDir
+          let selfSp = StorePath "cccccccccccccccccccccccccccccccc" "self"
+          BS.writeFile (scanDir </> "clean.txt") "no temp paths embedded here"
+          found <- scanTempReferences [(tmpBase </> "nova-nix-build" </> "fake-out", selfSp)] scanDir
+          removeIfExists scanDir
+          pure (assertEqual "no refs" [] found),
         -- addToStore moves dir + registers in DB
         runTestM "addToStore moves + registers" $ do
           tmpBase <- getTemporaryDirectory
@@ -4912,6 +5667,100 @@ testBytecodeCompile = do
     ]
 
 -- ---------------------------------------------------------------------------
+-- Tests: substituter signature verification (the --trusted-key trust gate)
+-- ---------------------------------------------------------------------------
+
+-- | Minimal narinfo for signing tests; the fingerprint covers StorePath,
+-- NarHash, NarSize, and References.
+sigTestNarInfo :: NarInfo.NarInfo
+sigTestNarInfo =
+  NarInfo.NarInfo
+    { NarInfo.niStorePath = "/nix/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-hello-1.0",
+      NarInfo.niUrl = "nar/aaaa.nar",
+      NarInfo.niCompression = "none",
+      NarInfo.niFileHash = "sha256:" <> T.replicate 52 "0",
+      NarInfo.niFileSize = 1,
+      NarInfo.niNarHash = "sha256:" <> T.replicate 52 "0",
+      NarInfo.niNarSize = 1,
+      NarInfo.niReferences = [],
+      NarInfo.niDeriver = Nothing,
+      NarInfo.niSigs = [],
+      NarInfo.niCA = Nothing
+    }
+
+-- | A substituter cache trusting the given public key text.
+sigTestCache :: Text -> Subst.CacheConfig
+sigTestCache publicKeyText =
+  Subst.CacheConfig
+    { Subst.ccUrl = "http://localhost/test-cache",
+      Subst.ccPublicKey = publicKeyText,
+      Subst.ccPriority = 40
+    }
+
+-- | Deterministic Ed25519 test keys: a nix secret key file is
+-- seed(32) + public(32), and both signing and public-key derivation use
+-- only the seed, so the public half can be zeros here.  Both keys carry
+-- the SAME name so the wrong-key test exercises the cryptographic
+-- verification, not just the name comparison.
+sigTestKeyText, sigTestWrongKeyText :: Text
+sigTestKeyText = "test-key-1:" <> B64.encode (BS.pack ([1 .. 32] ++ replicate 32 0))
+sigTestWrongKeyText = "test-key-1:" <> B64.encode (BS.pack ([101 .. 132] ++ replicate 32 0))
+
+-- | Derive (trusted cache, signature by the trusted key, signature by an
+-- impostor key with the same name).  Left on any setup failure.
+sigTestSetup :: Either String (Subst.CacheConfig, Text, Text)
+sigTestSetup = do
+  secretKey <- Signing.parseSecretKey sigTestKeyText
+  impostorKey <- Signing.parseSecretKey sigTestWrongKeyText
+  publicKey <- Signing.toPublicKey secretKey
+  let publicKeyText = Signing.renderPublicKey publicKey
+  validSig <- Signing.sign secretKey sigTestNarInfo
+  impostorSig <- Signing.sign impostorKey sigTestNarInfo
+  pure (sigTestCache publicKeyText, validSig, impostorSig)
+
+-- | verifySigs is the security boundary behind @--trusted-key@: unsigned
+-- narinfos, wrong-key signatures, and malformed trusted keys must all be
+-- rejected; a valid signature must be accepted.
+testVerifySigs :: IO [Bool]
+testVerifySigs = do
+  putStrLn "substituter/verify-sigs"
+  case sigTestSetup of
+    Left err -> (: []) <$> runTest "verifySigs test setup" (Fail (T.pack err))
+    Right (cache, validSig, impostorSig) ->
+      sequence
+        [ runTest "valid signature accepted" $
+            assertEqual "verify ok" (Right ()) (Subst.verifySigs cache sigTestNarInfo {NarInfo.niSigs = [validSig]}),
+          runTest "unsigned narinfo rejected" $
+            assertLeft "no sigs" (Subst.verifySigs cache sigTestNarInfo),
+          runTest "same-name signature from a different key rejected" $
+            assertLeft "impostor sig" (Subst.verifySigs cache sigTestNarInfo {NarInfo.niSigs = [impostorSig]}),
+          runTest "valid signature among invalid ones accepted" $
+            assertEqual "any valid" (Right ()) (Subst.verifySigs cache sigTestNarInfo {NarInfo.niSigs = [impostorSig, validSig]}),
+          runTest "signature under a different key name rejected" $
+            assertLeft "name mismatch" (Subst.verifySigs cache sigTestNarInfo {NarInfo.niSigs = ["other-key:" <> T.drop (T.length "test-key-1:") validSig]}),
+          runTest "malformed trusted public key rejected" $
+            assertLeft "bad pubkey" (Subst.verifySigs (sigTestCache "not-a-key") sigTestNarInfo {NarInfo.niSigs = [validSig]})
+        ]
+
+-- ---------------------------------------------------------------------------
+-- Tests: resolver static globals stay in sync with the root env
+-- ---------------------------------------------------------------------------
+
+-- | Every name the resolver treats as a static global must actually be
+-- bound in the root environment: 'Nix.Expr.Resolve.resolveVar' leaves such
+-- names as 'EVar' even under a @with@, so an unbound one would surface as
+-- an undefined variable.  Layering keeps Resolve from importing Builtins,
+-- so this test is the sync guarantee between the two lists.
+testStaticGlobalsSync :: IO [Bool]
+testStaticGlobalsSync = do
+  putStrLn "resolve/static-globals-sync"
+  mapM checkBound (Set.toList staticGlobalNames)
+  where
+    checkBound name =
+      runTest ("static global '" <> name <> "' is bound in the root env") $
+        assertEval ("global-" <> name) ("builtins.seq " <> name <> " true") (VBool True)
+
+-- ---------------------------------------------------------------------------
 -- Main
 -- ---------------------------------------------------------------------------
 
@@ -4932,6 +5781,7 @@ main = bracket_ arenaInit arenaDestroy $ do
           testDependentBuildIO,
           testEvalFidelity,
           testHashHelpers,
+          testNarKnownAnswer,
           testEvalLiterals,
           testEvalVariables,
           testEvalArithmetic,
@@ -4946,12 +5796,14 @@ main = bracket_ arenaInit arenaDestroy $ do
           testEvalLambda,
           testEvalWith,
           testEvalBuiltins,
+          testFromTOML,
           testEvalErrors,
           testEvalHigherOrder,
           testLexer,
           testParserExprs,
           testParserErrors,
           testParserIntegration,
+          testStaticGlobalsSync,
           testBatch1,
           testBatch2,
           testBatch3,
@@ -4962,6 +5814,7 @@ main = bracket_ arenaInit arenaDestroy $ do
           testImportPure,
           testImportIO,
           testBlackholeRecoveryIO,
+          testPathFilterIO,
           testBatchA,
           testBatchAIO,
           testBatchB,
@@ -4980,6 +5833,7 @@ main = bracket_ arenaInit arenaDestroy $ do
           testDrvContext,
           testDepGraph,
           testSubstituter,
+          testVerifySigs,
           testPushPure,
           testPushClosureIO,
           testBuildOrchestrator,

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1689,12 +1689,34 @@ testBlackholeRecoveryIO = do
         "builtins.tryEval (let y = y; in y)"
     ]
 
+-- | Whether this machine can materialize eval outputs at the platform
+-- store root (eval-time store writes resolve there by design).  Absent
+-- and uncreatable - macOS's sealed read-only /, a root-owned /nix on a
+-- Nix-installed Linux box - the store-writing eval tests skip loudly
+-- rather than fail on machines that cannot host a store.  Linux CI
+-- provisions /nix so coverage stays real there.
+storeRootAvailable :: IO Bool
+storeRootAvailable = do
+  outcome <- try (createDirectoryIfMissing True (T.unpack platformStoreDirText))
+  case outcome of
+    Left (_ :: SomeException) -> pure False
+    Right () -> writable <$> getPermissions (T.unpack platformStoreDirText)
+
 -- | builtins.path/filterSource with a filter: the tree is serialized with
 -- rejected entries removed (a rejected directory prunes its subtree),
 -- content-addressed over the FILTERED NAR, and materialized to the store.
 testPathFilterIO :: IO [Bool]
 testPathFilterIO = do
   putStrLn "eval/path-filter-io"
+  usableStore <- storeRootAvailable
+  if not usableStore
+    then do
+      putStrLn "  SKIP  platform store root unavailable; cannot materialize eval outputs here"
+      pure []
+    else testPathFilterBody
+
+testPathFilterBody :: IO [Bool]
+testPathFilterBody = do
   tmpBase <- getTemporaryDirectory
   let srcDir = tmpBase </> "nova-nix-test-path-filter"
   removeIfExists srcDir


### PR DESCRIPTION
Second batch of fixes from the July 2026 codebase audit (follows #15). Three commits: evaluator/lexer/C-layer correctness, store/push/substituter robustness, and test/CI/packaging hardening.

## Highlights

- `builtins.fetchTarball` verifies its sha256 pin (the recursive NAR hash of the extracted tree), honors `name`, and returns a store path; `builtins.path` is content-addressed with a verified pin and a working `filter`.
- `match`/`split` follow upstream's whole-string, single-line regex semantics; `tryEval` catches only throw/assert; equality short-circuits and compares derivations by outPath.
- `with` can no longer shadow lexical bindings from nested-path/dynamic-key blocks; duplicate attributes are parse-time errors, as upstream.
- Lexer: nested-interpolation brace stack, dot-led relative paths, CRLF normalization in double-quoted strings (indented strings keep CR, matching upstream), and exact upstream URI tokenization (scheme-only URIs, maximal munch, corrected charset).
- `fromTOML` parses multi-line arrays and strings (the Cargo.lock shapes) and places keys under `[[table]]` headers into the array's last element.
- Substituter: an erroring cache falls through to the next; stale read-only destinations are cleared before unpack; NAR symlinks are real typed links or a loud failure (two-pass creation types Windows links off materialized targets).
- Push refuses on-disk-but-unregistered paths instead of publishing fabricated empty-reference narinfos; `push --all --store DIR` works on non-default stores.
- `collectDrvEnv` propagates coercion errors instead of silently dropping derivation attributes; store writes are byte-faithful UTF-8.
- C layer: overflow-safe env page-fit check, NULL-checked env constructors, loud abort on thunk-arena init failure, Word16 element-count guard in the bytecode compiler.
- CI compiles test components under -Werror; the sdist ships NOTICE; cc-options drops the baked-in -Werror; setup.sh initializes CPPFLAGS/LDFLAGS and fails loudly when objdump is unavailable.

## Verification

Full suite: 826/826, with 34 new regression tests including hand-encoded NAR wire-format vectors and the sha256 nix-base32 known answer. Build is -Werror clean including test components; ormolu and hlint clean.

Benchmark vs main (5-run min/median, same machine): nixpkgs `hello.drvPath` eval 3395/3423 ms on main vs 3391/3450 ms here - no regression, and the drvPath is byte-identical to the parity oracle. The pkgs/windows drvPaths change only because setup.sh (a content-addressed input) changed: this branch's binary evaluating main's unmodified checkout reproduces main's hashes exactly.
