### PR TITLE
Move to nova-cache 0.5.0.0; decode key files as UTF-8; sdist CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,41 @@ jobs:
         run: cabal check
 
   # ---------------------------------------------------------------------------
+  # Build from the sdist, exactly as a Hackage user does (Linux-only).
+  # CI otherwise builds the git tree, where cabal.project and dev-only
+  # settings apply; the tarball is what users install, and divergence
+  # (files missing from the sdist, constraints that only exist in-repo)
+  # is invisible without this job.
+  # ---------------------------------------------------------------------------
+
+  sdist:
+    name: Build from sdist
+    needs: [cabal-check]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: haskell-actions/setup@v2
+        id: setup
+        with:
+          ghc-version: "9.8"
+          cabal-version: "latest"
+
+      - name: Cache Cabal store
+        uses: actions/cache@v5
+        with:
+          path: ${{ steps.setup.outputs.cabal-store }}
+          key: cabal-sdist-${{ hashFiles('nova-nix.cabal') }}
+          restore-keys: cabal-sdist-
+
+      - name: Build the tarball a Hackage user gets
+        run: |
+          cabal sdist -o "$RUNNER_TEMP/sdist"
+          tar -xzf "$RUNNER_TEMP"/sdist/nova-nix-*.tar.gz -C "$RUNNER_TEMP"
+          cd "$RUNNER_TEMP"/nova-nix-*/
+          cabal build --enable-tests
+
+  # ---------------------------------------------------------------------------
   # Build + Test (cross-platform matrix)
   # ---------------------------------------------------------------------------
 

--- a/cabal.project
+++ b/cabal.project
@@ -1,3 +1,1 @@
 packages: .
-constraints:
-  nova-cache -compression

--- a/nova-nix.cabal
+++ b/nova-nix.cabal
@@ -98,7 +98,7 @@ library
     , http-types          >= 0.12 && < 0.13
     , ram                 >= 0.20 && < 1
     , mtl                 >= 2.2 && < 2.4
-    , nova-cache          >= 0.4.2 && < 0.5
+    , nova-cache          >= 0.5 && < 0.6
     , process             >= 1.6 && < 1.7
     , regex-tdfa          >= 1.3 && < 1.4
     , sqlite-simple       >= 0.4 && < 0.5
@@ -172,7 +172,7 @@ test-suite nova-nix-test
     , containers          >= 0.6 && < 0.9
     , directory           >= 1.3 && < 1.4
     , filepath            >= 1.4 && < 1.6
-    , nova-cache          >= 0.4.2 && < 0.5
+    , nova-cache          >= 0.5 && < 0.6
     , nova-nix
     , process             >= 1.6 && < 1.7
     , tar                 >= 0.7.1 && < 0.8

--- a/src/Nix/Push.hs
+++ b/src/Nix/Push.hs
@@ -135,16 +135,23 @@ data PushSummary = PushSummary
 -- | Read an API key from a file, dropping byte-order marks and surrounding
 -- whitespace.  Key files written by Windows tooling are a known source of
 -- BOM contamination; 'normalizeKeyText' makes the transfer byte-clean.
+--
+-- The bytes are decoded as UTF-8 EXPLICITLY: locale text IO decodes by
+-- console code page, which turns the BOM bytes into codepage characters
+-- that no normalizer recognizes - on the very consoles the BOM handling
+-- exists for.
 loadApiKeyFile :: FilePath -> IO (Either Text Text)
 loadApiKeyFile path = do
-  attempt <- try (TIO.readFile path)
+  attempt <- try (BS.readFile path)
   pure $ case attempt of
     Left (e :: SomeException) -> Left ("cannot read key file: " <> T.pack (show e))
-    Right raw ->
-      let key = normalizeKeyText raw
-       in if T.null key
-            then Left ("key file is empty: " <> T.pack path)
-            else Right key
+    Right bytes -> case TE.decodeUtf8' bytes of
+      Left _ -> Left ("key file is not valid UTF-8: " <> T.pack path)
+      Right raw ->
+        let key = normalizeKeyText raw
+         in if T.null key
+              then Left ("key file is empty: " <> T.pack path)
+              else Right key
 
 -- ---------------------------------------------------------------------------
 -- Closure computation

