### PR TITLE
Class I upstream conformance: hash decode, number formatting, path/derivation/context identity

### DIFF
--- a/nova-nix.cabal
+++ b/nova-nix.cabal
@@ -57,6 +57,7 @@ library
     Nix.Parser.Lexer
     Nix.Parser.ParseError
     Nix.Eval
+    Nix.Eval.CanonPath
     Nix.Eval.Context
     Nix.Eval.Types
     Nix.Eval.IO

--- a/src/Nix/Derivation.hs
+++ b/src/Nix/Derivation.hs
@@ -226,13 +226,20 @@ atermOutputsWith maskOutputs outs =
         <> ")"
 
 -- | Input-derivations serializer for the modulo substitution: keys are the
--- modulo-hash hex strings (sorted), output-name lists sorted and deduplicated.
+-- modulo-hash hex strings.  Entries that share a key are merged, unioning
+-- their output-name sets, so the section carries one entry per distinct modulo
+-- hash - mirroring upstream @hashDerivationModulo@'s @std::map<Hash, StringSet>@,
+-- where two inputs that collapse to the same modulo hash (e.g. two fetches
+-- differing only in URL) become a single entry.  'Set.union' makes the merge
+-- order-independent; 'Map.toAscList' and 'Set.toAscList' fix the ascending
+-- hex-key and output-name order (hex is lowercase, so this matches the bytewise
+-- order of upstream's @std::map<std::string>@).
 atermInputDrvsSubst :: [(Text, [Text])] -> Text
 atermInputDrvsSubst subs =
-  let sorted = sortBy (compare `on` fst) subs
-   in "[" <> T.intercalate "," (map render sorted) <> "]"
+  let merged = Map.fromListWith Set.union [(key, Set.fromList outs) | (key, outs) <- subs]
+   in "[" <> T.intercalate "," (map render (Map.toAscList merged)) <> "]"
   where
-    render (key, outs) = "(" <> atermString key <> "," <> atermStringList (sortNubText outs) <> ")"
+    render (key, outs) = "(" <> atermString key <> "," <> atermStringList (Set.toAscList outs) <> ")"
 
 -- | Sort and deduplicate output names (matches C++ @std::set<string>@).
 sortNubText :: [Text] -> [Text]

--- a/src/Nix/Eval.hs
+++ b/src/Nix/Eval.hs
@@ -86,7 +86,7 @@ import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
-import Data.Word (Word32, Word8)
+import Data.Word (Word32, Word64, Word8)
 import Foreign.Ptr (Ptr, castPtr, nullPtr, ptrToWordPtr, wordPtrToPtr)
 import Foreign.Storable (peekElemOff, pokeElemOff)
 import Nix.Derivation (Derivation (..), DerivationOutput (..), textToPlatform, toATerm, toATermForHash)
@@ -94,10 +94,11 @@ import Nix.Eval.CBytecode (cbcArg1, cbcArg2, cbcArg3, cbcData, cbcFlags, cbcOpco
 import Nix.Eval.CEnv (cenvPushWith)
 import Nix.Eval.CList (CList (..), clistGet)
 import Nix.Eval.CThunk (CThunkPtr)
+import Nix.Eval.CanonPath (canonPath)
 import Nix.Eval.Compile (BcAttrKey (..), BcBinding (..), compileExpr, decodeBcBindings, decodeBcCaptureInfo, decodeBcFormals, reassembleDouble, reassembleInt64)
-import Nix.Eval.Context (extractInputDrvs, extractInputSrcs, plainContext)
+import Nix.Eval.Context (extractAllOutputRefs, extractInputDrvs, extractInputSrcs, plainContext)
 import Nix.Eval.Operator (checkedAdd, checkedMul, checkedSub, evalBinary, evalUnary, nixCompare, nixEqual)
-import Nix.Eval.StringInterp (coerceToString, formatNixFloat, stripIndentedChunks)
+import Nix.Eval.StringInterp (coerceToString, formatJsonFloat, formatNixFloat, formatXmlFloat, stripIndentedChunks)
 import Nix.Eval.Symbol (Symbol (..), symbolText)
 import Nix.Eval.Types
   ( AttrSet (..),
@@ -160,7 +161,7 @@ import Nix.Expr.Types
     NixAtom (..),
     UnaryOp (..),
   )
-import Nix.Hash (bytesToHexText, hashPlaceholder, hexToBytes, makeFixedOutputPath, makeOutputPath, makeTextPath, sha256Digest, sha256Hex)
+import Nix.Hash (base64HashLen, bytesToHexText, hashAlgoBytes, hashPlaceholder, hexHashLen, hexToBytes, makeFixedOutputPath, makeOutputPath, makeTextPath, nix32HashLen, sha256Digest, sha256Hex)
 import Nix.Store.Path (StorePath (..), defaultStoreDir, defaultStoreDirText, parseStorePath, storePathToText)
 import qualified NovaCache.Base32 as Nix32
 import qualified NovaCache.Base64 as B64
@@ -337,8 +338,10 @@ evalAddWithCoercion left right = case (left, right) of
   (VFloat _, _) -> evalBinary force OpAdd left right
   (_, VFloat _) -> evalBinary force OpAdd left right
   (VInt _, VInt _) -> evalBinary force OpAdd left right
-  -- Path + path: raw concatenation, still a path.
-  (VPath a, VPath b) -> pure (VPath (a <> b))
+  -- Path + path: text concatenation, canonicalized - the joined spelling
+  -- (dot segments, doubled separators) never survives into the value, as
+  -- upstream (CanonPath on the concatenated text).
+  (VPath a, VPath b) -> pure (VPath (canonPath (a <> b)))
   -- Path + coercible: the result stays a path, the right side coerces
   -- WITHOUT a store copy, and a right side carrying string context is an
   -- error, as upstream (a store-path reference cannot survive inside a
@@ -346,7 +349,7 @@ evalAddWithCoercion left right = case (left, right) of
   (VPath a, _) -> do
     (rightStr, rightCtx) <- coerceAddOperand right
     if rightCtx == emptyContext
-      then pure (VPath (a <> rightStr))
+      then pure (VPath (canonPath (a <> rightStr)))
       else throwEvalError "cannot append a string with context (a store-path reference) to a path"
   -- Strings: direct concat.
   (VStr {}, VStr {}) -> evalBinary force OpAdd left right
@@ -1121,6 +1124,7 @@ builtinRegistry =
       builtin2 "warn" builtinWarn,
       builtin1 "unsafeDiscardStringContext" builtinDiscardContext,
       builtin1 "unsafeDiscardOutputDependency" builtinDiscardOutputDep,
+      builtin1 "addDrvOutputDependencies" builtinAddDrvOutputDeps,
       -- String context introspection
       builtin1 "hasContext" builtinHasContext,
       builtin1 "getContext" builtinGetContext,
@@ -1343,6 +1347,7 @@ executeBuiltin name args = case name of
   "warn" -> apply2 builtinWarn
   "unsafeDiscardStringContext" -> apply1 builtinDiscardContext
   "unsafeDiscardOutputDependency" -> apply1 builtinDiscardOutputDep
+  "addDrvOutputDependencies" -> apply1 builtinAddDrvOutputDeps
   -- String context introspection
   "hasContext" -> apply1 builtinHasContext
   "getContext" -> apply1 builtinGetContext
@@ -1884,9 +1889,11 @@ builtinConcatStringsSep (VStr sep sepCtx) (VList cl) = do
   where
     forceToStrCtx thunk = do
       val <- force thunk
-      -- Nix coerces list elements to strings (paths, derivations, etc.).
-      -- concatStringsSep is strict (coerceMore=False): non-string scalars error.
-      coerceToString False force applyValue val
+      -- Nix 2.24's coerceToString defaults copyToStore=true and
+      -- concatStringsSep passes no override, so a path element is copied into
+      -- the store and the result carries its SCPlain context.  Non-string
+      -- scalars still error (coerceMore=False), matching interpolation.
+      coerceToStringInterp val
 builtinConcatStringsSep (VStr _ _) other =
   throwEvalError ("builtins.concatStringsSep: expected a list, got " <> typeName other)
 builtinConcatStringsSep other _ =
@@ -1992,11 +1999,17 @@ coerceToStringInterp other = coerceToString False force applyValue other
 -- SCPlain context - the copy-to-store coercion shared by interpolation,
 -- derivation arguments/env values, and @builtins.toJSON@.
 sourcePathWithContext :: (MonadEval m) => Text -> m (Text, StringContext)
-sourcePathWithContext p = do
-  spText <- storeSourcePath p
-  case parseStorePath defaultStoreDir spText of
-    Just sp -> pure (spText, StringContext (Set.singleton (SCPlain sp)))
-    Nothing -> pure (spText, mempty)
+sourcePathWithContext p
+  -- An already-in-store path coerces to itself with an SCPlain (Opaque)
+  -- reference - never re-copied.  This is the shared choke point for
+  -- interpolation, derivation args, concatStringsSep, and toJSON, so all of
+  -- them inherit the in-store short-circuit (and the Windows re-NAR fix).
+  | Just sp <- enclosingStorePath p = pure (p, plainContext sp)
+  | otherwise = do
+      spText <- storeSourcePath p
+      case parseStorePath defaultStoreDir spText of
+        Just sp -> pure (spText, plainContext sp)
+        Nothing -> pure (spText, mempty)
 
 -- | The current system platform string.
 currentSystemStr :: Text
@@ -2048,17 +2061,54 @@ builtinDiscardContext (VStr s _) = pure (mkStr s)
 builtinDiscardContext other =
   throwEvalError ("builtins.unsafeDiscardStringContext: expected a string, got " <> typeName other)
 
--- | Strip only derivation output dependencies (SCDrvOutput, SCAllOutputs),
--- keeping plain store path references (SCPlain).
+-- | @builtins.unsafeDiscardOutputDependency@ - downgrade all-outputs (DrvDeep)
+-- references to a plain (Opaque) reference on the same @.drv@ path, and KEEP
+-- derivation-output (Built) references unchanged, matching upstream.  It
+-- formerly dropped both kinds and kept only plain references, losing the
+-- @.drv@ reference the downgrade must preserve.  'Set.map' also folds a
+-- downgraded element into an existing plain reference on the same path.
 builtinDiscardOutputDep :: (MonadEval m) => NixValue -> m NixValue
 builtinDiscardOutputDep (VStr s (StringContext ctx)) =
-  let kept = Set.filter isPlain ctx
-   in pure (VStr s (StringContext kept))
+  pure (VStr s (StringContext (Set.map downgrade ctx)))
   where
-    isPlain (SCPlain _) = True
-    isPlain _ = False
+    downgrade (SCAllOutputs sp) = SCPlain sp
+    downgrade other = other
 builtinDiscardOutputDep other =
   throwEvalError ("builtins.unsafeDiscardOutputDependency: expected a string, got " <> typeName other)
+
+-- | @builtins.addDrvOutputDependencies@ - the inverse of the
+-- 'builtinDiscardOutputDep' downgrade for a single element: upgrade a plain
+-- (Opaque) reference to a @.drv@ path into an all-outputs (DrvDeep) reference.
+-- Upstream requires the string's context to have exactly one element and
+-- errors on a derivation-output (Built) element or a non-@.drv@ plain path.
+builtinAddDrvOutputDeps :: (MonadEval m) => NixValue -> m NixValue
+builtinAddDrvOutputDeps (VStr s (StringContext ctx)) =
+  case Set.toList ctx of
+    [only] -> VStr s . StringContext . Set.singleton <$> upgrade only
+    _ ->
+      throwEvalError
+        ( "builtins.addDrvOutputDependencies: the string must have exactly one "
+            <> "context element, but has "
+            <> T.pack (show (Set.size ctx))
+        )
+  where
+    upgrade (SCPlain sp)
+      | ".drv" `T.isSuffixOf` spName sp = pure (SCAllOutputs sp)
+      | otherwise =
+          throwEvalError
+            ( "builtins.addDrvOutputDependencies: path "
+                <> storePathToText defaultStoreDir sp
+                <> " is not a derivation"
+            )
+    upgrade (SCAllOutputs sp) = pure (SCAllOutputs sp)
+    upgrade (SCDrvOutput _ outName) =
+      throwEvalError
+        ( "builtins.addDrvOutputDependencies: can only act on derivations, not "
+            <> "on a derivation output such as "
+            <> outName
+        )
+builtinAddDrvOutputDeps other =
+  throwEvalError ("builtins.addDrvOutputDependencies: expected a string, got " <> typeName other)
 
 -- | Check whether a string has any context elements.
 builtinHasContext :: (MonadEval m) => NixValue -> m NixValue
@@ -2097,11 +2147,14 @@ groupContextByPath = foldl' addElement Map.empty
       Map.insertWith mergeEntry (spToText sp) (ContextEntry False False [outName]) acc
     addElement acc (SCAllOutputs sp) =
       Map.insertWith mergeEntry (spToText sp) (ContextEntry False True []) acc
+    -- 'Set.toList' feeds elements in ascending order and 'old' holds the
+    -- earlier (smaller) output names, so 'old ++ new' keeps the rendered
+    -- outputs list ascending, as upstream getContext produces it.
     mergeEntry new old =
       ContextEntry
         (cePath new || cePath old)
         (ceAllOutputs new || ceAllOutputs old)
-        (ceOutputs new ++ ceOutputs old)
+        (ceOutputs old ++ ceOutputs new)
     -- Context keys are identity, not IO: always the canonical /nix/store
     -- spelling, never the platform file-path mapping.
     spToText = storePathToText defaultStoreDir
@@ -2677,7 +2730,10 @@ valueToJSON VNull = pure ("null", emptyContext)
 valueToJSON (VBool True) = pure ("true", emptyContext)
 valueToJSON (VBool False) = pure ("false", emptyContext)
 valueToJSON (VInt n) = pure (T.pack (show n), emptyContext)
-valueToJSON (VFloat f) = pure (formatNixFloat f, emptyContext)
+valueToJSON (VFloat f)
+  -- upstream's serializer (nlohmann dump) writes a non-finite float as null
+  | isNaN f || isInfinite f = pure ("null", emptyContext)
+  | otherwise = pure (formatJsonFloat f, emptyContext)
 valueToJSON (VStr s ctx) = pure (jsonEscapeString s, ctx)
 valueToJSON (VList cl) = do
   let thunks = map Thunk (clistThunks cl)
@@ -2831,9 +2887,19 @@ parseJSONNumber t =
             then case reads (T.unpack numStr) :: [(Double, String)] of
               [(d, "")] -> Just (VFloat d, rest)
               _ -> Nothing
-            else case reads (T.unpack numStr) :: [(Int64, String)] of
-              [(n, "")] -> Just (VInt n, rest)
+            else case reads (T.unpack numStr) :: [(Integer, String)] of
+              [(n, "")] -> Just (jsonInteger n, rest)
               _ -> Nothing
+
+-- | Nix value for a JSON integer literal, as upstream's nlohmann-based
+-- parser produces it: a value in int64 range is an int; a positive value
+-- that fits only uint64 still arrives as an int (nlohmann hands it over
+-- unsigned, upstream stores it into the signed NixInt, two's-complement);
+-- anything wider than 64 bits falls back to a float.
+jsonInteger :: Integer -> NixValue
+jsonInteger n
+  | n >= toInteger (minBound :: Int64) && n <= toInteger (maxBound :: Word64) = VInt (fromInteger n)
+  | otherwise = VFloat (fromInteger n)
 
 parseJSONArray :: Text -> Maybe (NixValue, Text)
 parseJSONArray t = parseJSONArrayElements (T.stripStart t) []
@@ -3035,7 +3101,8 @@ builtinToPath :: (MonadEval m) => NixValue -> m NixValue
 builtinToPath (VPath p) = pure (VPath p)
 builtinToPath (VStr s _) = case T.uncons s of
   Nothing -> throwEvalError "builtins.toPath: empty path"
-  Just ('/', _) -> pure (VPath s)
+  -- Canonicalized like every other path production site, as upstream.
+  Just ('/', _) -> pure (VPath (canonPath s))
   Just _ -> throwEvalError ("builtins.toPath: path must be absolute, got " <> s)
 builtinToPath other =
   throwEvalError ("builtins.toPath: expected a string or path, got " <> typeName other)
@@ -3055,16 +3122,32 @@ builtinStorePath (VStr s _) = validateStorePath s
 builtinStorePath other =
   throwEvalError ("builtins.storePath: expected a path or string, got " <> typeName other)
 
+-- | @builtins.storePath@ - mark an already-in-store path as such.  Upstream
+-- returns a STRING carrying an Opaque (SCPlain) context entry for the enclosing
+-- store path, NOT a bare path: the Opaque marker is what stops a later coercion
+-- from re-serialising (re-NARing) the already-present path into a new store
+-- path.  Returning a context-free path (the old behavior) re-copied the path on
+-- coercion - a wrong store path on Unix, and a file-not-found on Windows, where
+-- the canonical @/nix/store@ text is not the on-disk location.
 validateStorePath :: (MonadEval m) => Text -> m NixValue
-validateStorePath p
-  | storeDirPrefix `T.isPrefixOf` p,
-    T.length p > T.length storeDirPrefix,
-    let basename = T.drop (T.length storeDirPrefix) p,
-    T.length basename >= 33,
-    Just ('-', _) <- T.uncons (T.drop 32 basename) =
-      pure (VPath p)
-  | otherwise =
-      throwEvalError ("builtins.storePath: not a valid store path: " <> p)
+validateStorePath p = case enclosingStorePath p of
+  Just sp -> pure (VStr p (plainContext sp))
+  Nothing -> throwEvalError ("builtins.storePath: not a valid store path: " <> p)
+
+-- | The store path enclosing an absolute path under the store dir, or
+-- 'Nothing' if the path is not in the store.  Accepts a bare store path and a
+-- subpath (@\/nix\/store\/\<hash\>-\<name\>\/sub@ resolves to its
+-- @\<hash\>-\<name\>@ component), the way upstream marks the enclosing store
+-- path Opaque for either.
+enclosingStorePath :: Text -> Maybe StorePath
+enclosingStorePath p = do
+  rest <- T.stripPrefix storeDirPrefix p
+  let component = T.takeWhile (/= '/') rest
+      (hash, hyphenName) = T.splitAt 32 component
+  (hyphen, name) <- T.uncons hyphenName
+  if hyphen == '-' && not (T.null name) && T.length hash == 32
+    then Just (StorePath hash name)
+    else Nothing
 
 -- ---------------------------------------------------------------------------
 -- Builtin implementations - Nix search path
@@ -3111,14 +3194,14 @@ findFirst [] name =
 findFirst ((prefix, path) : rest) name
   | prefix == name || (not (T.null prefix) && (prefix <> "/") `T.isPrefixOf` name) =
       let suffix = if prefix == name then "" else T.drop (T.length prefix + 1) name
-          candidate = if T.null suffix then path else path <> "/" <> suffix
+          candidate = canonPath (if T.null suffix then path else path <> "/" <> suffix)
        in do
             exists <- doesPathExist candidate
             if exists
               then pure (VPath candidate)
               else findFirst rest name
   | T.null prefix =
-      let candidate = path <> "/" <> name
+      let candidate = canonPath (path <> "/" <> name)
        in do
             exists <- doesPathExist candidate
             if exists
@@ -3328,6 +3411,84 @@ forceOptionalAttrStr attrs key =
 -- Builtin implementations - derivation construction
 -- ---------------------------------------------------------------------------
 
+-- | Resolve an input derivation's modulo hash (hex) for the ATerm substitution
+-- 'toATermForHash' performs.  The drv-hash cache is populated bottom-up as each
+-- derivation is evaluated, so an in-session input hits directly.  A miss - a
+-- cross-session reference, or a path fabricated by @builtins.appendContext@ -
+-- reads the input @.drv@ from the store and recurses, exactly as upstream
+-- @hashDerivationModulo@ does.  A miss whose @.drv@ cannot be read (pure
+-- evaluation, or a @.drv@ absent from the store) fails loudly: a divergent
+-- derivation hash is never emitted from a guessed input hash.  Reading the
+-- store is an effect, so hashing a dependent derivation is an IO-evaluator
+-- capability - pure evaluation, which cannot read the store, cannot do it.
+resolveInputModulo :: (MonadEval m) => (StorePath, [Text]) -> m (Text, [Text])
+resolveInputModulo (sp, outs) = do
+  let inputPathText = storePathToText defaultStoreDir sp
+  cached <- lookupDrvHash inputPathText
+  case cached of
+    Just hex -> pure (hex, outs)
+    Nothing -> do
+      mDrv <- readStoreDerivation sp
+      case mDrv of
+        Just inputDrv -> do
+          hex <- derivationModuloHex inputDrv
+          cacheDrvHash inputPathText hex
+          pure (hex, outs)
+        Nothing ->
+          throwEvalError
+            ( "derivation: cannot compute the input-derivation modulo hash for "
+                <> inputPathText
+                <> " - it was not evaluated in this session and its .drv is not "
+                <> "readable from the store (dependent-derivation hashing needs the IO evaluator)"
+            )
+
+-- | The derivation-modulo hash (hex) of a derivation, matching upstream
+-- @hashDerivationModulo@: a fixed-output derivation hashes the
+-- @fixed:out:\<algo\>:\<hash\>:\<path\>@ form; an input-addressed derivation
+-- substitutes each input's modulo hash into its ATerm and hashes that.  These
+-- are the same two rules 'builtinDerivationStrict' applies when it first
+-- computes a derivation's hash, so a store-read input yields the value it had
+-- in-session.
+derivationModuloHex :: (MonadEval m) => Derivation -> m Text
+derivationModuloHex drv = case drvOutputs drv of
+  [DerivationOutput "out" outPath algoField hashHex]
+    | not (T.null algoField) && not (T.null hashHex) ->
+        let outPathText = storePathToText defaultStoreDir outPath
+            fixedForm = "fixed:out:" <> algoField <> ":" <> hashHex <> ":" <> outPathText
+         in pure (bytesToHexText (sha256Digest (TE.encodeUtf8 fixedForm)))
+  _ -> do
+    inputSubst <- mapM resolveInputModulo (Map.toList (drvInputDrvs drv))
+    pure (bytesToHexText (sha256Digest (TE.encodeUtf8 (toATermForHash False (Just inputSubst) drv))))
+
+-- | The full output-name list of an all-outputs (upstream DrvDeep) reference:
+-- every output name of the referenced @.drv@, which upstream's derivationStrict
+-- inserts into the consuming derivation's inputDrvs.  Mirrors the
+-- 'resolveInputModulo' ladder - an in-session derivation from the recorded
+-- ATerm ('lookupSessionDrv'), else a cross-session @.drv@ read from the store
+-- ('readStoreDerivation'), else a loud error rather than a dropped reference
+-- (which would under-hash the dependent).  Pure evaluation can read neither
+-- source, so a dependent carrying an all-outputs reference errors there,
+-- consistent with dependent-derivation hashing being an IO-evaluator capability.
+resolveAllOutputNames :: (MonadEval m) => StorePath -> m [Text]
+resolveAllOutputNames sp = do
+  let drvPathText = storePathToText defaultStoreDir sp
+  session <- lookupSessionDrv drvPathText
+  case session of
+    Just drv -> pure (outputNamesOf drv)
+    Nothing -> do
+      onDisk <- readStoreDerivation sp
+      case onDisk of
+        Just drv -> pure (outputNamesOf drv)
+        Nothing ->
+          throwEvalError
+            ( "derivation: cannot resolve the output names of the all-outputs reference "
+                <> drvPathText
+                <> " - it was not evaluated in this session and its .drv is not "
+                <> "readable from the store (all-outputs references need the IO evaluator)"
+            )
+  where
+    outputNamesOf = map doName . drvOutputs
+
 -- | Eager derivation computation - @builtins.derivationStrict@.  Forces all
 -- input attrs into env vars, content-hashes, and returns the full derivation
 -- attrset (drvPath, outPath, per-output, _derivation).  Called LAZILY by the
@@ -3386,8 +3547,17 @@ builtinDerivationStrict (VAttrs attrs) = do
   (drvEnvPairs, envContext) <- collectDrvEnvWithContext ignoreNulls (Map.delete "__ignoreNulls" (Map.delete "args" materialized))
 
   let fullContext = envContext <> argsContext
-      inputDrvs = extractInputDrvs fullContext
+      builtInputDrvs = extractInputDrvs fullContext
       inputSrcs = extractInputSrcs fullContext
+      allOutputRefs = extractAllOutputRefs fullContext
+  -- All-outputs (DrvDeep) references - e.g. an embedded @dep.drvPath@ - add the
+  -- referenced .drv to inputDrvs with ALL its output names, as upstream's
+  -- derivationStrict does.  Merged in BEFORE drvRefs and the modulo
+  -- substitution so both the dependent's own .drv hash and its output paths
+  -- account for the reference.
+  deepInputDrvs <-
+    Map.fromList <$> mapM (\drvSp -> (,) drvSp <$> resolveAllOutputNames drvSp) allOutputRefs
+  let inputDrvs = Map.unionWith (++) builtInputDrvs deepInputDrvs
       platform = textToPlatform system
       baseEnv = Map.fromList drvEnvPairs
       drvRefs = inputSrcs ++ Map.keys inputDrvs
@@ -3405,22 +3575,6 @@ builtinDerivationStrict (VAttrs attrs) = do
           }
       -- Output carrying only its name; the path is masked at render time.
       maskedOutput name = DerivationOutput name (StorePath "" "") "" ""
-      -- Resolve an input derivation's modulo hash (hex) from the cache,
-      -- populated bottom-up by earlier 'builtinDerivationStrict' calls.
-      resolveInputModulo (sp, outs) = do
-        let inputPathText = storePathToText defaultStoreDir sp
-        cached <- lookupDrvHash inputPathText
-        case cached of
-          Just hex -> pure (hex, outs)
-          Nothing -> do
-            -- Eval is bottom-up, so inputs evaluated this session are always
-            -- cached by the time a dependent hashes.  A miss means an input
-            -- referenced but not evaluated here (a pure-eval synthetic context,
-            -- or a pre-built store drv): fall back to its store hash so
-            -- evaluation still produces a value, and warn for visibility.
-            traceMessage
-              ("derivation: input modulo hash not cached, using store hash for " <> inputPathText)
-            pure (spHash sp, outs)
 
   -- Fixed-output derivations (fetchurl etc.) are content-addressed and hash
   -- via the @fixed:out:@ scheme; input-addressed derivations recurse through
@@ -3708,13 +3862,27 @@ decodeHashInput attrs hashStr
       algo <- requireStrAttr "convertHash" "hashAlgo" attrs
       decodeWithAlgo algo hashStr
 
--- | Try to decode as hex, then nix32, then base64.
+-- | Decode a bare hash string for a known algorithm, keyed by length as
+-- upstream (@hash.cc@ @Hash@ parsing): an algorithm's base16, nix32, and
+-- base64 spellings have pairwise distinct lengths, so the input length
+-- selects the decoder and every other length is an error.  Trying decoders
+-- in sequence instead mis-reads edge inputs - an all-hex-digit string of
+-- nix32 length is a nix32 hash, and a truncated hash must be rejected, not
+-- decoded by whichever shorter format happens to accept it.
 decodeWithAlgo :: (MonadEval m) => Text -> Text -> m (Text, BS.ByteString)
-decodeWithAlgo algo s
-  | Just bytes <- hexToBytes s = pure (algo, bytes)
-  | Right bytes <- Nix32.decode s = pure (algo, bytes)
-  | Right bytes <- decodeBase64Pure s = pure (algo, bytes)
-  | otherwise = throwEvalError ("builtins.convertHash: cannot decode hash '" <> s <> "'")
+decodeWithAlgo algo s = case hashAlgoBytes algo of
+  Nothing -> throwEvalError ("unknown hash algorithm '" <> algo <> "'")
+  Just size
+    | T.length s == hexHashLen size -> accept size "base16" (hexToBytes s)
+    | T.length s == nix32HashLen size -> accept size "nix32" (rightToMaybe (Nix32.decode s))
+    | T.length s == base64HashLen size -> accept size "base64" (rightToMaybe (decodeBase64Pure s))
+    | otherwise ->
+        throwEvalError ("hash '" <> s <> "' has wrong length for hash algorithm '" <> algo <> "'")
+  where
+    accept size spelling decoded = case decoded of
+      Just bytes | BS.length bytes == size -> pure (algo, bytes)
+      _ -> throwEvalError ("hash '" <> s <> "' is not a valid " <> spelling <> " " <> algo <> " hash")
+    rightToMaybe = either (const Nothing) Just
 
 -- | Parse @sha256-base64...@ SRI format.
 parseSRI :: Text -> Maybe (Text, Text)
@@ -4100,33 +4268,42 @@ parseInt :: Text -> Either Text TOMLValue
 parseInt t =
   let cleaned = T.filter (/= '_') t
       (sign, digits) = case T.uncons cleaned of
-        Just ('+', rest) -> (1, rest)
+        Just ('+', rest) -> (1 :: Integer, rest)
         Just ('-', rest) -> (-1, rest)
         _ -> (1, cleaned)
    in case readDecimal digits of
-        Just n -> Right (TOMLInt (sign * n))
+        Just n -> tomlInt t (sign * n)
         Nothing -> Left ("invalid integer: " <> t)
 
 parseHexInt :: Text -> Either Text TOMLValue
 parseHexInt t =
   let cleaned = T.filter (/= '_') t
    in case readHexT cleaned of
-        Just n -> Right (TOMLInt n)
+        Just n -> tomlInt t n
         Nothing -> Left ("invalid hex integer: " <> t)
 
 parseOctInt :: Text -> Either Text TOMLValue
 parseOctInt t =
   let cleaned = T.filter (/= '_') t
    in case readOctT cleaned of
-        Just n -> Right (TOMLInt n)
+        Just n -> tomlInt t n
         Nothing -> Left ("invalid octal integer: " <> t)
 
 parseBinInt :: Text -> Either Text TOMLValue
 parseBinInt t =
   let cleaned = T.filter (/= '_') t
    in case readBinT cleaned of
-        Just n -> Right (TOMLInt n)
+        Just n -> tomlInt t n
         Nothing -> Left ("invalid binary integer: " <> t)
+
+-- | Finish a parsed TOML integer: a value outside the 64-bit signed range
+-- is a parse error, as upstream's TOML parser reports - silently wrapping
+-- would hand the evaluator a different number than the document wrote.
+tomlInt :: Text -> Integer -> Either Text TOMLValue
+tomlInt original n
+  | n < toInteger (minBound :: Int64) || n > toInteger (maxBound :: Int64) =
+      Left ("integer out of 64-bit range: " <> original)
+  | otherwise = Right (TOMLInt (fromInteger n))
 
 parseFloat :: Text -> Either Text TOMLValue
 parseFloat t =
@@ -4135,27 +4312,31 @@ parseFloat t =
         Just d -> Right (TOMLFloat d)
         Nothing -> Left ("invalid float: " <> t)
 
--- | Read a decimal integer from Text.
-readDecimal :: Text -> Maybe Int64
+-- Digit readers accumulate an unbounded 'Integer'; 'tomlInt' applies the
+-- 64-bit range gate after any sign, so the minimum int64 (whose magnitude
+-- alone exceeds the maximum) still parses.
+
+-- | Read an unbounded decimal integer from Text.
+readDecimal :: Text -> Maybe Integer
 readDecimal t
   | T.null t = Nothing
   | T.all isDigit t = Just (T.foldl' (\acc c -> acc * 10 + fromIntegral (digitToInt c)) 0 t)
   | otherwise = Nothing
 
-readHexT :: Text -> Maybe Int64
+readHexT :: Text -> Maybe Integer
 readHexT t
   | T.null t = Nothing
   | T.all isHexDigit t = Just (T.foldl' (\acc c -> acc * 16 + fromIntegral (digitToInt c)) 0 t)
   | otherwise = Nothing
 
-readOctT :: Text -> Maybe Int64
+readOctT :: Text -> Maybe Integer
 readOctT t
   | T.null t = Nothing
   | T.all isOctDigit t =
       Just (T.foldl' (\acc c -> acc * 8 + fromIntegral (digitToInt c)) 0 t)
   | otherwise = Nothing
 
-readBinT :: Text -> Maybe Int64
+readBinT :: Text -> Maybe Integer
 readBinT t
   | T.null t = Nothing
   | T.all (\c -> c == '0' || c == '1') t =
@@ -4298,7 +4479,7 @@ valueToXML depth val = case val of
   VInt n ->
     pure (indent depth <> "<int value=\"" <> T.pack (show n) <> "\" />\n")
   VFloat d ->
-    pure (indent depth <> "<float value=\"" <> T.pack (show d) <> "\" />\n")
+    pure (indent depth <> "<float value=\"" <> formatXmlFloat d <> "\" />\n")
   VBool True ->
     pure (indent depth <> "<bool value=\"true\" />\n")
   VBool False ->

--- a/src/Nix/Eval/CanonPath.hs
+++ b/src/Nix/Eval/CanonPath.hs
@@ -1,0 +1,90 @@
+-- | Lexical path canonicalization for eval-produced path values.
+--
+-- Upstream Nix canonicalizes every path value (@CanonPath@): @.@ segments
+-- drop, @..@ pops the previous segment (at a root it drops), repeated
+-- separators collapse to one.  nova-nix applies the same algorithm at the
+-- points a path value is produced - literal resolution, @toPath@, path
+-- concatenation, search-path candidates - so the canonical text, not the
+-- user's spelling, is what reaches store-copy names, string coercions, and
+-- comparisons.
+--
+-- Purely lexical: no filesystem access, and symlinks are not resolved
+-- (upstream resolves symlinks separately, where required).  The separator
+-- style of the input is preserved: a canonical forward-slash path stays
+-- forward-slash (this is the identity form for store paths, on every
+-- platform), and a native Windows path keeps its backslashes.  A leading
+-- separator marks a rooted path independent of platform, because eval-time
+-- path values are rooted in the canonical @\/nix\/store@ sense even on
+-- Windows, where 'System.FilePath.splitDrive' would not see a bare @\/@ as
+-- rooted.  A relative input stays relative: leading @..@ segments are kept,
+-- and a fully-collapsed relative path is @.@.
+module Nix.Eval.CanonPath
+  ( canonPath,
+    canonBaseName,
+  )
+where
+
+import Data.Char (isAlpha)
+import Data.List (foldl')
+import Data.Text (Text)
+import qualified Data.Text as T
+import System.FilePath (isPathSeparator, pathSeparator)
+
+-- | Canonicalize a path's text form.  See the module comment for the
+-- algorithm and the separator-preservation guarantee.
+canonPath :: Text -> Text
+canonPath t
+  | T.null t = "."
+  | otherwise = assemble
+  where
+    (drive, afterDrive) = splitDriveLetter t
+    (leadingSeps, body) = T.span isPathSeparator afterDrive
+    rooted = not (T.null leadingSeps)
+    -- Preserve style: emit backslashes only when the input already uses the
+    -- platform separator (Windows '\\').  On POSIX 'pathSeparator' is '/',
+    -- so a literal backslash - an ordinary file-name character there - never
+    -- flips the choice.
+    sep = if T.any (== pathSeparator) t then pathSeparator else '/'
+    segments = filter (not . T.null) (splitOnSeparators body)
+    resolved = reverse (foldl' (collapseStep rooted) [] segments)
+    joined = T.intercalate (T.singleton sep) resolved
+    rootTok = if rooted then T.singleton sep else ""
+    assemble
+      | rooted = drive <> rootTok <> joined
+      | not (T.null drive) = drive <> joined -- drive-relative (@C:foo@)
+      | null resolved = "."
+      | otherwise = joined
+
+-- | Split a leading @X:@ drive letter (Windows) from the rest.  A bare
+-- rooted path (@\/foo@) or a POSIX path has no drive.  UNC roots are left
+-- to the leading-separator handling, which collapses them to a single root.
+splitDriveLetter :: Text -> (Text, Text)
+splitDriveLetter t
+  | Just (c0, rest0) <- T.uncons t,
+    isAlpha c0,
+    Just (':', _) <- T.uncons rest0 =
+      T.splitAt 2 t
+  | otherwise = ("", t)
+
+-- | One segment of the collapse fold; the accumulator holds resolved
+-- segments in reverse.  A @..@ pops a real predecessor, drops at a root,
+-- and is otherwise kept (a relative path may lead with @..@).
+collapseStep :: Bool -> [Text] -> Text -> [Text]
+collapseStep rooted acc segment = case segment of
+  "." -> acc
+  ".." -> case acc of
+    [] -> [".." | not rooted]
+    (top : below)
+      | top == ".." -> ".." : acc
+      | otherwise -> below
+  _ -> segment : acc
+
+-- | Split on platform path separators: both @\/@ and @\\@ on Windows, only
+-- @\/@ on POSIX, where a backslash is an ordinary file-name character.
+splitOnSeparators :: Text -> [Text]
+splitOnSeparators = T.split isPathSeparator
+
+-- | Last segment of a path - upstream @baseNameOf@.  Empty for a root or a
+-- trailing separator, which the caller treats as "no base name".
+canonBaseName :: Text -> Text
+canonBaseName = T.takeWhileEnd (not . isPathSeparator)

--- a/src/Nix/Eval/Context.hs
+++ b/src/Nix/Eval/Context.hs
@@ -17,6 +17,7 @@ module Nix.Eval.Context
     -- * Extraction (for derivation building)
     extractInputSrcs,
     extractInputDrvs,
+    extractAllOutputRefs,
 
     -- * String operations with context
     appendStrings,
@@ -70,6 +71,14 @@ extractInputSrcs (StringContext s) =
 extractInputDrvs :: StringContext -> Map StorePath [Text]
 extractInputDrvs (StringContext s) =
   Map.fromListWith (++) [(sp, [outName]) | SCDrvOutput sp outName <- Set.toList s]
+
+-- | Extract all-outputs (upstream DrvDeep) derivation references - the @.drv@
+-- store paths only.  Unlike 'extractInputDrvs', the output names are not
+-- carried by the context element; the caller reads the referenced derivation
+-- to recover its full set of output names.
+extractAllOutputRefs :: StringContext -> [StorePath]
+extractAllOutputRefs (StringContext s) =
+  [sp | SCAllOutputs sp <- Set.toList s]
 
 -- ---------------------------------------------------------------------------
 -- String operations with context

--- a/src/Nix/Eval/IO.hs
+++ b/src/Nix/Eval/IO.hs
@@ -40,14 +40,16 @@ import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Text (Text)
 import qualified Data.Text as T
-import Data.Text.Encoding (encodeUtf8)
+import Data.Text.Encoding (decodeUtf8', encodeUtf8)
 import Data.Time.Clock.POSIX (getPOSIXTime)
 import Foreign.Ptr (Ptr, castPtr, nullPtr)
 import Foreign.StablePtr (castPtrToStablePtr, castStablePtrToPtr, deRefStablePtr, freeStablePtr, newStablePtr)
 import Nix.Builtins (builtinEnv, builtinEnvWithScope, parseNixPath)
+import Nix.Derivation (fromATerm)
 import Nix.Eval (eval)
 import Nix.Eval.CList (CList (..))
 import Nix.Eval.CThunk (CThunkPtr, cthunkGetAttrs, cthunkGetBcIdx, cthunkGetBool, cthunkGetCtxStr, cthunkGetFloat, cthunkGetInt, cthunkGetLambda, cthunkGetList, cthunkGetPath, cthunkGetStr, cthunkMarkBlackhole, cthunkMarkPending, cthunkPayload, cthunkSetComputed, cthunkSetComputedAttrs, cthunkSetComputedBool, cthunkSetComputedCtxStr, cthunkSetComputedFloat, cthunkSetComputedInt, cthunkSetComputedLambda, cthunkSetComputedList, cthunkSetComputedNull, cthunkSetComputedPath, cthunkSetComputedStr, cthunkState, cthunkValueTag)
+import Nix.Eval.CanonPath (canonBaseName, canonPath)
 import Nix.Eval.Symbol (Symbol (..), symbolIntern, symbolText)
 import Nix.Eval.Types (AttrSet (..), Env (..), MonadEval (..), NixValue (..), Thunk (..), attrSetSize, emptyContext, marshalLambda, marshalStringContext, unmarshalLambdaValue, unmarshalStringContext, pattern ValueAttrs, pattern ValueBool, pattern ValueCtxStr, pattern ValueFloat, pattern ValueInt, pattern ValueLambda, pattern ValueList, pattern ValueNull, pattern ValuePath, pattern ValueStr)
 import Nix.Expr.Types (AttrKey (..), Binding (..), Expr (..), Formal (..), Formals (..), NixAtom (..), StringPart (..))
@@ -59,7 +61,7 @@ import qualified NovaCache.NAR as NAR
 import qualified System.Directory as Dir
 import System.Environment (lookupEnv)
 import System.Exit (ExitCode (..))
-import System.FilePath (isRelative, takeDirectory, takeFileName, (</>))
+import System.FilePath (isRelative, takeDirectory, (</>))
 import System.IO (hPutStrLn, stderr)
 import qualified System.Process as Proc
 
@@ -244,15 +246,42 @@ instance MonadEval EvalIO where
     ref <- asks esDrvClosure
     liftIO (modifyIORef' ref (Map.insert key aterm))
 
+  -- Read a .drv from the store on a modulo-hash cache miss (a cross-session or
+  -- appendContext reference).  Mirrors the build side's readDrvFromStore: map
+  -- to the on-disk path, read the raw bytes, decode UTF-8, parse the ATerm.
+  -- Any failure - absent file, bad encoding, malformed ATerm - is 'Nothing',
+  -- which the caller turns into a loud modulo-hash error.
+  readStoreDerivation sp = EvalIO $ do
+    let filePath = SP.storePathToFilePath SP.defaultStoreDir sp
+    result <- liftIO (try (BS.readFile filePath) :: IO (Either SomeException BS.ByteString))
+    pure $ case result of
+      Left _ -> Nothing
+      Right bytes -> case decodeUtf8' bytes of
+        Left _ -> Nothing
+        Right text -> either (const Nothing) Just (fromATerm text)
+
+  -- Look up a derivation recorded earlier this session by its .drv path,
+  -- reusing the esDrvClosure ATerm map (populated bottom-up by recordDrvAterm).
+  -- This recovers an in-session all-outputs reference's output names without a
+  -- disk read - the .drv is not written to the store until after evaluation.
+  lookupSessionDrv drvPathText = EvalIO $ do
+    ref <- asks esDrvClosure
+    closure <- liftIO (readIORef ref)
+    pure (Map.lookup drvPathText closure >>= either (const Nothing) Just . fromATerm)
+
   storeSourcePath rawPath = do
     ref <- EvalIO (asks esSourcePathCache)
     cached <- EvalIO (liftIO (Map.lookup rawPath <$> readIORef ref))
     case cached of
       Just hit -> pure hit
       Nothing -> do
+        -- Upstream names the copy baseNameOf(canonicalized path); path
+        -- values arrive canonicalized, so the last segment is the name.
+        let name = canonBaseName rawPath
+        when (T.null name) $
+          throwEvalError ("cannot copy '" <> rawPath <> "' to the store: the path has no base name")
         entry <- wrapIO (NAR.serialiseFromPath (T.unpack rawPath))
         let narDigest = sha256Digest (NAR.serialise entry)
-            name = T.pack (takeFileName (T.unpack rawPath))
             sp = makeFixedOutputPath name "sha256" "recursive" narDigest
             spText = SP.storePathToText SP.defaultStoreDir sp
         EvalIO (liftIO (modifyIORef' ref (Map.insert rawPath spText)))
@@ -399,10 +428,17 @@ instance MonadEval EvalIO where
 
   resolvePathLiteral path = do
     baseDir <- EvalIO (asks esBaseDir)
-    let raw = T.unpack path
-    if isRelative raw
-      then pure (T.pack (baseDir </> raw))
-      else pure path
+    -- ~/x resolves against the home directory (upstream lexes HPATH and
+    -- expands it at eval); everything else relative joins the base dir.
+    -- Both end in lexical canonicalization, so no dot segment, repeated
+    -- separator, or platform backslash survives into the path value.
+    expanded <- case T.stripPrefix "~/" path of
+      Just below -> do
+        home <- wrapIO Dir.getHomeDirectory
+        pure (home </> T.unpack below)
+      Nothing -> pure (T.unpack path)
+    let absolute = if isRelative expanded then baseDir </> expanded else expanded
+    pure (canonPath (T.pack absolute))
 
   forceThunk evalFn (Thunk ptr) = do
     -- Force protocol: PENDING to BLACKHOLE to COMPUTED with memoization.

--- a/src/Nix/Eval/StringInterp.hs
+++ b/src/Nix/Eval/StringInterp.hs
@@ -8,6 +8,8 @@ module Nix.Eval.StringInterp
   ( stripIndentedChunks,
     coerceToString,
     formatNixFloat,
+    formatJsonFloat,
+    formatXmlFloat,
   )
 where
 
@@ -15,7 +17,7 @@ import Data.List (foldl')
 import Data.Text (Text)
 import qualified Data.Text as T
 import Nix.Eval.Types (MonadEval (..), NixValue (..), StringContext, Thunk, attrSetLookup, emptyContext, typeName)
-import Numeric (showFFloat)
+import Numeric (floatToDigits, showFFloat)
 
 -- | Force a thunk to a value.
 type Force m = Thunk -> m NixValue
@@ -134,3 +136,127 @@ formatNixFloat n
       | otherwise = s
     dropDot ('.' : rest) = rest
     dropDot xs = xs
+
+-- | Format a finite float exactly as the JSON serializer upstream links
+-- (nlohmann @to_chars@): shortest round-trip digits, laid out as plain
+-- decimal only while the decimal point lands within positions
+-- 'jsonMinPointPos'..'jsonMaxPointPos', a @.0@ suffix on integral values,
+-- and otherwise @d.ddde+XX@ with a signed exponent of at least two digits.
+-- Zero is @0.0@ (sign preserved).  Digits come from 'floatToDigits', which
+-- is always shortest; nlohmann's grisu2 can emit a longer-than-shortest
+-- form for rare values, an accepted divergence.  Non-finite input is the
+-- caller's concern (JSON spells it @null@).
+formatJsonFloat :: Double -> Text
+formatJsonFloat d
+  | isNegativeZero d = "-0.0"
+  | d == 0 = "0.0"
+  | d < 0 = "-" <> formatJsonFloat (negate d)
+  | otherwise =
+      let (digitList, pointPos) = floatToDigits 10 d
+          digits = concatMap show digitList
+       in T.pack (jsonFloatLayout digits (length digits) pointPos)
+
+-- | Positional layout of shortest digits with the decimal point at
+-- @pointPos@, replicating nlohmann's @format_buffer@ branch by branch.
+jsonFloatLayout :: String -> Int -> Int -> String
+jsonFloatLayout digits digitCount pointPos
+  -- Integral value with the point in plain range: digits, zeros, ".0".
+  | digitCount <= pointPos && pointPos <= jsonMaxPointPos =
+      digits <> replicate (pointPos - digitCount) '0' <> ".0"
+  -- Point falls inside the digit run.
+  | 0 < pointPos && pointPos <= jsonMaxPointPos =
+      take pointPos digits <> "." <> drop pointPos digits
+  -- Small magnitude: leading "0." and padding zeros.
+  | jsonMinPointPos < pointPos && pointPos <= 0 =
+      "0." <> replicate (negate pointPos) '0' <> digits
+  -- Scientific notation.
+  | otherwise = mantissa <> "e" <> signedExponent (pointPos - 1)
+  where
+    mantissa = case digits of
+      [single] -> [single]
+      lead : rest -> lead : '.' : rest
+      [] -> "0" -- unreachable: a positive double yields at least one digit
+
+-- | nlohmann @format_buffer@ bounds (@kMaxExp@ = double's @digits10@,
+-- @kMinExp@): plain decimal only while the decimal point position is in
+-- (-4, 15]; everything else is scientific.
+jsonMaxPointPos :: Int
+jsonMaxPointPos = 15
+
+-- | Lower point-position bound, exclusive.  See 'jsonMaxPointPos'.
+jsonMinPointPos :: Int
+jsonMinPointPos = -4
+
+-- | Exponent suffix shared by the JSON and XML float layouts: sign always
+-- present, magnitude zero-padded to at least two digits (@+05@, @-21@).
+signedExponent :: Int -> String
+signedExponent e
+  | e < 0 = '-' : padded (negate e)
+  | otherwise = '+' : padded e
+  where
+    padded n
+      | n < 10 = '0' : show n
+      | otherwise = show n
+
+-- | Format a float as upstream @toXML@ renders one - C++ @operator<<@ on a
+-- default-format ostream: 6 significant digits, trailing zeros stripped,
+-- plain decimal only for decimal exponents in [-4, 5], otherwise
+-- @d.ddde+XX@ with a signed exponent of at least two digits.  Rounding is
+-- half-even on the exact binary value, matching a correctly-rounded printf.
+formatXmlFloat :: Double -> Text
+formatXmlFloat d
+  | isNaN d = "nan"
+  | isInfinite d = if d > 0 then "inf" else "-inf"
+  | d == 0 = if isNegativeZero d then "-0" else "0"
+  | d < 0 = "-" <> formatXmlFloat (negate d)
+  | otherwise = T.pack (xmlFloatPositive d)
+
+-- | 6-significant-digit @%g@ layout of a positive finite double.
+xmlFloatPositive :: Double -> String
+xmlFloatPositive d =
+  let exact = toRational d
+      roughExp = decimalExponentOf exact
+      rounded = round (exact * 10 ^^ (xmlSigDigits - 1 - roughExp)) :: Integer
+      -- Rounding can carry into a new leading digit (999999.9 -> 1000000).
+      (sigDigits, pointExp) =
+        if rounded >= 10 ^ xmlSigDigits
+          then (rounded `div` 10, roughExp + 1)
+          else (rounded, roughExp)
+      digits = show sigDigits
+   in if xmlMinFixedExp <= pointExp && pointExp < xmlSigDigits
+        then fixedForm digits pointExp
+        else sciForm digits pointExp
+  where
+    fixedForm digits pointExp
+      | pointExp >= 0 =
+          let (intPart, fracPart) = splitAt (pointExp + 1) digits
+           in joinFraction intPart (stripTrailingZeros fracPart)
+      | otherwise =
+          joinFraction "0" (stripTrailingZeros (replicate (negate pointExp - 1) '0' <> digits))
+    sciForm digits pointExp =
+      joinFraction (take 1 digits) (stripTrailingZeros (drop 1 digits))
+        <> "e"
+        <> signedExponent pointExp
+    joinFraction intPart fracPart
+      | null fracPart = intPart
+      | otherwise = intPart <> "." <> fracPart
+    stripTrailingZeros = reverse . dropWhile (== '0') . reverse
+
+-- | @%g@ default precision: 6 significant digits.
+xmlSigDigits :: Int
+xmlSigDigits = 6
+
+-- | @%g@ switches to scientific below a decimal exponent of -4.
+xmlMinFixedExp :: Int
+xmlMinFixedExp = -4
+
+-- | The decimal exponent @e@ of a positive rational: the unique @e@ with
+-- @10^e <= r < 10^(e+1)@.  A float log gives the estimate; the exact
+-- comparisons correct it, since the log is off by one near powers of ten.
+decimalExponentOf :: Rational -> Int
+decimalExponentOf r = correct (floor (logBase 10 (fromRational r :: Double)))
+  where
+    correct e
+      | 10 ^^ e > r = correct (e - 1)
+      | 10 ^^ (e + 1) <= r = correct (e + 1)
+      | otherwise = e

--- a/src/Nix/Eval/Types.hs
+++ b/src/Nix/Eval/Types.hs
@@ -129,6 +129,7 @@ import Nix.Eval.CEnv (NnEnv, cenvAllocSlots, cenvAllocWithScopes, cenvEmpty, cen
 import Nix.Eval.CLambda (clambdaAllowExtra, clambdaBody, clambdaEntryDefault, clambdaEntryHasDefault, clambdaEntryName, clambdaEnv, clambdaFormalCount, clambdaFormalsType, clambdaNameSym, clambdaNew, clambdaSetEntry)
 import Nix.Eval.CList (CList (..), clistFromThunks, clistLen, clistThunks, emptyCList)
 import Nix.Eval.CThunk (CThunkPtr, cthunkGetAttrs, cthunkGetBcIdx, cthunkGetBool, cthunkGetCtxStr, cthunkGetFloat, cthunkGetInt, cthunkGetList, cthunkGetPath, cthunkGetStr, cthunkNewBc, cthunkNewComputed, cthunkNewComputedAttrs, cthunkNewComputedBool, cthunkNewComputedCtxStr, cthunkNewComputedFloat, cthunkNewComputedInt, cthunkNewComputedLambda, cthunkNewComputedList, cthunkNewComputedNull, cthunkNewComputedPath, cthunkNewComputedStr, cthunkPayload, cthunkState, cthunkValueTag)
+import Nix.Eval.CanonPath (canonPath)
 import Nix.Eval.Compile (compileExpr, compileFormalsToEval)
 import Nix.Eval.EvalFormals (EvalFormal (..), EvalFormals (..))
 import Nix.Eval.Symbol (Symbol (..), symbolIntern, symbolText)
@@ -1106,11 +1107,14 @@ class (Monad m) => MonadEval m where
   -- | Run an external process: @(command, args, stdin) -> (exitCode, stdout, stderr)@.
   runProcess :: Text -> [Text] -> Text -> m (Int, Text, Text)
 
-  -- | Resolve a path literal to an absolute path.
-  -- In IO evaluation, relative paths are resolved against the current
-  -- file's directory (@esBaseDir@).  In pure evaluation, paths are
-  -- returned unchanged.  This ensures that path values captured in
-  -- closures remain valid after the import scope ends.
+  -- | Resolve a path literal to a canonical path.
+  -- In IO evaluation, @~/@ resolves against the home directory and other
+  -- relative paths resolve against the current file's directory
+  -- (@esBaseDir@); this ensures that path values captured in closures
+  -- remain valid after the import scope ends.  In pure evaluation the
+  -- text is not absolutized.  Every implementation ends with lexical
+  -- canonicalization ('Nix.Eval.CanonPath.canonPath'), as upstream: no
+  -- dot segment or repeated separator survives into a path value.
   resolvePathLiteral :: Text -> m Text
 
   -- | Copy a path (file or directory) to the store, returning the store
@@ -1166,6 +1170,23 @@ class (Monad m) => MonadEval m where
   -- build driver can materialize the entire input-@.drv@ closure to the store
   -- before a dependency-aware build.  A no-op in pure evaluators.
   recordDrvAterm :: Text -> Text -> m ()
+
+  -- | Read and parse a derivation from its @.drv@ in the store, or 'Nothing'
+  -- if it is absent or unreadable.  Used to resolve an input derivation's
+  -- modulo hash on a cache miss - a cross-session reference, or a path
+  -- fabricated by @builtins.appendContext@ - where the referenced derivation
+  -- was not evaluated this session.  Reading the store is an effect, so this
+  -- is an IO-evaluator capability: pure evaluators return 'Nothing', which
+  -- makes hashing a dependent derivation something only the IO evaluator can do.
+  readStoreDerivation :: StorePath -> m (Maybe Derivation)
+
+  -- | Look up a derivation evaluated earlier THIS session by its @.drv@ store
+  -- path, or 'Nothing' if it was not.  The IO evaluator reads the ATerm it
+  -- recorded bottom-up ('recordDrvAterm'); pure evaluators return 'Nothing'.
+  -- Used to recover a referenced derivation's output names for an all-outputs
+  -- (DrvDeep) context reference without a disk read - the in-session @.drv@ is
+  -- not on disk during evaluation.
+  lookupSessionDrv :: Text -> m (Maybe Derivation)
 
   -- | Compute the store path a source file/directory gets when copied into
   -- the store (recursive NAR sha256 to a @source@ fixed-output path), WITHOUT
@@ -1226,10 +1247,19 @@ instance MonadEval PureEval where
   cacheDrvHash _ _ = pure ()
   recordDrvAterm _ _ = pure ()
 
+  -- Pure eval cannot read the store, so a dependent derivation's input hash
+  -- is never recoverable here; the caller turns this into a loud error rather
+  -- than a guessed hash.
+  readStoreDerivation _ = pure Nothing
+
+  -- Pure eval keeps no session drv closure, so an all-outputs reference's
+  -- output names are never recoverable here either.
+  lookupSessionDrv _ = pure Nothing
+
   -- Pure eval cannot read files: a path coerces to itself (no store copy);
   -- the real copy-to-store happens only under 'EvalIO'.
   storeSourcePath = pure
-  resolvePathLiteral = pure
+  resolvePathLiteral = pure . canonPath
   forceThunk evalFn (Thunk ptr) =
     -- Read the C thunk via unsafePerformIO - safe because reads are
     -- idempotent and PureEval never writes back (no memoization).

--- a/src/Nix/Hash.hs
+++ b/src/Nix/Hash.hs
@@ -36,6 +36,10 @@ module Nix.Hash
     byteToHex,
     hexToBytes,
     rawHashWithAlgo,
+    hashAlgoBytes,
+    hexHashLen,
+    nix32HashLen,
+    base64HashLen,
 
     -- * Store path construction (Nix @makeStorePath@ family)
     makeStorePath,
@@ -159,6 +163,33 @@ rawHashWithAlgo algo bytes = case algo of
   "sha1" -> Just (BA.convert (CH.hash bytes :: CH.Digest CH.SHA1))
   "md5" -> Just (BA.convert (CH.hash bytes :: CH.Digest CH.MD5))
   _ -> Nothing
+
+-- | Raw digest size in bytes of a supported hash algorithm.  'Nothing' for
+-- an unknown algorithm name.
+hashAlgoBytes :: Text -> Maybe Int
+hashAlgoBytes algo = case algo of
+  "md5" -> Just 16
+  "sha1" -> Just 20
+  "sha256" -> Just 32
+  "sha512" -> Just 64
+  _ -> Nothing
+
+-- The three spelling lengths of an @n@-byte digest, mirroring upstream
+-- (@hash.cc@ @base16Len@\/@base32Len@\/@base64Len@).  For every supported
+-- digest size the three lengths are pairwise distinct, which is what makes
+-- length-keyed hash-format detection sound.
+
+-- | Character length of an @n@-byte digest spelled in base-16.
+hexHashLen :: Int -> Int
+hexHashLen n = 2 * n
+
+-- | Character length of an @n@-byte digest spelled in nix-base32.
+nix32HashLen :: Int -> Int
+nix32HashLen n = (8 * n - 1) `div` 5 + 1
+
+-- | Character length of an @n@-byte digest spelled in padded base64.
+base64HashLen :: Int -> Int
+base64HashLen n = 4 * ((n + 2) `div` 3)
 
 -- | The core store-path construction primitive.  Given a @type@ string, the
 -- inner content digest (raw SHA-256 bytes), and a name, produce the store

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -26,7 +26,7 @@ import Nix.Builder (BuildConfig (..), BuildResult (..), buildDerivation, buildWi
 import Nix.Builder.Unpack (builtinUnpackBuilder, entryComponents, envSrcs, resolveLinkTarget)
 import Nix.Builtins (builtinEnv, parseNixPath)
 import qualified Nix.DependencyGraph as DepGraph
-import Nix.Derivation (Derivation (..), DerivationOutput (..), Platform (..), currentPlatform, fromATerm, platformToText, toATerm)
+import Nix.Derivation (Derivation (..), DerivationOutput (..), Platform (..), currentPlatform, fromATerm, platformToText, toATerm, toATermForHash)
 import Nix.Eval (NixValue (..), StringContext (..), StringContextElement (..), attrSetFromMap, attrSetLookup, attrSetNull, attrSetSize, builtinNames, emptyContext, emptyEnv, eval, force, mkStr, readThunkValue, runPureEval)
 import Nix.Eval.Arena (arenaDestroy, arenaInit)
 import Nix.Eval.CAttrSet (cattrsetFreeze, cattrsetInsert, cattrsetKeys, cattrsetLookup, cattrsetNew, cattrsetSize, cattrsetUnion)
@@ -2030,12 +2030,23 @@ testBatchB = do
           assertEqual "different" (VBool False) val,
       runTest "placeholder type error" $
         assertEvalFail "placeholder-err" "builtins.placeholder 42",
-      -- storePath
-      runTest "storePath valid" $
+      -- storePath returns a STRING marked already-in-store (SCPlain context),
+      -- not a bare path - the marker is what stops a later coercion re-NARing it.
+      runTest "storePath returns an in-store string" $
         assertEval
-          "storePath-valid"
-          "builtins.storePath \"/nix/store/s66mzxpvicwk07gjbjfw9izjfa797vsw-hello-2.12.1\""
-          (VPath "/nix/store/s66mzxpvicwk07gjbjfw9izjfa797vsw-hello-2.12.1"),
+          "storePath-isstring"
+          "builtins.isString (builtins.storePath \"/nix/store/s66mzxpvicwk07gjbjfw9izjfa797vsw-hello-2.12.1\")"
+          (VBool True),
+      runTest "storePath result carries a plain-path context" $
+        assertEval
+          "storePath-hasctx"
+          "(builtins.getContext (builtins.storePath \"/nix/store/s66mzxpvicwk07gjbjfw9izjfa797vsw-hello-2.12.1\")).\"/nix/store/s66mzxpvicwk07gjbjfw9izjfa797vsw-hello-2.12.1\".path"
+          (VBool True),
+      runTest "storePath preserves the path text" $
+        assertEval
+          "storePath-text"
+          "builtins.unsafeDiscardStringContext (builtins.storePath \"/nix/store/s66mzxpvicwk07gjbjfw9izjfa797vsw-hello-2.12.1\")"
+          (mkStr "/nix/store/s66mzxpvicwk07gjbjfw9izjfa797vsw-hello-2.12.1"),
       runTest "storePath invalid" $
         assertEvalFail "storePath-bad" "builtins.storePath \"/tmp/not-a-store-path\"",
       runTest "storePath type error" $
@@ -2500,10 +2511,11 @@ testDrvContext = do
       -- appendContext: empty context is no-op
       runTest "appendContext empty is no-op" $
         assertEval "appendCtx-empty" "builtins.hasContext (builtins.appendContext \"hello\" {})" (VBool False),
-      -- unsafeDiscardOutputDependency: strips drv context, keeps plain
-      runTest "discardOutputDep strips drv context"
+      -- unsafeDiscardOutputDependency KEEPS a derivation-output (Built) ref
+      -- unchanged (upstream), rather than dropping it as it once did.
+      runTest "discardOutputDep keeps output-dependency context"
         $ assertRight
-          "discardOutDep"
+          "discardOutDep-keep"
           ( evalNix $
               T.concat
                 [ "let d = derivation { name = \"test\"; system = \"x86_64-linux\"; builder = \"/bin/sh\"; }; ",
@@ -2511,7 +2523,42 @@ testDrvContext = do
                   "in builtins.hasContext stripped"
                 ]
           )
-        $ \val -> assertEqual "no-ctx" (VBool False) val,
+        $ \val -> assertEqual "keep-ctx" (VBool True) val,
+      -- ctx3: an all-outputs (DrvDeep) reference on d.drvPath is DOWNGRADED to
+      -- a plain path reference, not dropped.
+      runTest "discardOutputDep downgrades drvPath to a plain ref" $
+        assertEval
+          "discardOutDep-downgrade"
+          "let d = derivation { name = \"test\"; system = \"x86_64-linux\"; builder = \"/bin/sh\"; }; ctx = builtins.getContext (builtins.unsafeDiscardOutputDependency d.drvPath); key = builtins.elemAt (builtins.attrNames ctx) 0; in ctx.${key} == { path = true; }"
+          (VBool True),
+      -- ctx4: getContext renders each path's output names ascending.
+      runTest "getContext output names are ascending" $
+        assertEval
+          "getctx-ascending"
+          "let d = derivation { name = \"test\"; system = \"x86_64-linux\"; builder = \"/bin/sh\"; outputs = [ \"out\" \"dev\" \"lib\" ]; }; s = \"${d.out}${d.lib}${d.dev}\"; ctx = builtins.getContext s; key = builtins.elemAt (builtins.attrNames ctx) 0; in ctx.${key}.outputs == [ \"dev\" \"lib\" \"out\" ]"
+          (VBool True),
+      -- ctx5: addDrvOutputDependencies upgrades a plain .drv reference back to
+      -- an all-outputs reference (the inverse of the ctx3 downgrade).
+      runTest "addDrvOutputDependencies upgrades a plain drv ref" $
+        assertEval
+          "adddrvout-upgrade"
+          "let d = derivation { name = \"test\"; system = \"x86_64-linux\"; builder = \"/bin/sh\"; }; plain = builtins.unsafeDiscardOutputDependency d.drvPath; ctx = builtins.getContext (builtins.addDrvOutputDependencies plain); key = builtins.elemAt (builtins.attrNames ctx) 0; in ctx.${key} == { allOutputs = true; }"
+          (VBool True),
+      runTest "addDrvOutputDependencies rejects a derivation output" $
+        assertEvalFail
+          "adddrvout-built"
+          "let d = derivation { name = \"test\"; system = \"x86_64-linux\"; builder = \"/bin/sh\"; }; in builtins.addDrvOutputDependencies d.outPath",
+      runTest "addDrvOutputDependencies rejects a multi-element context" $
+        assertEvalFail
+          "adddrvout-multi"
+          "let d = derivation { name = \"test\"; system = \"x86_64-linux\"; builder = \"/bin/sh\"; }; in builtins.addDrvOutputDependencies \"${d.drvPath}${d.outPath}\"",
+      -- drv1: a derivation embedding another's drvPath (an all-outputs ref)
+      -- needs the referenced .drv's output names, which only the IO evaluator
+      -- supplies; pure eval fails loudly rather than dropping the reference.
+      runTest "deep drvPath reference fails loudly in pure eval" $
+        assertEvalFail
+          "drv1-pure-miss"
+          "let dep = derivation { name = \"dep\"; system = \"x86_64-linux\"; builder = \"/bin/sh\"; }; main = derivation { name = \"main\"; system = \"x86_64-linux\"; builder = \"/bin/sh\"; ref = dep.drvPath; }; in main.drvPath",
       -- derivation outPath is a string (not path) with context
       runTest "drv outPath is VStr"
         $ assertRight
@@ -3015,21 +3062,57 @@ testBuildOrchestrator = do
          in case DepGraph.buildDepGraph readFn drv (StorePath "rrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr" "root.drv") of
               Left _ -> Pass
               Right _ -> Fail "expected failure for missing .drv",
-      -- derivation with context creates populated inputDrvs
-      runTest "derivation context populates inputDrvs"
-        $ assertRight
-          "drv-ctx-inputs"
-          ( evalNix $
-              T.concat
-                [ "let dep = derivation { name = \"dep\"; system = \"x86_64-linux\"; builder = \"/bin/sh\"; }; ",
-                  "main = derivation { name = \"main\"; system = \"x86_64-linux\"; builder = \"/bin/sh\"; src = dep.outPath; }; ",
-                  "in main._derivation"
-                ]
-          )
-        $ \case
+      -- derivation with context creates populated inputDrvs.  Hashing a
+      -- dependent derivation reads input modulo hashes from the drv-hash
+      -- cache, which only the IO evaluator maintains, so this runs under
+      -- evalNixIO (an in-session dependency hits the cache bottom-up).
+      runTestM "derivation context populates inputDrvs" $ do
+        tmpBase <- getTemporaryDirectory
+        result <-
+          evalNixIO tmpBase $
+            T.concat
+              [ "let dep = derivation { name = \"dep\"; system = \"x86_64-linux\"; builder = \"/bin/sh\"; }; ",
+                "main = derivation { name = \"main\"; system = \"x86_64-linux\"; builder = \"/bin/sh\"; src = dep.outPath; }; ",
+                "in main._derivation"
+              ]
+        pure $ assertRight "drv-ctx-inputs" result $ \case
           VDerivation drv ->
             if Map.null (drvInputDrvs drv)
               then Fail "expected non-empty drvInputDrvs"
+              else Pass
+          _ -> Fail "expected VDerivation",
+      -- drv3: a dependent derivation's drvPath is stable across evaluations
+      -- (the input modulo substitution is deterministic).
+      runTestM "dependent derivation drvPath is deterministic (IO eval)" $ do
+        tmpBase <- getTemporaryDirectory
+        let expr =
+              T.concat
+                [ "let dep = derivation { name = \"dep\"; system = \"x86_64-linux\"; builder = \"/bin/sh\"; }; ",
+                  "main = derivation { name = \"main\"; system = \"x86_64-linux\"; builder = \"/bin/sh\"; src = dep.outPath; }; ",
+                  "in main.drvPath"
+                ]
+        r1 <- evalNixIO tmpBase expr
+        r2 <- evalNixIO tmpBase expr
+        pure $ case (r1, r2) of
+          (Right (VStr a _), Right (VStr b _))
+            | a == b -> Pass
+            | otherwise -> Fail ("drvPath not deterministic: " <> a <> " vs " <> b)
+          _ -> Fail "expected main.drvPath to evaluate to a string under IO eval",
+      -- drv1: embedding another derivation's drvPath (an all-outputs ref) adds
+      -- it to inputDrvs; the IO evaluator recovers its output names in-session.
+      runTestM "derivation embedding a drvPath lists it in inputDrvs (IO eval)" $ do
+        tmpBase <- getTemporaryDirectory
+        result <-
+          evalNixIO tmpBase $
+            T.concat
+              [ "let dep = derivation { name = \"dep\"; system = \"x86_64-linux\"; builder = \"/bin/sh\"; }; ",
+                "main = derivation { name = \"main\"; system = \"x86_64-linux\"; builder = \"/bin/sh\"; ref = dep.drvPath; }; ",
+                "in main._derivation"
+              ]
+        pure $ assertRight "drv1-deep-io" result $ \case
+          VDerivation drv ->
+            if Map.null (drvInputDrvs drv)
+              then Fail "expected dep in inputDrvs via the deep drvPath ref"
               else Pass
           _ -> Fail "expected VDerivation"
     ]
@@ -3854,6 +3937,127 @@ testDependentBuildIO = do
               Fail ("dependency-aware build failed (exit " <> T.pack (show code) <> "): " <> msg)
           ]
 
+-- | Upstream value-conformance tests: each pins exact output bytes (hash
+-- decode, number formatting) that must match what upstream Nix computes for
+-- the same input, because these values can reach names, derivations, and
+-- hashes.
+testUpstreamConformance :: IO [Bool]
+testUpstreamConformance = do
+  putStrLn "eval/conformance"
+  sequence
+    [ -- Hash decode is length-keyed per algorithm, never first-format-wins:
+      -- a 52-char all-hex-digit string is a nix32 sha256 hash (64 hex chars
+      -- after conversion), not a 26-byte hex string echoed back.
+      runTest "hash decode keys on nix32 length" $
+        assertEval
+          "hash-nix32-length"
+          "builtins.stringLength (builtins.convertHash { hash = \"0aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"; hashAlgo = \"sha256\"; toHashFormat = \"base16\"; })"
+          (VInt 64),
+      runTest "hash hex to nix32 round-trips" $
+        assertEval
+          "hash-roundtrip"
+          "builtins.convertHash { hash = builtins.convertHash { hash = \"sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\"; toHashFormat = \"nix32\"; }; hashAlgo = \"sha256\"; toHashFormat = \"base16\"; }"
+          (mkStr "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"),
+      runTest "hash base64 spelling decodes by length" $
+        assertEval
+          "hash-base64"
+          "builtins.convertHash { hash = \"sha256:47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=\"; toHashFormat = \"base16\"; }"
+          (mkStr "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"),
+      runTest "truncated hash is rejected" $
+        assertEvalFail
+          "hash-truncated"
+          "builtins.convertHash { hash = \"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b85\"; hashAlgo = \"sha256\"; toHashFormat = \"base16\"; }",
+      runTest "unknown hash algorithm is rejected" $
+        assertEvalFail
+          "hash-bad-algo"
+          "builtins.convertHash { hash = \"00\"; hashAlgo = \"sha3\"; toHashFormat = \"base16\"; }",
+      -- toJSON floats: nlohmann's layout - shortest round-trip digits, .0
+      -- kept on integral values, scientific outside point positions (-4, 15].
+      runTest "toJSON float shortest digits" $
+        assertEval "json-float-third" "builtins.toJSON (1.0 / 3.0)" (mkStr "0.3333333333333333"),
+      runTest "toJSON integral float keeps .0" $
+        assertEval "json-float-integral" "builtins.toJSON 100.0" (mkStr "100.0"),
+      runTest "toJSON float plain decimal" $
+        assertEval "json-float-tenth" "builtins.toJSON 0.1" (mkStr "0.1"),
+      runTest "toJSON float zero" $
+        assertEval "json-float-zero" "builtins.toJSON 0.0" (mkStr "0.0"),
+      runTest "toJSON float widest plain integral" $
+        assertEval "json-float-e14" "builtins.toJSON 1.0e14" (mkStr "100000000000000.0"),
+      runTest "toJSON float first scientific integral" $
+        assertEval "json-float-e15" "builtins.toJSON 1.0e15" (mkStr "1e+15"),
+      runTest "toJSON float large exponent" $
+        assertEval "json-float-e21" "builtins.toJSON 1.0e21" (mkStr "1e+21"),
+      runTest "toJSON float negative exponent" $
+        assertEval "json-float-e-5" "builtins.toJSON 1.0e-5" (mkStr "1e-05"),
+      runTest "toJSON float smallest plain" $
+        assertEval "json-float-e-4" "builtins.toJSON 1.0e-4" (mkStr "0.0001"),
+      runTest "toJSON non-finite float is null" $
+        assertEval "json-float-inf" "builtins.toJSON (1.0e308 * 10.0)" (mkStr "null"),
+      -- fromJSON integers: int64 range stays int, wider falls back to float.
+      runTest "fromJSON promotes past-64-bit integer to float" $
+        assertEval "json-bigint-type" "builtins.typeOf (builtins.fromJSON \"999999999999999999999\")" (mkStr "float"),
+      runTest "fromJSON past-64-bit integer value" $
+        assertEval "json-bigint-val" "builtins.fromJSON \"999999999999999999999\" == 999999999999999999999.0" (VBool True),
+      runTest "fromJSON int64 max stays an int" $
+        assertEval "json-int64-max" "builtins.fromJSON \"9223372036854775807\"" (VInt 9223372036854775807),
+      -- toXML floats: C++ default ostream formatting, 6 significant digits.
+      runTest "toXML float 6 significant digits" $
+        assertEval
+          "xml-float-third"
+          "builtins.toXML (1.0 / 3.0)"
+          (mkStr "<?xml version='1.0' encoding='utf-8'?>\n<expr>\n<float value=\"0.333333\" />\n</expr>\n"),
+      runTest "toXML float plain decimal" $
+        assertEval
+          "xml-float-centi"
+          "builtins.toXML 0.01"
+          (mkStr "<?xml version='1.0' encoding='utf-8'?>\n<expr>\n<float value=\"0.01\" />\n</expr>\n"),
+      runTest "toXML integral float drops the point" $
+        assertEval
+          "xml-float-integral"
+          "builtins.toXML 100.0"
+          (mkStr "<?xml version='1.0' encoding='utf-8'?>\n<expr>\n<float value=\"100\" />\n</expr>\n"),
+      runTest "toXML float large exponent" $
+        assertEval
+          "xml-float-e21"
+          "builtins.toXML 1.0e21"
+          (mkStr "<?xml version='1.0' encoding='utf-8'?>\n<expr>\n<float value=\"1e+21\" />\n</expr>\n"),
+      runTest "toXML float small exponent" $
+        assertEval
+          "xml-float-e-5"
+          "builtins.toXML 2.5e-5"
+          (mkStr "<?xml version='1.0' encoding='utf-8'?>\n<expr>\n<float value=\"2.5e-05\" />\n</expr>\n"),
+      -- fromTOML integers: 64-bit signed range enforced, no silent wrap.
+      runTest "fromTOML rejects past-64-bit integer" $
+        assertEvalFail "toml-int-overflow" "builtins.fromTOML \"v = 99999999999999999999\"",
+      runTest "fromTOML rejects past-64-bit hex integer" $
+        assertEvalFail "toml-hex-overflow" "builtins.fromTOML \"v = 0xffffffffffffffff\"",
+      runTest "fromTOML int64 max parses" $
+        assertEval "toml-int64-max" "(builtins.fromTOML \"v = 9223372036854775807\").v" (VInt 9223372036854775807),
+      runTest "fromTOML int64 min parses" $
+        assertEval "toml-int64-min" "(builtins.fromTOML \"v = -9223372036854775808\").v == (0 - 9223372036854775807 - 1)" (VBool True),
+      -- drv3: pure eval cannot read the store, so hashing a dependent
+      -- derivation fails loudly rather than emitting a guessed input hash.
+      runTest "dependent derivation drvPath fails loudly in pure eval" $
+        assertEvalFail
+          "drv-modulo-pure-miss"
+          "let dep = derivation { name = \"dep\"; system = \"x86_64-linux\"; builder = \"/bin/sh\"; }; main = derivation { name = \"main\"; system = \"x86_64-linux\"; builder = \"/bin/sh\"; src = dep.outPath; }; in main.drvPath",
+      -- Path values canonicalize lexically (CanonPath): no dot segment or
+      -- doubled separator survives into a path value's text, so different
+      -- spellings of the same path compare equal.
+      runTest "path literal canonicalizes dot segments" $
+        assertEval "path-canon-dot" "builtins.toString ./. == builtins.toString ./x/.." (VBool True),
+      runTest "path literal collapses inner dot" $
+        assertEval "path-canon-inner" "builtins.toString ./a/./b == builtins.toString ./a/b" (VBool True),
+      runTest "path plus string canonicalizes" $
+        assertEval "path-canon-plus" "./a + \"/../b\" == ./b" (VBool True),
+      runTest "toPath canonicalizes" $
+        assertEval "path-canon-topath" "builtins.toString (builtins.toPath \"/a/../b\")" (mkStr "/b"),
+      runTest "toPath collapses inner dot" $
+        assertEval "path-canon-topath-dot" "builtins.toString (builtins.toPath \"/a/./b\")" (mkStr "/a/b"),
+      runTest "toPath preserves forward-slash root" $
+        assertEval "path-canon-topath-root" "builtins.toString (builtins.toPath \"//nix//store\")" (mkStr "/nix/store")
+    ]
+
 -- | Eval-fidelity regression tests: each pins a semantic where the evaluator
 -- must match upstream Nix.  All are parity-safe - none affects a derivation
 -- or store-path hash.
@@ -4570,6 +4774,26 @@ testFromATerm = do
       -- Round-trip: complex derivation
       runTest "fromATerm round-trip complex" $
         assertEqual "complex round-trip" (Right complexTestDrv) (fromATerm (toATerm complexTestDrv)),
+      -- drv4: the modulo-substitution section merges input-drv entries that
+      -- share a modulo-hash key, unioning their output-name sets, so it is
+      -- byte-identical to the already-merged form.  (Just subs replaces the
+      -- whole input-drv section, so simpleTestDrv's own inputs are irrelevant.)
+      runTest "inputDrvsSubst merges equal modulo keys" $
+        assertEqual
+          "subst-merge"
+          (toATermForHash False (Just [("00000000", ["dev", "out"])]) simpleTestDrv)
+          (toATermForHash False (Just [("00000000", ["out"]), ("00000000", ["dev"])]) simpleTestDrv),
+      runTest "inputDrvsSubst unions and dedups merged out-names" $
+        assertEqual
+          "subst-union"
+          (toATermForHash False (Just [("aabbccdd", ["dev", "out"])]) simpleTestDrv)
+          (toATermForHash False (Just [("aabbccdd", ["out"]), ("aabbccdd", ["out", "dev"])]) simpleTestDrv),
+      -- Distinct keys are untouched: still one entry each, ascending by key.
+      runTest "inputDrvsSubst preserves distinct keys in order" $
+        assertEqual
+          "subst-distinct"
+          (toATermForHash False (Just [("00000000", ["out"]), ("11111111", ["out"])]) simpleTestDrv)
+          (toATermForHash False (Just [("11111111", ["out"]), ("00000000", ["out"])]) simpleTestDrv),
       -- Round-trip: empty derivation (no outputs, no inputs, no args, no env)
       runTest "fromATerm round-trip empty" $
         let emptyDrv =
@@ -6150,6 +6374,7 @@ main = bracket_ arenaInit arenaDestroy $ do
           testUnpackBuildIO,
           testDependentBuildIO,
           testEvalFidelity,
+          testUpstreamConformance,
           testHashHelpers,
           testNarKnownAnswer,
           testEvalLiterals,


### PR DESCRIPTION
Brings evaluator output into byte-identical agreement with upstream Nix across the
verified Class I conformance findings. Four root-cause groups, each with regression
tests; the byte-string representation layer is deliberately left out and tracked in
**#34** for its own change.

## What's here

- **Hash decode** is length-keyed per algorithm (was first-format-wins), rejecting
  truncated or wrong-length hashes. Covers `convertHash`, fetch pins, fixed-output
  `outputHash`.
- **Number formatting** — `toJSON` floats use nlohmann shortest-round-trip; `toXML`
  floats use C++ ostream 6-significant-digit; `fromJSON` promotes an out-of-int64
  integer to a float; `fromTOML` rejects an out-of-int64 integer.
- **Path canonicalization** (`Nix.Eval.CanonPath`) applied at every path-production
  site — literals, `~/`, `toPath`, `+`, search-path lookup, store-copy naming.
- **Derivation modulo hashing** — merge duplicate modulo keys (upstream
  `std::map<Hash, StringSet>`); on a cache miss read the referenced `.drv` and recurse
  rather than substituting a wrong store hash. Dependent-derivation hashing needs the
  store, so it is an IO-evaluator capability; pure eval fails loudly.
- **String-context algebra** — all-outputs (DrvDeep) refs flow into `inputDrvs` with
  all output names (the nixpkgs blocker); `storePath` returns an in-store string (no
  re-NAR, fixes a Windows crash); `concatStringsSep` copies path elements;
  `unsafeDiscardOutputDependency` downgrades all-outputs and keeps Built; `getContext`
  orders outputs ascending; `addDrvOutputDependencies` is bound.

The context-element layer needed no C changes — all three element kinds already had
faithful representations on both the Haskell and C sides.

## Verification

`cabal test` 921/921; `cabal build --enable-tests --ghc-options="-Werror"` clean;
`ormolu` and `hlint` clean on all changed files.

## Not in this PR

- **#34** the byte-string layer (`substring`/`stringLength`/`match`/`split`/`readFile`
  by byte) — its correct fix is switching `VStr` from `Text` to `ByteString`, a core-
  type migration that lands separately. Design is captured on #34.
- **#35** Windows executable-bit model and **#36** `__structuredAttrs` — parked design
  and feature work.

Fixes #31, fixes #32, fixes #33.