--- a/src/Nix/Push.hs
+++ b/src/Nix/Push.hs
@@ -203,8 +203,8 @@ mkNarInfo sp narHash narSize refs deriver =
     { niStorePath = storePathToText defaultStoreDir sp,
       niUrl = narDirSegment <> "/" <> narFileName narHash,
       niCompression = compressionNone,
-      niFileHash = narHash,
-      niFileSize = fromIntegral narSize,
+      niFileHash = Just narHash,
+      niFileSize = Just (fromIntegral narSize),
       niNarHash = narHash,
       niNarSize = fromIntegral narSize,
       niReferences = sort (map storePathBasename refs),
@@ -261,11 +261,13 @@ newPushManager =
   HTTP.newManager
     HTTPS.tlsManagerSettings {HTTP.managerResponseTimeout = HTTP.responseTimeoutNone}
 
--- | Fetch the set of narinfo hashes the cache already stores.
+-- | Fetch the set of narinfo hashes the cache already stores.  The
+-- endpoint is push-tool plumbing and the server requires the write key
+-- for it (nova-cache 0.5), so the request authenticates like the PUTs.
 fetchRemoteHashes :: HTTP.Manager -> PushConfig -> ExceptT Text IO (Set Text)
 fetchRemoteHashes manager cfg = do
   let url = pcCacheUrl cfg <> "/" <> narinfoHashesEndpoint
-  response <- httpRequest manager "GET" url [] Nothing
+  response <- httpRequest manager "GET" url (authHeaders cfg) Nothing
   let code = HTTP.statusCode (HTTP.responseStatus response)
   unless (code == httpStatusOk) $
     throwError ("GET " <> narinfoHashesEndpoint <> " returned HTTP " <> T.pack (show code))

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -2768,8 +2768,8 @@ testSubstituter = do
         { NarInfo.niStorePath = "/nix/store/" <> sampleHash <> "-hello",
           NarInfo.niUrl = "nar/sample.nar",
           NarInfo.niCompression = "none",
-          NarInfo.niFileHash = sampleNarHash,
-          NarInfo.niFileSize = 0,
+          NarInfo.niFileHash = Just sampleNarHash,
+          NarInfo.niFileSize = Just 0,
           NarInfo.niNarHash = narHash,
           NarInfo.niNarSize = fromIntegral (BS.length sampleNarBytes),
           NarInfo.niReferences = [],
@@ -3090,7 +3090,7 @@ testPushPure = do
       runTest "compression none mirrors NAR fields into file fields" $
         assertEqual
           "file fields"
-          ("none", NarInfo.niNarHash ni, NarInfo.niNarSize ni)
+          ("none", Just (NarInfo.niNarHash ni), Just (NarInfo.niNarSize ni))
           (NarInfo.niCompression ni, NarInfo.niFileHash ni, NarInfo.niFileSize ni),
       runTest "narinfo sizes carry through" $
         assertEqual "NarSize" 1234 (NarInfo.niNarSize ni),
@@ -5700,8 +5700,8 @@ sigTestNarInfo =
     { NarInfo.niStorePath = "/nix/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-hello-1.0",
       NarInfo.niUrl = "nar/aaaa.nar",
       NarInfo.niCompression = "none",
-      NarInfo.niFileHash = "sha256:" <> T.replicate 52 "0",
-      NarInfo.niFileSize = 1,
+      NarInfo.niFileHash = Just ("sha256:" <> T.replicate 52 "0"),
+      NarInfo.niFileSize = Just 1,
       NarInfo.niNarHash = "sha256:" <> T.replicate 52 "0",
       NarInfo.niNarSize = 1,
       NarInfo.niReferences = [],


### PR DESCRIPTION
Closes the audit's last HIGH: released sdists previously built nova-cache with +compression because the -compression constraint lived only in cabal.project, which is not shipped. nova-cache 0.5.0.0 removed the flag and the lzma dependency at the root, so the constraint is deleted and both bounds move to >= 0.5 && < 0.6. The new build-from-sdist CI job builds the tarball outside the repo - without cabal.project - so this class of tree-vs-release divergence now fails the pipeline instead of surfacing at install time.

Adaptations to 0.5.0.0: FileHash/FileSize are Maybe (pushes still populate them - Compression: none mirrors the NAR fields), and fetchRemoteHashes sends the bearer header since the server now requires the write key for the /narinfo-hashes listing.

Also fixes a latent locale bug the bump surfaced: loadApiKeyFile read the key file with locale text IO, so on a legacy-codepage Windows console the UTF-8 BOM decoded to codepage characters that normalizeKeyText cannot recognize - silent auth failure on exactly the consoles the BOM handling was built for. UTF-8 shells (including all CI runners) masked it. The file is now read as bytes and decoded as UTF-8 explicitly, with undecodable input a loud error.

Full suite 826/826 against the Hackage-published 0.5.0.0; -Werror with tests, ormolu, hlint, ascii all clean.