### PR TITLE
Eval: byte-indexed string semantics - VStr carries ByteString

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -21,10 +21,13 @@ module Main (main) where
 
 import Control.Exception (IOException, displayException, try)
 import Control.Monad (void, (>=>))
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as BC
 import Data.IORef (readIORef)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (catMaybes)
 import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
 import qualified Data.Text.IO as TIO
 import Nix.Builder (BuildConfig (..), BuildResult (..), buildWithDeps, defaultBuildConfig)
 import Nix.Builtins (builtinEnv, parseNixPath)
@@ -32,7 +35,7 @@ import Nix.Derivation (Derivation (..), DerivationOutput (..), toATerm)
 import Nix.Eval (MonadEval, NixValue (..), Thunk (..), attrSetFromMap, attrSetLookup, attrSetToAscList, attrSetToMap, eval, evaluated, force, readThunkValue)
 import Nix.Eval.Arena (arenaInit)
 import Nix.Eval.IO (EvalState (..), newEvalState, runEvalIO)
-import Nix.Eval.Types (clistFromThunks, clistThunks, thunkToCPtr)
+import Nix.Eval.Types (bytesToTextLossy, clistFromThunks, clistThunks, thunkToCPtr)
 import Nix.Parser (parseNix, readFileAutoEncoding)
 import Nix.Push (PushConfig (..), PushSummary (..), loadApiKeyFile, pushPaths)
 import Nix.Store (Store (..), closeStore, materializeEvalSources, openStore, queryAllValidPaths, writeDrv, writeDrvAterm)
@@ -280,7 +283,9 @@ evalExprAterm extraPaths dataDir source =
           exitFailure
         Right val -> do
           (drv, _) <- extractDerivation val
-          TIO.putStrLn (toATerm drv)
+          -- Raw ATerm bytes (BC.putStrLn bypasses the handle encoding),
+          -- so the printed .drv diffs byte-exactly against upstream's.
+          BC.putStrLn (toATerm drv)
 
 -- | Parse, evaluate, extract derivation, build, and print result.
 -- The file argument is canonicalized for the same reason as in 'evalFile'.
@@ -352,12 +357,16 @@ extractDerivation (VAttrs attrs) = do
       exitFailure
   -- Extract drvPath - this is the store path of the .drv file itself,
   -- computed by hashing the ATerm serialization during evaluation.
+  -- Store paths are ASCII, so the byte payload decodes strictly.
   drvSP <- case attrSetLookup "drvPath" attrs of
-    Just thunk | Just (VStr path _) <- readThunkValue thunk -> case parseStorePath defaultStoreDir path of
-      Just sp -> pure sp
-      Nothing -> do
-        TIO.hPutStrLn stderr ("error: invalid drvPath: " <> path)
-        exitFailure
+    Just thunk
+      | Just (VStr pathBytes _) <- readThunkValue thunk,
+        Right path <- TE.decodeUtf8' pathBytes ->
+          case parseStorePath defaultStoreDir path of
+            Just sp -> pure sp
+            Nothing -> do
+              TIO.hPutStrLn stderr ("error: invalid drvPath: " <> path)
+              exitFailure
     _ -> do
       hPutStrLn stderr "error: derivation result missing drvPath"
       exitFailure
@@ -393,7 +402,7 @@ substituterConfig (Just url) (Just key) =
 -- | Write the .drv file to the store and build with dependency resolution.
 -- The drvPath is the store path of the .drv file itself, extracted from
 -- the evaluation result alongside the Derivation struct.
-buildAndRegister :: Store -> [CacheConfig] -> Map.Map T.Text T.Text -> Derivation -> StorePath -> IO BuildResult
+buildAndRegister :: Store -> [CacheConfig] -> Map.Map T.Text BS.ByteString -> Derivation -> StorePath -> IO BuildResult
 buildAndRegister store caches drvClosure drv drvSP = do
   -- Materialize the full input-.drv closure (every transitive dependency's
   -- recipe) to the store.  buildWithDeps reads these back to construct the
@@ -493,7 +502,7 @@ failWith msg = do
 -- | Write every recorded @.drv@ ATerm (keyed by its store-path text) to the
 -- store.  Keys come from evaluation via 'storePathToText' so they always parse;
 -- an unparseable key is skipped defensively.
-writeDrvClosure :: Store -> Map.Map T.Text T.Text -> IO ()
+writeDrvClosure :: Store -> Map.Map T.Text BS.ByteString -> IO ()
 writeDrvClosure store = mapM_ writeOne . Map.toList
   where
     writeOne (pathText, aterm) =
@@ -537,7 +546,7 @@ prettyValue (VFloat f) = T.pack (show f)
 prettyValue (VBool True) = "true"
 prettyValue (VBool False) = "false"
 prettyValue VNull = "null"
-prettyValue (VStr s _) = "\"" <> escapeNixString s <> "\""
+prettyValue (VStr s _) = "\"" <> escapeNixString (bytesToTextLossy s) <> "\""
 prettyValue (VPath p) = p
 prettyValue (VList cl) =
   "[ " <> T.intercalate " " (map (prettyThunk . Thunk) (clistThunks cl)) <> " ]"

--- a/nova-nix.cabal
+++ b/nova-nix.cabal
@@ -149,6 +149,7 @@ executable nova-nix
 
   build-depends:
       base                >= 4.16 && < 5
+    , bytestring          >= 0.11 && < 0.13
     , containers          >= 0.6 && < 0.9
     , directory           >= 1.3 && < 1.4
     , filepath            >= 1.4 && < 1.6

--- a/src/Nix/Builder.hs
+++ b/src/Nix/Builder.hs
@@ -56,6 +56,8 @@ import qualified Data.Map.Strict as Map
 import Data.Maybe (catMaybes)
 import Data.Text (Text)
 import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
+import Data.Text.Encoding.Error (lenientDecode)
 import qualified Data.Text.IO as TIO
 import qualified Network.HTTP.Client as HTTP
 import qualified Network.HTTP.Client.TLS as HTTPS
@@ -100,7 +102,8 @@ envPath = "PATH"
 -- | The magic builder string for the built-in URL fetcher.  A derivation with
 -- this builder is not executed as a process - the Builder downloads its @url@
 -- and verifies it against @outputHash@ (see 'runBuiltinFetchurl').
-builtinFetchurlBuilder :: Text
+-- Bytes, matching the 'drvBuilder' field it is compared against.
+builtinFetchurlBuilder :: BS.ByteString
 builtinFetchurlBuilder = "builtin:fetchurl"
 
 -- | Derivation environment keys read by @builtin:fetchurl@.
@@ -216,20 +219,23 @@ buildDerivationInner config store drv = do
         --    is responsible for creating $out, $dev, etc.)
         let outputDirs = [(doName out, buildDir </> T.unpack (doName out)) | out <- drvOutputs drv]
 
-        -- 4. Set up environment
-        let builderPath = T.unpack (drvBuilder drv)
-            environ = buildEnvironment config drv builderPath buildDir outputDirs
-
-            -- 5. Run the builder
-            builderArgs = map T.unpack (drvArgs drv)
-        -- A "builtin:" builder (e.g. builtin:fetchurl) is handled in-process;
-        -- everything else is a normal subprocess.  The output validation and
-        -- registration below are shared by both paths.
+        -- 4. Decode builder/args/env for the spawn boundary.  Derivation
+        --    strings are BYTES (identity); spawning a process needs real
+        --    text, so invalid UTF-8 in any of them is a clean build
+        --    failure, never a mojibake spawn.  The builtin builders skip
+        --    this - they read the byte fields directly.
         exitResult <- case drvBuilder drv of
           b
             | b == builtinFetchurlBuilder -> runBuiltinFetchurl drv outputDirs
             | b == builtinUnpackBuilder -> runBuiltinUnpack drv outputDirs
-          _ -> runBuilder builderPath builderArgs environ buildDir
+          _ -> case decodeBuilderStrings drv of
+            Left errMsg -> pure (Left (1, errMsg))
+            Right (builderText, argTexts, decodedEnv) ->
+              let builderPath = T.unpack builderText
+                  environ = buildEnvironment config decodedEnv builderPath buildDir outputDirs
+                  builderArgs = map T.unpack argTexts
+               in -- 5. Run the builder
+                  runBuilder builderPath builderArgs environ buildDir
         case exitResult of
           Left (exitCode, stderrText) ->
             pure (BuildFailure ("builder failed: " <> stderrText) exitCode)
@@ -244,6 +250,23 @@ buildDerivationInner config store drv = do
               _ -> do
                 let names = T.intercalate ", " (map fst missing)
                 pure (BuildFailure ("builder succeeded but outputs missing: " <> names) 1)
+
+-- | Decode a derivation's builder path, arguments, and env values from
+-- their identity bytes to the 'Text' the process-spawn boundary needs.
+-- @Left@ names the offending field.
+decodeBuilderStrings :: Derivation -> Either Text (Text, [Text], Map Text Text)
+decodeBuilderStrings drv = do
+  builderText <- decodeField "the builder path" (drvBuilder drv)
+  argTexts <- traverse (decodeField "a builder argument") (drvArgs drv)
+  envTexts <-
+    Map.traverseWithKey
+      (\key val -> decodeField ("environment variable '" <> key <> "'") val)
+      (drvEnv drv)
+  pure (builderText, argTexts, envTexts)
+  where
+    decodeField what bytes = case TE.decodeUtf8' bytes of
+      Right t -> Right t
+      Left _ -> Left ("cannot spawn builder: " <> what <> " contains invalid UTF-8")
 
 -- ---------------------------------------------------------------------------
 -- Input validation
@@ -328,14 +351,15 @@ cleanupBuildDir dir = do
 -- store paths from declared build dependencies.
 buildEnvironment ::
   BuildConfig ->
-  Derivation ->
+  Map Text Text ->
   FilePath ->
   FilePath ->
   [(Text, FilePath)] ->
   Map Text Text
-buildEnvironment config drv builderPath buildDir outputDirs =
-  let -- Start with derivation environment
-      baseEnv = drvEnv drv
+buildEnvironment config decodedEnv builderPath buildDir outputDirs =
+  let -- Start with the derivation environment (values decoded at the
+      -- spawn boundary by 'decodeBuilderStrings')
+      baseEnv = decodedEnv
       -- Add output paths: $out, $dev, etc.
       outputEnv = Map.fromList [(name, T.pack path) | (name, path) <- outputDirs]
       -- Standard build variables
@@ -466,13 +490,15 @@ runBuiltinFetchurl drv outputDirs =
     (Nothing, _, _) -> pure (Left (1, "builtin:fetchurl: derivation has no 'url'"))
     (_, Nothing, _) -> pure (Left (1, "builtin:fetchurl: derivation defines no 'out' output"))
     (_, _, Nothing) -> pure (Left (1, "builtin:fetchurl: 'out' output has no fixed-output hash"))
-    (Just url, Just outPath, Just out) -> do
-      downloaded <- downloadUrl url
-      case downloaded of
-        Left err -> pure (Left (1, "builtin:fetchurl: " <> err))
-        Right body -> do
-          BS.writeFile outPath body
-          pure (verifyFetchHash url out body)
+    (Just urlBytes, Just outPath, Just out) -> case TE.decodeUtf8' urlBytes of
+      Left _ -> pure (Left (1, "builtin:fetchurl: 'url' contains invalid UTF-8"))
+      Right url -> do
+        downloaded <- downloadUrl url
+        case downloaded of
+          Left err -> pure (Left (1, "builtin:fetchurl: " <> err))
+          Right body -> do
+            BS.writeFile outPath body
+            pure (verifyFetchHash url out body)
   where
     -- builtin:fetchurl derivations are always fixed-output; the expected hash
     -- lives in the canonical output spec (doHashAlgo + doHash), not the env.
@@ -682,11 +708,12 @@ readDrvFromStore config sp =
         Nothing -> Left ("cannot read .drv file: " <> T.pack drvFilePath)
         Just content -> fromATerm content
 
--- | Read a file as Text, returning Nothing on any error.
--- Used only for reading immutable .drv files from the store.
-unsafeReadFile :: FilePath -> Maybe Text
+-- | Read a file's raw bytes, returning Nothing on any error.  Used only
+-- for reading immutable .drv files from the store - byte IO, never
+-- text-mode (no locale decode, no newline translation).
+unsafeReadFile :: FilePath -> Maybe BS.ByteString
 unsafeReadFile path =
-  case System.IO.Unsafe.unsafePerformIO (try (TIO.readFile path)) of
+  case System.IO.Unsafe.unsafePerformIO (try (BS.readFile path)) of
     Left (_ :: SomeException) -> Nothing
     Right content -> Just content
 
@@ -783,11 +810,12 @@ trySubstituteOutputs config store drv
     substRegistration (SubstSuccess reg) = Just reg
     substRegistration _ = Nothing
 
--- | Format a derivation name for status output.
+-- | Format a derivation name for status output (display-only, so the
+-- byte-string env value decodes lossily).
 formatDrvName :: Derivation -> Text
 formatDrvName drv =
   case Map.lookup "name" (drvEnv drv) of
-    Just n -> n
+    Just n -> TE.decodeUtf8With lenientDecode n
     Nothing -> case drvOutputs drv of
       (out : _) -> spName (doPath out)
       [] -> "<unknown>"

--- a/src/Nix/Builder/Unpack.hs
+++ b/src/Nix/Builder/Unpack.hs
@@ -54,12 +54,14 @@ import qualified Codec.Compression.Zstd.Lazy as Zstd
 import Control.Exception (SomeException, try)
 import Control.Monad (when)
 import Data.Bits ((.&.))
+import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BL
 import Data.Char (toLower)
 import Data.List (isPrefixOf, isSuffixOf)
 import qualified Data.Map.Strict as Map
 import Data.Text (Text)
 import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
 import Nix.Derivation (Derivation (..))
 import System.Directory
   ( copyFile,
@@ -82,7 +84,8 @@ import qualified System.Info
 -- | The magic builder string for the built-in archive extractor.  A
 -- derivation with this builder is not executed as a process - the Builder
 -- extracts its @srcs@ archives into @$out@ (see 'runBuiltinUnpack').
-builtinUnpackBuilder :: Text
+-- Bytes, matching the 'drvBuilder' field it is compared against.
+builtinUnpackBuilder :: BS.ByteString
 builtinUnpackBuilder = "builtin:unpack"
 
 -- | Derivation environment key holding the whitespace-separated archive
@@ -140,15 +143,19 @@ runBuiltinUnpack :: Derivation -> [(Text, FilePath)] -> IO (Either (Int, Text) (
 runBuiltinUnpack drv outputDirs =
   case (Map.lookup envSrcs (drvEnv drv), lookup unpackOutputName outputDirs) of
     (Nothing, _) -> failure "derivation has no 'srcs'"
-    (Just srcs, _)
-      | null (sourcePaths srcs) -> failure "'srcs' is empty"
-    (_, Nothing) -> failure "derivation defines no 'out' output"
-    (Just srcs, Just outDir) -> do
-      createDirectoryIfMissing True outDir
-      result <- unpackAll outDir (sourcePaths srcs)
-      pure $ case result of
-        Left msg -> Left (1, "builtin:unpack: " <> msg)
-        Right () -> Right ()
+    (Just srcsBytes, mOutDir) -> case TE.decodeUtf8' srcsBytes of
+      -- Store paths are ASCII; a non-UTF-8 srcs value cannot name any.
+      Left _ -> failure "'srcs' contains invalid UTF-8"
+      Right srcs
+        | null (sourcePaths srcs) -> failure "'srcs' is empty"
+        | otherwise -> case mOutDir of
+            Nothing -> failure "derivation defines no 'out' output"
+            Just outDir -> do
+              createDirectoryIfMissing True outDir
+              result <- unpackAll outDir (sourcePaths srcs)
+              pure $ case result of
+                Left msg -> Left (1, "builtin:unpack: " <> msg)
+                Right () -> Right ()
   where
     failure msg = pure (Left (1, "builtin:unpack: " <> msg))
     sourcePaths = map T.unpack . T.words

--- a/src/Nix/Derivation.hs
+++ b/src/Nix/Derivation.hs
@@ -66,6 +66,11 @@ module Nix.Derivation
   )
 where
 
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Builder as B
+import qualified Data.ByteString.Char8 as BC
+import qualified Data.ByteString.Lazy as LBS
 import Data.Function (on)
 import Data.List (sortBy)
 import Data.Map.Strict (Map)
@@ -73,6 +78,8 @@ import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
+import Data.Text.Encoding.Error (lenientDecode)
 import Nix.Store.Path (StorePath (..))
 import qualified Nix.Store.Path as SP
 import qualified System.Info as SI
@@ -146,6 +153,13 @@ data DerivationOutput = DerivationOutput
   deriving (Eq, Show)
 
 -- | A complete derivation - everything needed to build a package.
+--
+-- The builder, args, and env VALUES are byte strings: they are coerced
+-- Nix strings, which carry arbitrary bytes, and they flow byte-exact
+-- into the ATerm (and therefore the @.drv@ hash and every output path).
+-- Env KEYS are attr names, which nova-nix constrains to valid UTF-8
+-- 'Text'; for valid UTF-8, Text ordering equals byte ordering, so the
+-- sorted env section matches upstream's bytewise @std::map@ order.
 data Derivation = Derivation
   { -- | What this derivation produces.
     drvOutputs :: ![DerivationOutput],
@@ -156,19 +170,21 @@ data Derivation = Derivation
     -- | Target platform: "x86_64-linux", "x86_64-windows", etc.
     drvPlatform :: !Platform,
     -- | The builder executable (store path to bash, or other).
-    drvBuilder :: !Text,
+    drvBuilder :: !ByteString,
     -- | Arguments to the builder.
-    drvArgs :: ![Text],
+    drvArgs :: ![ByteString],
     -- | Environment variables for the build.
-    drvEnv :: !(Map Text Text)
+    drvEnv :: !(Map Text ByteString)
   }
   deriving (Eq, Show)
 
 -- | Serialize a derivation to ATerm format (the .drv file format).
--- This serialization is what gets hashed to compute the store path.
+-- This serialization is what gets hashed to compute the store path,
+-- so the result is BYTES: env values, args, and the builder land in it
+-- exactly as coerced, with no encoding step in between.
 --
 -- Format: @Derive([outputs],[inputDrvs],[inputSrcs],platform,builder,[args],[env])@
-toATerm :: Derivation -> Text
+toATerm :: Derivation -> ByteString
 toATerm = toATermForHash False Nothing
 
 -- | Serialize a derivation for HASHING, with the two knobs the Nix
@@ -184,23 +200,25 @@ toATerm = toATermForHash False Nothing
 --     input's path spelling (not its content) hash identically.
 --
 -- @toATermForHash False Nothing@ is exactly 'toATerm'.
-toATermForHash :: Bool -> Maybe [(Text, [Text])] -> Derivation -> Text
+toATermForHash :: Bool -> Maybe [(Text, [Text])] -> Derivation -> ByteString
 toATermForHash maskOutputs inputSubst drv =
-  "Derive("
-    <> atermOutputsWith maskOutputs (drvOutputs drv)
-    <> ","
-    <> inputDrvsSection
-    <> ","
-    <> atermInputSrcs (drvInputSrcs drv)
-    <> ","
-    <> atermString (platformToText (drvPlatform drv))
-    <> ","
-    <> atermString (drvBuilder drv)
-    <> ","
-    <> atermStringList (drvArgs drv)
-    <> ","
-    <> atermEnv (drvEnv drv)
-    <> ")"
+  LBS.toStrict $
+    B.toLazyByteString $
+      "Derive("
+        <> atermOutputsWith maskOutputs (drvOutputs drv)
+        <> ","
+        <> inputDrvsSection
+        <> ","
+        <> atermInputSrcs (drvInputSrcs drv)
+        <> ","
+        <> atermStringT (platformToText (drvPlatform drv))
+        <> ","
+        <> atermString (drvBuilder drv)
+        <> ","
+        <> atermList (map atermString (drvArgs drv))
+        <> ","
+        <> atermEnv (drvEnv drv)
+        <> ")"
   where
     inputDrvsSection = case inputSubst of
       Nothing -> atermInputDrvs (drvInputDrvs drv)
@@ -209,20 +227,20 @@ toATermForHash maskOutputs inputSubst drv =
 -- | Serialize outputs: @[(name,path,hashAlgo,hash)]@, sorted by output name.
 -- When @maskOutputs@ is set, every path is rendered as @\"\"@ (used by the
 -- masked modulo hash, where output paths aren't known yet).
-atermOutputsWith :: Bool -> [DerivationOutput] -> Text
+atermOutputsWith :: Bool -> [DerivationOutput] -> B.Builder
 atermOutputsWith maskOutputs outs =
   let sorted = sortBy (compare `on` doName) outs
-   in "[" <> T.intercalate "," (map render sorted) <> "]"
+   in atermList (map render sorted)
   where
     render out =
       "("
-        <> atermString (doName out)
+        <> atermStringT (doName out)
         <> ","
-        <> atermString (if maskOutputs then "" else SP.storePathToText SP.defaultStoreDir (doPath out))
+        <> atermStringT (if maskOutputs then "" else SP.storePathToText SP.defaultStoreDir (doPath out))
         <> ","
-        <> atermString (doHashAlgo out)
+        <> atermStringT (doHashAlgo out)
         <> ","
-        <> atermString (doHash out)
+        <> atermStringT (doHash out)
         <> ")"
 
 -- | Input-derivations serializer for the modulo substitution: keys are the
@@ -234,12 +252,12 @@ atermOutputsWith maskOutputs outs =
 -- order-independent; 'Map.toAscList' and 'Set.toAscList' fix the ascending
 -- hex-key and output-name order (hex is lowercase, so this matches the bytewise
 -- order of upstream's @std::map<std::string>@).
-atermInputDrvsSubst :: [(Text, [Text])] -> Text
+atermInputDrvsSubst :: [(Text, [Text])] -> B.Builder
 atermInputDrvsSubst subs =
   let merged = Map.fromListWith Set.union [(key, Set.fromList outs) | (key, outs) <- subs]
-   in "[" <> T.intercalate "," (map render (Map.toAscList merged)) <> "]"
+   in atermList (map render (Map.toAscList merged))
   where
-    render (key, outs) = "(" <> atermString key <> "," <> atermStringList (Set.toAscList outs) <> ")"
+    render (key, outs) = "(" <> atermStringT key <> "," <> atermList (map atermStringT (Set.toAscList outs)) <> ")"
 
 -- | Sort and deduplicate output names (matches C++ @std::set<string>@).
 sortNubText :: [Text] -> [Text]
@@ -247,60 +265,84 @@ sortNubText = Set.toAscList . Set.fromList
 
 -- | Serialize input derivations: @[(drvPath,[outName1,outName2])]@
 -- Sorted by store path for determinism.
-atermInputDrvs :: Map StorePath [Text] -> Text
+atermInputDrvs :: Map StorePath [Text] -> B.Builder
 atermInputDrvs drvs =
   let sorted = Map.toAscList drvs
-   in "[" <> T.intercalate "," (map atermInputDrv sorted) <> "]"
+   in atermList (map atermInputDrv sorted)
 
-atermInputDrv :: (StorePath, [Text]) -> Text
+atermInputDrv :: (StorePath, [Text]) -> B.Builder
 atermInputDrv (sp, outs) =
   "("
-    <> atermString (SP.storePathToText SP.defaultStoreDir sp)
+    <> atermStringT (SP.storePathToText SP.defaultStoreDir sp)
     <> ","
-    <> atermStringList (sortNubText outs)
+    <> atermList (map atermStringT (sortNubText outs))
     <> ")"
 
 -- | Serialize input sources: @[path1,path2,...]@
 -- Sorted for deterministic ATerm hashing.
-atermInputSrcs :: [StorePath] -> Text
+atermInputSrcs :: [StorePath] -> B.Builder
 atermInputSrcs srcs =
   let sorted = sortBy (compare `on` SP.storePathToText SP.defaultStoreDir) srcs
-   in "[" <> T.intercalate "," (map (atermString . SP.storePathToText SP.defaultStoreDir) sorted) <> "]"
+   in atermList (map (atermStringT . SP.storePathToText SP.defaultStoreDir) sorted)
 
--- | Serialize a list of strings: @[s1,s2,...]@
-atermStringList :: [Text] -> Text
-atermStringList strs =
-  "[" <> T.intercalate "," (map atermString strs) <> "]"
+-- | Bracketed, comma-separated section.
+atermList :: [B.Builder] -> B.Builder
+atermList items = "[" <> mconcat (intersperseComma items) <> "]"
+  where
+    intersperseComma [] = []
+    intersperseComma [only] = [only]
+    intersperseComma (item : rest) = item : "," : intersperseComma rest
 
--- | Serialize environment: @[(key,value)]@ sorted by key.
-atermEnv :: Map Text Text -> Text
+-- | Serialize environment: @[(key,value)]@ sorted by key.  Keys are
+-- valid-UTF-8 Text, so 'Map.toAscList' order equals upstream's bytewise
+-- order; values are raw bytes.
+atermEnv :: Map Text ByteString -> B.Builder
 atermEnv env =
   let sorted = Map.toAscList env
-   in "[" <> T.intercalate "," (map atermEnvPair sorted) <> "]"
+   in atermList (map atermEnvPair sorted)
 
-atermEnvPair :: (Text, Text) -> Text
+atermEnvPair :: (Text, ByteString) -> B.Builder
 atermEnvPair (key, val) =
-  "(" <> atermString key <> "," <> atermString val <> ")"
+  "(" <> atermStringT key <> "," <> atermString val <> ")"
 
--- | ATerm string: double-quoted with standard escaping.
-atermString :: Text -> Text
-atermString s = "\"" <> T.concatMap escapeATerm s <> "\""
+-- | ATerm string: double-quoted with standard escaping, byte-level.
+-- Every escapable is a single ASCII byte, so escaping the byte stream is
+-- exactly upstream's per-char escaping over its byte strings.
+atermString :: ByteString -> B.Builder
+atermString s = "\"" <> escapeATermBytes s <> "\""
 
--- | Escape a character for ATerm format.
-escapeATerm :: Char -> Text
-escapeATerm '\\' = "\\\\"
-escapeATerm '"' = "\\\""
-escapeATerm '\n' = "\\n"
-escapeATerm '\r' = "\\r"
-escapeATerm '\t' = "\\t"
-escapeATerm c = T.singleton c
+-- | ATerm string from Text (names, store paths, hex keys): UTF-8 bytes,
+-- then the shared byte-level escaping.
+atermStringT :: Text -> B.Builder
+atermStringT = atermString . TE.encodeUtf8
+
+-- | Escape the five ATerm specials; all other bytes pass through verbatim.
+-- Scans for the next special with 'BC.break' so clean spans copy in bulk.
+escapeATermBytes :: ByteString -> B.Builder
+escapeATermBytes s =
+  let (plain, rest) = BC.break atermSpecial s
+   in case BC.uncons rest of
+        Nothing -> B.byteString plain
+        Just (c, remaining) ->
+          B.byteString plain <> escapeOne c <> escapeATermBytes remaining
+  where
+    atermSpecial c = c == '\\' || c == '"' || c == '\n' || c == '\r' || c == '\t'
+    escapeOne '\\' = "\\\\"
+    escapeOne '"' = "\\\""
+    escapeOne '\n' = "\\n"
+    escapeOne '\r' = "\\r"
+    escapeOne '\t' = "\\t"
+    -- Unreachable: 'BC.break atermSpecial' only stops at the five specials.
+    escapeOne c = B.charUtf8 c
 
 -- ---------------------------------------------------------------------------
 -- ATerm parser (hand-rolled recursive descent)
 -- ---------------------------------------------------------------------------
 
--- | Parser state: remaining input text.
-newtype Parser a = Parser {runParser :: Text -> Either Text (a, Text)}
+-- | Parser state: remaining input bytes.  The @.drv@ on disk is a byte
+-- string; only Text-shaped fields (names, paths, keys) decode, and only
+-- after unescaping.
+newtype Parser a = Parser {runParser :: ByteString -> Either Text (a, ByteString)}
 
 instance Functor Parser where
   fmap f (Parser p) = Parser $ \input -> case p input of
@@ -323,46 +365,65 @@ instance Monad Parser where
 parserFail :: Text -> Parser a
 parserFail msg = Parser $ \_ -> Left msg
 
+-- | Lossy decode for parse-error snippets only.
+snippet :: ByteString -> Text
+snippet = TE.decodeUtf8With lenientDecode
+
 -- | Consume a specific character.
 pChar :: Char -> Parser ()
 pChar expected = Parser $ \input ->
-  case T.uncons input of
+  case BC.uncons input of
     Just (c, rest) | c == expected -> Right ((), rest)
     Just (c, _) -> Left ("expected '" <> T.singleton expected <> "' but got '" <> T.singleton c <> "'")
     Nothing -> Left ("expected '" <> T.singleton expected <> "' but got end of input")
 
 -- | Consume a specific string prefix.
-pString :: Text -> Parser ()
+pString :: ByteString -> Parser ()
 pString prefix = Parser $ \input ->
-  case T.stripPrefix prefix input of
+  case BS.stripPrefix prefix input of
     Just rest -> Right ((), rest)
-    Nothing -> Left ("expected \"" <> prefix <> "\" at: " <> T.take 20 input)
+    Nothing -> Left ("expected \"" <> snippet prefix <> "\" at: " <> snippet (BS.take 20 input))
 
--- | Parse a quoted ATerm string with escape handling.
-pQuotedString :: Parser Text
+-- | Parse a quoted ATerm string with escape handling; the content is the
+-- raw unescaped bytes.
+pQuotedString :: Parser ByteString
 pQuotedString = do
   pChar '"'
   content <- pStringContent
   pChar '"'
   pure content
 
+-- | Like 'pQuotedString' for Text-shaped fields (names, store paths, env
+-- keys, platform): strict UTF-8 decode after unescaping, so invalid bytes
+-- in a field nova-nix represents as Text are a parse error, never mojibake.
+pQuotedText :: Parser Text
+pQuotedText = do
+  content <- pQuotedString
+  case TE.decodeUtf8' content of
+    Right t -> pure t
+    Left _ -> parserFail ("invalid UTF-8 in ATerm string: " <> snippet (BS.take 40 content))
+
 -- | Parse the contents of a quoted string (up to unescaped quote).
-pStringContent :: Parser Text
-pStringContent = Parser $ \input -> go input T.empty
+-- Scans to the next special byte with 'BC.break' so clean spans are
+-- copied in bulk, accumulating reversed chunks (O(n) total).
+pStringContent :: Parser ByteString
+pStringContent = Parser $ \input -> go input []
   where
     go remaining acc =
-      case T.uncons remaining of
-        Nothing -> Left "unterminated string"
-        Just ('"', _) -> Right (acc, remaining)
-        Just ('\\', rest) -> case T.uncons rest of
-          Nothing -> Left "unterminated escape"
-          Just ('\\', rest2) -> go rest2 (acc <> "\\")
-          Just ('"', rest2) -> go rest2 (acc <> "\"")
-          Just ('n', rest2) -> go rest2 (acc <> "\n")
-          Just ('r', rest2) -> go rest2 (acc <> "\r")
-          Just ('t', rest2) -> go rest2 (acc <> "\t")
-          Just (c, rest2) -> go rest2 (acc <> "\\" <> T.singleton c)
-        Just (c, rest) -> go rest (acc <> T.singleton c)
+      let (plain, rest) = BC.break (\c -> c == '"' || c == '\\') remaining
+       in case BC.uncons rest of
+            Nothing -> Left "unterminated string"
+            Just ('"', _) -> Right (BS.concat (reverse (plain : acc)), rest)
+            Just ('\\', afterSlash) -> case BC.uncons afterSlash of
+              Nothing -> Left "unterminated escape"
+              Just ('\\', rest2) -> go rest2 ("\\" : plain : acc)
+              Just ('"', rest2) -> go rest2 ("\"" : plain : acc)
+              Just ('n', rest2) -> go rest2 ("\n" : plain : acc)
+              Just ('r', rest2) -> go rest2 ("\r" : plain : acc)
+              Just ('t', rest2) -> go rest2 ("\t" : plain : acc)
+              Just (c, rest2) -> go rest2 (BC.pack ['\\', c] : plain : acc)
+            -- Unreachable: BC.break stops only at '"' or '\\'.
+            Just (c, _) -> Left ("pStringContent: impossible break byte '" <> T.singleton c <> "'")
 
 -- | Parse a comma-separated list enclosed in brackets: @[item,item,...]@
 pList :: Parser a -> Parser [a]
@@ -391,13 +452,13 @@ pSepBy pItem pSep = Parser $ \input ->
 pOutput :: Parser DerivationOutput
 pOutput = do
   pChar '('
-  name <- pQuotedString
+  name <- pQuotedText
   pChar ','
-  pathStr <- pQuotedString
+  pathStr <- pQuotedText
   pChar ','
-  hashAlgo <- pQuotedString
+  hashAlgo <- pQuotedText
   pChar ','
-  hashVal <- pQuotedString
+  hashVal <- pQuotedText
   pChar ')'
   case parseStorePathFromATerm pathStr of
     Just sp -> pure (DerivationOutput name sp hashAlgo hashVal)
@@ -415,9 +476,9 @@ parseStorePathFromATerm pathStr =
 pInputDrv :: Parser (StorePath, [Text])
 pInputDrv = do
   pChar '('
-  pathStr <- pQuotedString
+  pathStr <- pQuotedText
   pChar ','
-  outs <- pList pQuotedString
+  outs <- pList pQuotedText
   pChar ')'
   case parseStorePathFromATerm pathStr of
     Just sp -> pure (sp, outs)
@@ -426,31 +487,32 @@ pInputDrv = do
 -- | Parse an input source (quoted store path string).
 pInputSrc :: Parser StorePath
 pInputSrc = do
-  pathStr <- pQuotedString
+  pathStr <- pQuotedText
   case parseStorePathFromATerm pathStr of
     Just sp -> pure sp
     Nothing -> parserFail ("invalid input src store path: " <> pathStr)
 
--- | Parse an environment pair: @(key, value)@.
-pEnvPair :: Parser (Text, Text)
+-- | Parse an environment pair: @(key, value)@.  The key is an attr name
+-- (Text); the value keeps its raw bytes.
+pEnvPair :: Parser (Text, ByteString)
 pEnvPair = do
   pChar '('
-  key <- pQuotedString
+  key <- pQuotedText
   pChar ','
   val <- pQuotedString
   pChar ')'
   pure (key, val)
 
--- | Parse a full derivation from ATerm format.
+-- | Parse a full derivation from its ATerm bytes.
 -- Format: @Derive([outputs],[inputDrvs],[inputSrcs],platform,builder,[args],[env])@
 --
 -- Total function: returns @Left@ on any malformed input.
-fromATerm :: Text -> Either Text Derivation
+fromATerm :: ByteString -> Either Text Derivation
 fromATerm input = case runParser pDerivation input of
   Left err -> Left ("ATerm parse error: " <> err)
   Right (drv, remaining)
-    | T.null remaining -> Right drv
-    | otherwise -> Left ("ATerm parse error: unexpected trailing: " <> T.take 40 remaining)
+    | BS.null remaining -> Right drv
+    | otherwise -> Left ("ATerm parse error: unexpected trailing: " <> snippet (BS.take 40 remaining))
 
 pDerivation :: Parser Derivation
 pDerivation = do
@@ -461,7 +523,7 @@ pDerivation = do
   pChar ','
   inputSrcs <- pList pInputSrc
   pChar ','
-  platformStr <- pQuotedString
+  platformStr <- pQuotedText
   pChar ','
   builder <- pQuotedString
   pChar ','

--- a/src/Nix/Eval.hs
+++ b/src/Nix/Eval.hs
@@ -1535,7 +1535,7 @@ builtinTail other = throwEvalError ("builtins.tail: expected a list, got " <> ty
 -- Builtin implementations - string (arity 1)
 -- ---------------------------------------------------------------------------
 
--- | Byte length, as upstream: @stringLength "ä"@ is 2, not 1.
+-- | Byte length, as upstream: stringLength of a 2-byte character is 2, not 1.
 builtinStringLength :: (MonadEval m) => NixValue -> m NixValue
 builtinStringLength (VStr s _) = pure (VInt (fromIntegral (BS.length s)))
 builtinStringLength other =

--- a/src/Nix/Eval.hs
+++ b/src/Nix/Eval.hs
@@ -3479,9 +3479,20 @@ verifyFetchPin ctx url bytes expectedStr = do
 -- @sha256:@-prefixed, or a bare hex/nix32/base64 digest).
 decodeSha256Pin :: (MonadEval m) => Text -> Text -> m BS.ByteString
 decodeSha256Pin ctx s
-  | Just (_, b64) <- parseSRI s = decodeBase64E ctx b64
-  | Just (algo, rest) <- parseAlgoPrefix s = snd <$> decodeWithAlgo algo rest
+  | Just (algo, b64) <- parseSRI s = do
+      requireSha256 algo
+      decodeSRI ctx algo b64
+  | Just (algo, rest) <- parseAlgoPrefix s = do
+      requireSha256 algo
+      snd <$> decodeWithAlgo algo rest
   | otherwise = snd <$> decodeWithAlgo "sha256" s
+  where
+    -- The pin names a sha256 digest specifically, so a spelling carrying
+    -- its own algorithm tag must carry sha256 - a sha512 pin here is an
+    -- error at decode time, as upstream's typed Hash parse.
+    requireSha256 "sha256" = pure ()
+    requireSha256 algo =
+      throwEvalError (ctx <> ": hash '" <> s <> "' should have type 'sha256', not '" <> algo <> "'")
 
 -- | Force a required string attribute from an attrset, using full Nix string
 -- coercion (VStr, VPath, VInt, VBool, VAttrs via __toString/outPath).
@@ -3815,7 +3826,7 @@ optDrvStrAttr key attrs =
 normalizeFixedHash :: (MonadEval m) => Text -> Text -> m (Text, BS.ByteString)
 normalizeFixedHash ohash ohAlgo
   | Just (algo, b64) <- parseSRI ohash = do
-      bytes <- decodeBase64E "derivation" b64
+      bytes <- decodeSRI "derivation" algo b64
       pure (algo, bytes)
   | Just (algo, rest) <- parseAlgoPrefix ohash = decodeWithAlgo algo rest
   | not (T.null ohAlgo) = decodeWithAlgo ohAlgo ohash
@@ -3971,7 +3982,7 @@ decodeHashInput :: (MonadEval m) => AttrSet -> Text -> m (Text, BS.ByteString)
 decodeHashInput attrs hashStr
   -- SRI format: algo-base64
   | Just (algo, b64) <- parseSRI hashStr = do
-      bytes <- decodeBase64E "convertHash" b64
+      bytes <- decodeSRI "convertHash" algo b64
       pure (algo, bytes)
   -- Prefixed format: algo:hex or algo:nix32
   | Just (algo, rest) <- parseAlgoPrefix hashStr =
@@ -4002,6 +4013,23 @@ decodeWithAlgo algo s = case hashAlgoBytes algo of
       Just bytes | BS.length bytes == size -> pure (algo, bytes)
       _ -> throwEvalError ("hash '" <> s <> "' is not a valid " <> spelling <> " " <> algo <> " hash")
     rightToMaybe = either (const Nothing) Just
+
+-- | Decode an SRI digest (@algo-base64@) with the decoded-length check
+-- every spelling gets upstream (hash.cc checks SRI too): well-formed
+-- base64 of the wrong byte count is an invalid hash at eval time, not a
+-- short digest that defers failure to fetch or build time.  Shared by
+-- convertHash, the fetch pins, and fixed-output outputHash.
+decodeSRI :: (MonadEval m) => Text -> Text -> Text -> m BS.ByteString
+decodeSRI ctx algo b64 = case hashAlgoBytes algo of
+  -- Unreachable via parseSRI (it admits only known algorithm tags), but
+  -- this helper must not silently skip the check for an unknown one.
+  Nothing -> throwEvalError ("unknown hash algorithm '" <> algo <> "'")
+  Just size -> do
+    bytes <- decodeBase64E ctx b64
+    when (BS.length bytes /= size) $
+      throwEvalError
+        ("hash '" <> algo <> "-" <> b64 <> "' has wrong length for hash algorithm '" <> algo <> "'")
+    pure bytes
 
 -- | Parse @sha256-base64...@ SRI format.
 parseSRI :: Text -> Maybe (Text, Text)

--- a/src/Nix/Eval.hs
+++ b/src/Nix/Eval.hs
@@ -73,7 +73,8 @@ import qualified Data.Array as Array
 import Data.Bits (complement, xor, (.&.), (.|.))
 import qualified Data.ByteArray as BA
 import qualified Data.ByteString as BS
-import Data.Char (chr, digitToInt, isAlpha, isDigit, isHexDigit, isOctDigit, ord)
+import qualified Data.ByteString.Char8 as BC
+import Data.Char (chr, digitToInt, isAsciiLower, isAsciiUpper, isDigit, isHexDigit, isOctDigit, ord)
 import Data.IORef (IORef, atomicModifyIORef', newIORef)
 import Data.Int (Int64)
 import Data.List (find, foldl', partition, sort)
@@ -99,7 +100,7 @@ import Nix.Eval.Compile (BcAttrKey (..), BcBinding (..), compileExpr, decodeBcBi
 import Nix.Eval.Context (extractAllOutputRefs, extractInputDrvs, extractInputSrcs, plainContext)
 import Nix.Eval.Operator (checkedAdd, checkedMul, checkedSub, evalBinary, evalUnary, nixCompare, nixEqual)
 import Nix.Eval.StringInterp (coerceToString, formatJsonFloat, formatNixFloat, formatXmlFloat, stripIndentedChunks)
-import Nix.Eval.Symbol (Symbol (..), symbolText)
+import Nix.Eval.Symbol (Symbol (..), symbolBytes, symbolText)
 import Nix.Eval.Types
   ( AttrSet (..),
     CAttrSet,
@@ -127,6 +128,7 @@ import Nix.Eval.Types
     attrSetToMap,
     buildCAttrSetKeys,
     buildCSlots,
+    bytesToTextLossy,
     cheapThunkBc,
     checkedEnvPtr,
     clistFromThunks,
@@ -142,6 +144,7 @@ import Nix.Eval.Types
     fillCAttrSetValues,
     fillCSlots,
     mkStr,
+    mkStrBytes,
     mkSyntheticThunk,
     mkThunk,
     mkThunkBc,
@@ -170,6 +173,7 @@ import System.IO.Unsafe (unsafePerformIO)
 import qualified System.Info
 import Text.Regex.TDFA (matchAllText)
 import qualified Text.Regex.TDFA as RE
+import Text.Regex.TDFA.ByteString ()
 
 -- | Evaluate a Nix expression in an environment.
 -- Compiles the expression to bytecode and dispatches to 'evalBytecode'.
@@ -185,6 +189,16 @@ eval env expr =
 -- after the first force) while pure evaluators simply re-evaluate.
 force :: (MonadEval m) => Thunk -> m NixValue
 force = forceThunk evalBytecode
+
+-- | Strict UTF-8 decode at a Text-typed boundary (attr names, filesystem
+-- paths, algorithm names, ...).  A Nix string is a byte string; where the
+-- implementation needs 'Text', invalid UTF-8 is a clean eval error - never
+-- a lossy replacement, which would smuggle a DIFFERENT string through an
+-- identity-bearing boundary.
+decodedText :: (MonadEval m) => Text -> BS.ByteString -> m Text
+decodedText what bytes = case TE.decodeUtf8' bytes of
+  Right t -> pure t
+  Left _ -> throwEvalError (what <> ": invalid UTF-8 in string")
 
 -- | Evaluate a bytecode instruction by index.
 -- This is the primary evaluator - reads opcodes from the C bytecode
@@ -208,7 +222,7 @@ evalBytecode env bcIdx =
         OpLitNull -> pure VNull
         OpLitUri ->
           let sym = unsafePerformIO (cbcArg1 bcIdx)
-           in pure (mkStr (symbolText (Symbol sym)))
+           in pure (mkStrBytes (symbolBytes (Symbol sym)))
         OpLitPath ->
           let sym = unsafePerformIO (cbcArg1 bcIdx)
            in VPath <$> resolvePathLiteral (symbolText (Symbol sym))
@@ -345,11 +359,14 @@ evalAddWithCoercion left right = case (left, right) of
   -- Path + coercible: the result stays a path, the right side coerces
   -- WITHOUT a store copy, and a right side carrying string context is an
   -- error, as upstream (a store-path reference cannot survive inside a
-  -- path value).
+  -- path value).  Paths are Text in nova, so the appended bytes must
+  -- decode; invalid UTF-8 cannot form a filesystem path here.
   (VPath a, _) -> do
     (rightStr, rightCtx) <- coerceAddOperand right
     if rightCtx == emptyContext
-      then pure (VPath (canonPath (a <> rightStr)))
+      then do
+        appended <- decodedText "path concatenation" rightStr
+        pure (VPath (canonPath (a <> appended)))
       else throwEvalError "cannot append a string with context (a store-path reference) to a path"
   -- Strings: direct concat.
   (VStr {}, VStr {}) -> evalBinary force OpAdd left right
@@ -368,7 +385,7 @@ evalAddWithCoercion left right = case (left, right) of
 -- strings, sets with @__toString@\/@outPath@, and paths (copied to the
 -- store, carrying context) coerce; numbers, booleans, null, lists, and
 -- functions are type errors.
-coerceAddOperand :: (MonadEval m) => NixValue -> m (Text, StringContext)
+coerceAddOperand :: (MonadEval m) => NixValue -> m (BS.ByteString, StringContext)
 coerceAddOperand v@(VStr {}) = coerceToString False force applyValue v
 coerceAddOperand v@(VAttrs {}) = coerceToString False force applyValue v
 coerceAddOperand v@(VPath _) = coerceToStoreString v
@@ -420,7 +437,7 @@ evalBcStr env bcIdx0 = do
   let count = fromIntegral (unsafePerformIO (cbcShortArg bcIdx0))
       dataOff = unsafePerformIO (cbcArg1 bcIdx0)
   chunks <- evalBcStringParts env count dataOff
-  pure (VStr (T.concat [t | (_, t, _) <- chunks]) (mconcat [c | (_, _, c) <- chunks]))
+  pure (VStr (BS.concat [t | (_, t, _) <- chunks]) (mconcat [c | (_, _, c) <- chunks]))
 
 -- | Evaluate an indented string literal from bytecode data buffer.  The common
 -- indentation is stripped from the LITERAL chunks before concatenation, so an
@@ -438,13 +455,13 @@ evalBcIndStr env bcIdx0 = do
 -- words: (tag, value).  tag=0 means literal (value = symbol), tag=1 means
 -- interpolation (value = bc_idx).  The 'Bool' marks literal (@True@) vs
 -- interpolated (@False@) so indented strings strip only the literals.
-evalBcStringParts :: (MonadEval m) => Env -> Int -> Word32 -> m [(Bool, Text, StringContext)]
+evalBcStringParts :: (MonadEval m) => Env -> Int -> Word32 -> m [(Bool, BS.ByteString, StringContext)]
 evalBcStringParts _ 0 _ = pure []
 evalBcStringParts env n off = do
   let tag = unsafePerformIO (cbcData off)
       val = unsafePerformIO (cbcData (off + 1))
   chunk <- case tag of
-    0 -> pure (True, symbolText (Symbol val), emptyContext)
+    0 -> pure (True, symbolBytes (Symbol val), emptyContext)
     _ -> do
       v <- evalBytecode env val
       (txt, ctx) <- coerceToStringInterp v
@@ -592,7 +609,7 @@ walkBcAttrPath env n off val = case val of
         then do
           keyResult <- evalBytecode env keyVal
           case keyResult of
-            VStr s _ -> pure (Just s)
+            VStr s _ -> Just <$> decodedText "dynamic attribute key" s
             VNull -> pure Nothing
             _ -> throwEvalError ("dynamic attribute key must be a string, got " <> typeName keyResult)
         else pure (Just (symbolText (Symbol keyVal)))
@@ -804,7 +821,7 @@ resolveBcKey _env (BcStaticKey sym) = pure (Just (symbolText (Symbol sym)))
 resolveBcKey env (BcDynamicKey bcIdx0) = do
   val <- evalBytecode env bcIdx0
   case val of
-    VStr s _ -> pure (Just s)
+    VStr s _ -> Just <$> decodedText "dynamic attribute key" s
     VNull -> pure Nothing
     _ -> throwEvalError ("dynamic attribute key must be a string, got " <> typeName val)
 
@@ -1248,7 +1265,7 @@ precompileArgs _ args = args
 
 -- | The single-element arg list for a regex builtin: the compiled pattern
 -- if valid, the raw string otherwise (the error surfaces at execute time).
-compiledRegexArg :: Text -> [NixValue]
+compiledRegexArg :: BS.ByteString -> [NixValue]
 compiledRegexArg pat = case cachedCompileRegex pat of
   Just compiled -> [VCompiledRegex (CompiledRegex pat compiled)]
   Nothing -> [VStr pat emptyContext]
@@ -1518,8 +1535,9 @@ builtinTail other = throwEvalError ("builtins.tail: expected a list, got " <> ty
 -- Builtin implementations - string (arity 1)
 -- ---------------------------------------------------------------------------
 
+-- | Byte length, as upstream: @stringLength "ä"@ is 2, not 1.
 builtinStringLength :: (MonadEval m) => NixValue -> m NixValue
-builtinStringLength (VStr s _) = pure (VInt (fromIntegral (T.length s)))
+builtinStringLength (VStr s _) = pure (VInt (fromIntegral (BS.length s)))
 builtinStringLength other =
   throwEvalError ("builtins.stringLength: expected a string, got " <> typeName other)
 
@@ -1527,12 +1545,14 @@ builtinStringLength other =
 -- Builtin implementations - control
 -- ---------------------------------------------------------------------------
 
+-- | The error channel is Text and display-only (tryEval discards the
+-- message), so throw/abort messages decode lossily.
 builtinThrow :: (MonadEval m) => NixValue -> m NixValue
-builtinThrow (VStr msg _) = throwCatchableError msg
+builtinThrow (VStr msg _) = throwCatchableError (bytesToTextLossy msg)
 builtinThrow other = throwEvalError ("builtins.throw: expected a string, got " <> typeName other)
 
 builtinAbort :: (MonadEval m) => NixValue -> m NixValue
-builtinAbort (VStr msg _) = abortEvaluation msg
+builtinAbort (VStr msg _) = abortEvaluation (bytesToTextLossy msg)
 builtinAbort other = abortEvaluation ("builtins.abort: expected a string, got " <> typeName other)
 
 -- ---------------------------------------------------------------------------
@@ -1578,7 +1598,9 @@ listToAttrsPair thunk = do
       case nameVal of
         VStr keyName _ ->
           case attrSetLookup "value" attrs of
-            Just valueThunk -> pure (keyName, valueThunk)
+            Just valueThunk -> do
+              key <- decodedText "builtins.listToAttrs: attribute name" keyName
+              pure (key, valueThunk)
             Nothing -> throwEvalError "builtins.listToAttrs: element missing 'value'"
         _ -> throwEvalError "builtins.listToAttrs: 'name' must be a string"
     _ -> throwEvalError "builtins.listToAttrs: element must be a set"
@@ -1588,18 +1610,20 @@ listToAttrsPair thunk = do
 -- ---------------------------------------------------------------------------
 
 builtinHasAttr :: (MonadEval m) => NixValue -> NixValue -> m NixValue
-builtinHasAttr (VStr key _) (VAttrs attrs) =
-  pure (VBool (attrSetMember key attrs))
+builtinHasAttr (VStr key _) (VAttrs attrs) = do
+  name <- decodedText "builtins.hasAttr" key
+  pure (VBool (attrSetMember name attrs))
 builtinHasAttr (VStr _ _) other =
   throwEvalError ("builtins.hasAttr: expected a set, got " <> typeName other)
 builtinHasAttr other _ =
   throwEvalError ("builtins.hasAttr: expected a string, got " <> typeName other)
 
 builtinGetAttr :: (MonadEval m) => NixValue -> NixValue -> m NixValue
-builtinGetAttr (VStr key _) (VAttrs attrs) =
-  case attrSetLookup key attrs of
+builtinGetAttr (VStr key _) (VAttrs attrs) = do
+  name <- decodedText "builtins.getAttr" key
+  case attrSetLookup name attrs of
     Just thunk -> force thunk
-    Nothing -> throwEvalError ("builtins.getAttr: attribute '" <> key <> "' not found")
+    Nothing -> throwEvalError ("builtins.getAttr: attribute '" <> name <> "' not found")
 builtinGetAttr (VStr _ _) other =
   throwEvalError ("builtins.getAttr: expected a set, got " <> typeName other)
 builtinGetAttr other _ =
@@ -1614,7 +1638,7 @@ builtinRemoveAttrs (VAttrs attrs) (VList cl) = do
     forceToString thunk = do
       val <- force thunk
       case val of
-        VStr s _ -> pure s
+        VStr s _ -> decodedText "builtins.removeAttrs" s
         _ -> throwEvalError "builtins.removeAttrs: key list must contain strings"
 builtinRemoveAttrs (VAttrs _) other =
   throwEvalError ("builtins.removeAttrs: expected a list, got " <> typeName other)
@@ -1636,8 +1660,9 @@ builtinIntersectAttrs other _ =
 
 builtinCatAttrs :: (MonadEval m) => NixValue -> NixValue -> m NixValue
 builtinCatAttrs (VStr key _) (VList cl) = do
+  name <- decodedText "builtins.catAttrs" key
   let thunks = map Thunk (clistThunks cl)
-  vals <- catAttrsCollect key thunks
+  vals <- catAttrsCollect name thunks
   pure (VList (clistFromThunks (map thunkToCPtr vals)))
 builtinCatAttrs (VStr _ _) other =
   throwEvalError ("builtins.catAttrs: expected a list, got " <> typeName other)
@@ -1871,8 +1896,9 @@ groupByCollect _ [] acc = pure acc
 groupByCollect func (thunk : rest) acc = do
   result <- applyValueLazy func thunk
   case result of
-    VStr key _ ->
-      groupByCollect func rest (Map.insertWith (++) key [thunk] acc)
+    VStr key _ -> do
+      name <- decodedText "builtins.groupBy" key
+      groupByCollect func rest (Map.insertWith (++) name [thunk] acc)
     _ -> throwEvalError "builtins.groupBy: function must return a string"
 
 -- ---------------------------------------------------------------------------
@@ -1885,7 +1911,7 @@ builtinConcatStringsSep (VStr sep sepCtx) (VList cl) = do
   pairs <- mapM forceToStrCtx thunks
   let texts = map fst pairs
       mergedCtx = sepCtx <> mconcat (map snd pairs)
-  pure (VStr (T.intercalate sep texts) mergedCtx)
+  pure (VStr (BS.intercalate sep texts) mergedCtx)
   where
     forceToStrCtx thunk = do
       val <- force thunk
@@ -1919,19 +1945,21 @@ foldlStrict op acc (thunk : rest) = do
   stepped <- applyValueLazy partial thunk
   foldlStrict op stepped rest
 
+-- | Byte-indexed slicing, as upstream: offsets and lengths count bytes,
+-- and a slice may fall mid-codepoint (the resulting bytes are the value).
 builtinSubstring :: (MonadEval m) => NixValue -> NixValue -> NixValue -> m NixValue
 builtinSubstring (VInt start) (VInt len) (VStr s ctx)
   | start < 0 = throwEvalError "builtins.substring: negative start position"
   | otherwise =
       let startPos = fromIntegral start
           -- Nix clamps len to available length (negative len means rest of string)
-          available = T.length s - startPos
+          available = BS.length s - startPos
           clampedLen =
             if len < 0
               then available
               else min (fromIntegral len) available
        in -- Context is preserved through substring (matching real Nix).
-          pure (VStr (T.take clampedLen (T.drop startPos s)) ctx)
+          pure (VStr (BS.take clampedLen (BS.drop startPos s)) ctx)
 builtinSubstring _ _ (VStr _ _) =
   throwEvalError "builtins.substring: start and length must be integers"
 builtinSubstring _ _ other =
@@ -1961,13 +1989,13 @@ deferApplyExpr = EApp (EResolvedVar 0 0) (EResolvedVar 0 1)
 -- Like 'coerceToString' but additionally handles lists: elements are
 -- recursively coerced and joined with spaces, matching real Nix semantics.
 -- @toString [1 2 3]@ gives @"1 2 3"@.
-coerceToStringPermissive :: (MonadEval m) => NixValue -> m (Text, StringContext)
+coerceToStringPermissive :: (MonadEval m) => NixValue -> m (BS.ByteString, StringContext)
 coerceToStringPermissive (VList cl) = do
   let thunks = map Thunk (clistThunks cl)
   parts <- mapM coerceThunk thunks
   let texts = map fst parts
       ctx = mconcat (map snd parts)
-  pure (T.intercalate " " texts, ctx)
+  pure (BS.intercalate " " texts, ctx)
   where
     coerceThunk thunk = do
       val <- force thunk
@@ -1979,20 +2007,24 @@ coerceToStringPermissive other = coerceToString True force applyValue other
 -- the store: it becomes its source store path, with that path added to the
 -- string context so it lands in the derivation's @inputSrcs@ - matching C++
 -- Nix's copy-to-store coercion of paths in derivation arguments/environment.
-coerceToStoreString :: (MonadEval m) => NixValue -> m (Text, StringContext)
-coerceToStoreString (VPath p) = sourcePathWithContext p
+coerceToStoreString :: (MonadEval m) => NixValue -> m (BS.ByteString, StringContext)
+coerceToStoreString (VPath p) = do
+  (spText, ctx) <- sourcePathWithContext p
+  pure (TE.encodeUtf8 spText, ctx)
 coerceToStoreString (VList cl) = do
   let thunks = map Thunk (clistThunks cl)
   parts <- mapM (force >=> coerceToStoreString) thunks
-  pure (T.intercalate " " (map fst parts), mconcat (map snd parts))
+  pure (BS.intercalate " " (map fst parts), mconcat (map snd parts))
 coerceToStoreString other = coerceToStringPermissive other
 
 -- | Coerce a value for string interpolation (@"${...}"@).  Like
 -- 'coerceToString', but a path literal is copied into the store and replaced by
 -- its source store path (with context) - matching C++ Nix, where interpolation
 -- uses @copyToStore = true@, unlike 'builtins.toString', which does not copy.
-coerceToStringInterp :: (MonadEval m) => NixValue -> m (Text, StringContext)
-coerceToStringInterp (VPath p) = sourcePathWithContext p
+coerceToStringInterp :: (MonadEval m) => NixValue -> m (BS.ByteString, StringContext)
+coerceToStringInterp (VPath p) = do
+  (spText, ctx) <- sourcePathWithContext p
+  pure (TE.encodeUtf8 spText, ctx)
 coerceToStringInterp other = coerceToString False force applyValue other
 
 -- | The store path a source path literal coerces to, carrying its
@@ -2057,7 +2089,7 @@ intFromDouble ctx rounder f
     rounded = rounder f
 
 builtinDiscardContext :: (MonadEval m) => NixValue -> m NixValue
-builtinDiscardContext (VStr s _) = pure (mkStr s)
+builtinDiscardContext (VStr s _) = pure (mkStrBytes s)
 builtinDiscardContext other =
   throwEvalError ("builtins.unsafeDiscardStringContext: expected a string, got " <> typeName other)
 
@@ -2224,24 +2256,29 @@ parseContextAttrs attrs = do
     forceToOutputName thunk = do
       val <- force thunk
       case val of
-        VStr s _ -> pure s
+        VStr s _ -> decodedText "builtins.appendContext" s
         _ -> throwEvalError "builtins.appendContext: output name must be a string"
 
 builtinBaseNameOf :: (MonadEval m) => NixValue -> m NixValue
-builtinBaseNameOf (VStr s ctx) = pure (VStr (lastComponent s) ctx)
+builtinBaseNameOf (VStr s ctx) = pure (VStr (lastComponentBytes s) ctx)
 builtinBaseNameOf (VPath p) = pure (mkStr (lastComponent p))
 builtinBaseNameOf other =
   throwEvalError ("builtins.baseNameOf: expected a string or path, got " <> typeName other)
 
 lastComponent :: Text -> Text
-lastComponent t = case T.splitOn "/" t of
-  [] -> t
-  parts -> case reverse (filter (not . T.null) parts) of
-    [] -> ""
-    (final : _) -> final
+lastComponent t = case reverse (filter (not . T.null) (T.splitOn "/" t)) of
+  [] -> ""
+  (final : _) -> final
+
+-- | Byte-level 'lastComponent' for string operands ('/' is a single byte
+-- in UTF-8 and never occurs inside a multi-byte sequence).
+lastComponentBytes :: BS.ByteString -> BS.ByteString
+lastComponentBytes t = case reverse (filter (not . BS.null) (BC.split '/' t)) of
+  [] -> ""
+  (final : _) -> final
 
 builtinDirOf :: (MonadEval m) => NixValue -> m NixValue
-builtinDirOf (VStr s ctx) = pure (VStr (dirComponent s) ctx)
+builtinDirOf (VStr s ctx) = pure (VStr (dirComponentBytes s) ctx)
 builtinDirOf (VPath p) = pure (VPath (dirComponent p))
 builtinDirOf other =
   throwEvalError ("builtins.dirOf: expected a string or path, got " <> typeName other)
@@ -2254,6 +2291,16 @@ dirComponent t =
       let dir = T.take (T.length t - n - 1) t
        in -- A leading or sole '/' leaves an empty prefix; Nix's dirOf yields "/".
           if T.null dir then "/" else dir
+
+-- | Byte-level 'dirComponent' for string operands: everything before the
+-- last '/' byte, with the same "." / "/" edge results.
+dirComponentBytes :: BS.ByteString -> BS.ByteString
+dirComponentBytes t =
+  case BC.elemIndexEnd '/' t of
+    Nothing -> "."
+    Just idx ->
+      let dir = BS.take idx t
+       in if BS.null dir then "/" else dir
 
 builtinConcatLists :: (MonadEval m) => NixValue -> m NixValue
 builtinConcatLists (VList cl) = do
@@ -2428,31 +2475,34 @@ builtinReplaceStrings _ _ (VStr _ _) =
 builtinReplaceStrings _ _ other =
   throwEvalError ("builtins.replaceStrings: expected a string, got " <> typeName other)
 
--- | Replace all occurrences, O(n) via chunk list + T.concat.
-replaceAll :: [(Text, Text)] -> Text -> Text
-replaceAll pairs input = T.concat (go input)
+-- | Replace all occurrences, O(n) via chunk list + BS.concat.
+-- Matching and stepping are byte-level, as upstream: an empty @from@
+-- element inserts between BYTES, so a 2-byte character gets a
+-- replacement inside it.
+replaceAll :: [(BS.ByteString, BS.ByteString)] -> BS.ByteString -> BS.ByteString
+replaceAll pairs input = BS.concat (go input)
   where
     go remaining
-      | T.null remaining =
+      | BS.null remaining =
           -- At end of string, still check for empty-from match
           case findMatch pairs remaining of
             Just (replacement, _, _) -> [replacement]
             Nothing -> []
       | otherwise = case findMatch pairs remaining of
           Just (replacement, rest, matched) ->
-            if T.null matched
-              then case T.uncons remaining of
-                -- empty-from: insert replacement then advance 1 char
-                Just (ch, after) -> replacement : T.singleton ch : go after
+            if BS.null matched
+              then case BS.uncons remaining of
+                -- empty-from: insert replacement then advance ONE BYTE
+                Just (byte, after) -> replacement : BS.singleton byte : go after
                 Nothing -> [replacement]
               else replacement : go rest
-          Nothing -> case T.uncons remaining of
-            Just (ch, after) -> T.singleton ch : go after
+          Nothing -> case BS.uncons remaining of
+            Just (byte, after) -> BS.singleton byte : go after
             Nothing -> []
     findMatch [] _ = Nothing
     findMatch ((from, to) : rest) txt
-      | T.null from = Just (to, txt, from)
-      | Just suffix <- T.stripPrefix from txt = Just (to, suffix, from)
+      | BS.null from = Just (to, txt, from)
+      | Just suffix <- BS.stripPrefix from txt = Just (to, suffix, from)
       | otherwise = findMatch rest txt
 
 -- ---------------------------------------------------------------------------
@@ -2463,11 +2513,11 @@ replaceAll pairs input = T.concat (go input)
 -- Regex compilation cache
 -- ---------------------------------------------------------------------------
 
--- | Global regex compilation cache.  Keyed by the raw pattern string
+-- | Global regex compilation cache.  Keyed by the raw pattern bytes
 -- (match and split share entries).  Idempotent memoization via
 -- unsafePerformIO - same rationale as thunk memoization.
 {-# NOINLINE regexCacheRef #-}
-regexCacheRef :: IORef (Map Text RE.Regex)
+regexCacheRef :: IORef (Map BS.ByteString RE.Regex)
 regexCacheRef = unsafePerformIO (newIORef Map.empty)
 
 -- | Compile options matching C++ Nix's POSIX ERE semantics: no multiline
@@ -2477,17 +2527,20 @@ regexCacheRef = unsafePerformIO (newIORef Map.empty)
 wholeStringCompOpt :: RE.CompOption
 wholeStringCompOpt = RE.defaultCompOpt {RE.multiline = False}
 
--- | Compile a regex, using the global cache to avoid recompilation.
+-- | Compile a regex from its raw pattern bytes, using the global cache to
+-- avoid recompilation.  Compiling from bytes makes the PATTERN byte-level
+-- too, matching upstream: a multi-byte character in the pattern is a
+-- sequence of single-byte atoms, so it lines up with byte-level subjects.
 -- Returns Nothing for invalid patterns.  NOINLINE prevents GHC from
 -- inlining and floating the unsafePerformIO reads.
 {-# NOINLINE cachedCompileRegex #-}
-cachedCompileRegex :: Text -> Maybe RE.Regex
+cachedCompileRegex :: BS.ByteString -> Maybe RE.Regex
 cachedCompileRegex pat =
   unsafePerformIO $ do
     cache <- atomicModifyIORef' regexCacheRef (\c -> (c, c))
     case Map.lookup pat cache of
       Just compiled -> pure (Just compiled)
-      Nothing -> case RE.makeRegexOptsM wholeStringCompOpt RE.defaultExecOpt (T.unpack pat) :: Maybe RE.Regex of
+      Nothing -> case RE.makeRegexOptsM wholeStringCompOpt RE.defaultExecOpt pat :: Maybe RE.Regex of
         Nothing -> pure Nothing
         Just compiled -> do
           atomicModifyIORef' regexCacheRef (\c -> (Map.insert pat compiled c, ()))
@@ -2508,7 +2561,7 @@ builtinMatch (VCompiledRegex (CompiledRegex _ compiled)) (VStr str _) =
 -- Direct 2-arg call: use global compilation cache.
 builtinMatch (VStr regex _) (VStr str _) =
   case cachedCompileRegex regex of
-    Nothing -> throwEvalError ("builtins.match: invalid regex: " <> regex)
+    Nothing -> throwEvalError ("builtins.match: invalid regex: " <> bytesToTextLossy regex)
     Just compiled -> matchWithCompiled compiled str
 builtinMatch (VStr _ _) other =
   throwEvalError ("builtins.match: expected a string, got " <> typeName other)
@@ -2525,19 +2578,19 @@ builtinMatch other _ =
 -- whole subject exactly when a whole-string match exists.  This is what
 -- regex_match gives C++ Nix; textual @^...$@ anchoring is NOT equivalent
 -- (it misparses top-level alternation).
-matchWithCompiled :: (MonadEval m) => RE.Regex -> Text -> m NixValue
+matchWithCompiled :: (MonadEval m) => RE.Regex -> BS.ByteString -> m NixValue
 matchWithCompiled compiled str =
-  case RE.matchOnceText compiled (T.unpack str) of
+  case RE.matchOnceText compiled str of
     Just (beforeMatch, match, afterMatch)
-      | null beforeMatch,
-        null afterMatch ->
-          -- match is an Array of (String, (offset, len)) pairs.
+      | BS.null beforeMatch,
+        BS.null afterMatch ->
+          -- match is an Array of (bytes, (offset, len)) pairs.
           -- Index 0 is the full match; indices 1.. are capture groups.
           let captureGroups = drop 1 (Array.elems match)
               -- A non-participating capture group has offset (-1); C++ Nix
               -- yields null for it, not the empty string.
               toThunk (s, (off, _)) =
-                if off < 0 then evaluated VNull else evaluated (mkStr (T.pack s))
+                if off < 0 then evaluated VNull else evaluated (mkStrBytes s)
            in pure (VList (clistFromThunks (map (thunkToCPtr . toThunk) captureGroups)))
     _ -> pure VNull
 
@@ -2551,7 +2604,7 @@ builtinSplit (VCompiledRegex (CompiledRegex _ compiled)) (VStr str _) =
 -- Direct 2-arg call: use global compilation cache.
 builtinSplit (VStr regex _) (VStr str _) =
   case cachedCompileRegex regex of
-    Nothing -> throwEvalError ("builtins.split: invalid regex: " <> regex)
+    Nothing -> throwEvalError ("builtins.split: invalid regex: " <> bytesToTextLossy regex)
     Just compiled -> splitWithCompiled compiled str
 builtinSplit (VStr _ _) other =
   throwEvalError ("builtins.split: expected a string, got " <> typeName other)
@@ -2561,33 +2614,34 @@ builtinSplit other _ =
   throwEvalError ("builtins.split: expected a string (regex), got " <> typeName other)
 
 -- | Shared split logic for pre-compiled and freshly-compiled regex paths.
-splitWithCompiled :: (MonadEval m) => RE.Regex -> Text -> m NixValue
+splitWithCompiled :: (MonadEval m) => RE.Regex -> BS.ByteString -> m NixValue
 splitWithCompiled compiled str =
-  let allMatches = matchAllText compiled (T.unpack str)
-      strText = T.unpack str
-      result = buildSplitResult strText 0 allMatches
+  let allMatches = matchAllText compiled str
+      result = buildSplitResult str 0 allMatches
    in pure (VList (clistFromThunks (map thunkToCPtr result)))
 
--- | Build the alternating list for builtins.split.
-buildSplitResult :: String -> Int -> [Array.Array Int (String, (Int, Int))] -> [Thunk]
+-- | Build the alternating list for builtins.split.  Offsets from the
+-- ByteString regex instance are byte offsets, so slicing is O(1)
+-- 'BS.take'/'BS.drop'.
+buildSplitResult :: BS.ByteString -> Int -> [Array.Array Int (BS.ByteString, (Int, Int))] -> [Thunk]
 buildSplitResult remaining pos [] =
   -- No more matches - emit the rest of the string.
-  [evaluated (mkStr (T.pack (drop pos remaining)))]
+  [evaluated (mkStrBytes (BS.drop pos remaining))]
 buildSplitResult remaining pos (match : rest) =
   let elems = Array.elems match
       (_, (matchStart, matchLen)) = case elems of
         (full : _) -> full
         [] -> ("", (pos, 0)) -- defensive: should not happen from matchAllText
-        -- Text before this match
-      before = T.pack (take (matchStart - pos) (drop pos remaining))
+        -- Bytes before this match
+      before = BS.take (matchStart - pos) (BS.drop pos remaining)
       -- Capture groups (indices 1..)
-      groups = drop 1 (Array.elems match)
+      groups = drop 1 elems
       -- A non-participating capture group has offset (-1) becomes null (as 'match').
       groupThunks =
-        map (\(s, (off, _)) -> if off < 0 then evaluated VNull else evaluated (mkStr (T.pack s))) groups
+        map (\(s, (off, _)) -> if off < 0 then evaluated VNull else evaluated (mkStrBytes s)) groups
       -- Continue after this match
       afterPos = matchStart + matchLen
-   in evaluated (mkStr before)
+   in evaluated (mkStrBytes before)
         : evaluated (VList (clistFromThunks (map thunkToCPtr groupThunks)))
         : buildSplitResult remaining afterPos rest
 
@@ -2602,7 +2656,7 @@ ordToNix LT = -1
 ordToNix EQ = 0
 ordToNix GT = 1
 
-compareVersionParts :: [Text] -> [Text] -> Int64
+compareVersionParts :: [BS.ByteString] -> [BS.ByteString] -> Int64
 compareVersionParts [] [] = 0
 -- When one version runs out, Nix pads the shorter side with an empty
 -- component and keeps comparing - so "1.0" > "1.0pre" (empty sorts AFTER
@@ -2620,7 +2674,13 @@ compareVersionParts (a : as) (b : bs) =
     EQ -> compareVersionParts as bs
     cmp -> ordToNix cmp
 
-compareComponent :: Text -> Text -> Ordering
+-- | Byte-level alpha classification, as upstream (C @isalpha@ over
+-- bytes): a non-ASCII letter is a separator, never an alphabetic
+-- component.  Digits need no counterpart - 'isDigit' is @0-9@ only.
+isVersionAlpha :: Char -> Bool
+isVersionAlpha c = isAsciiLower c || isAsciiUpper c
+
+compareComponent :: BS.ByteString -> BS.ByteString -> Ordering
 compareComponent a b
   | a == b = EQ
   | allDigits a && allDigits b = compare (readInt a) (readInt b)
@@ -2634,57 +2694,56 @@ compareComponent a b
   | allDigits a && isAlphaComp b = GT
   | otherwise = compare a b
   where
-    allDigits t = not (T.null t) && T.all isDigit t
-    isAlphaComp t = case T.uncons t of
-      Just (c, _) -> isAlpha c
+    allDigits t = not (BS.null t) && BC.all isDigit t
+    isAlphaComp t = case BC.uncons t of
+      Just (c, _) -> isVersionAlpha c
       Nothing -> False
-    readInt :: Text -> Int64
-    readInt = T.foldl' (\acc c -> acc * 10 + fromIntegral (digitToInt c)) (0 :: Int64)
+    readInt :: BS.ByteString -> Int64
+    readInt = BC.foldl' (\acc c -> acc * 10 + fromIntegral (digitToInt c)) (0 :: Int64)
 
-splitVersionStr :: Text -> [Text]
+splitVersionStr :: BS.ByteString -> [BS.ByteString]
 splitVersionStr t
-  | T.null t = []
+  | BS.null t = []
   | otherwise =
       let (component, rest) = spanComponent t
        in component : splitVersionAfterComponent rest
 
-splitVersionAfterComponent :: Text -> [Text]
-splitVersionAfterComponent t = case T.uncons t of
+splitVersionAfterComponent :: BS.ByteString -> [BS.ByteString]
+splitVersionAfterComponent t = case BC.uncons t of
   Nothing -> []
   -- '.' and '-' are both component separators in Nix's version grammar, so a
   -- '-' is skipped, not emitted as a one-character component.
   Just (sep, rest) | sep == '.' || sep == '-' -> splitVersionStr rest
   Just _ -> splitVersionStr t
 
-spanComponent :: Text -> (Text, Text)
-spanComponent t = case T.uncons t of
+spanComponent :: BS.ByteString -> (BS.ByteString, BS.ByteString)
+spanComponent t = case BC.uncons t of
   Nothing -> ("", "")
   Just (c, rest)
-    | isDigit c -> T.span isDigit t
-    | isAlpha c -> T.span isAlpha t
-    | otherwise -> (T.singleton c, rest)
+    | isDigit c -> BC.span isDigit t
+    | isVersionAlpha c -> BC.span isVersionAlpha t
+    | otherwise -> (BS.take 1 t, rest)
 
 builtinSplitVersion :: (MonadEval m) => NixValue -> m NixValue
 builtinSplitVersion (VStr s _) =
-  pure (VList (clistFromThunks (map (thunkToCPtr . evaluated . mkStr) (splitVersionComponents s))))
+  pure (VList (clistFromThunks (map (thunkToCPtr . evaluated . mkStrBytes) (splitVersionComponents s))))
 builtinSplitVersion other =
   throwEvalError ("builtins.splitVersion: expected a string, got " <> typeName other)
 
-splitVersionComponents :: Text -> [Text]
-splitVersionComponents t = case T.uncons t of
+splitVersionComponents :: BS.ByteString -> [BS.ByteString]
+splitVersionComponents t = case BC.uncons t of
   Nothing -> []
   Just ('.', rest) -> splitVersionComponents rest
   Just (c, _)
     | isDigit c ->
-        let (digits, rest) = T.span isDigit t
+        let (digits, rest) = BC.span isDigit t
          in digits : splitVersionComponents rest
-    | isAlpha c ->
-        let (alpha, rest) = T.span isAlpha t
+    | isVersionAlpha c ->
+        let (alpha, rest) = BC.span isVersionAlpha t
          in alpha : splitVersionComponents rest
     | otherwise ->
-        -- Non-alphanumeric separator (e.g. '-', '_'): consume as single char
-        let (_, rest) = T.splitAt 1 t
-         in splitVersionComponents rest
+        -- Non-alphanumeric separator byte (e.g. '-', '_'): consume it
+        splitVersionComponents (BS.drop 1 t)
 
 builtinParseDrvName :: (MonadEval m) => NixValue -> m NixValue
 builtinParseDrvName (VStr s _) =
@@ -2693,25 +2752,25 @@ builtinParseDrvName (VStr s _) =
         ( VAttrs
             ( attrSetFromMap $
                 Map.fromList
-                  [ ("name", evaluated (mkStr name)),
-                    ("version", evaluated (mkStr version))
+                  [ ("name", evaluated (mkStrBytes name)),
+                    ("version", evaluated (mkStrBytes version))
                   ]
             )
         )
 builtinParseDrvName other =
   throwEvalError ("builtins.parseDrvName: expected a string, got " <> typeName other)
 
-parseName :: Text -> (Text, Text)
+parseName :: BS.ByteString -> (BS.ByteString, BS.ByteString)
 parseName t =
   case findVersionDash t 0 of
     Nothing -> (t, "")
-    Just idx -> (T.take idx t, T.drop (idx + 1) t)
+    Just idx -> (BS.take idx t, BS.drop (idx + 1) t)
 
-findVersionDash :: Text -> Int -> Maybe Int
-findVersionDash t idx = case T.uncons (T.drop idx t) of
+findVersionDash :: BS.ByteString -> Int -> Maybe Int
+findVersionDash t idx = case BC.uncons (BS.drop idx t) of
   Nothing -> Nothing
   Just ('-', after)
-    | Just (d, _) <- T.uncons after,
+    | Just (d, _) <- BC.uncons after,
       isDigit d ->
         Just idx
   Just _ -> findVersionDash t (idx + 1)
@@ -2723,8 +2782,11 @@ findVersionDash t idx = case T.uncons (T.drop idx t) of
 builtinToJSON :: (MonadEval m) => NixValue -> m NixValue
 builtinToJSON val = do
   (json, ctx) <- valueToJSON val
-  pure (VStr json ctx)
+  pure (VStr (TE.encodeUtf8 json) ctx)
 
+-- | JSON is built as 'Text' and encoded once at the top: upstream's
+-- serializer (nlohmann) REJECTS invalid UTF-8, so string payloads decode
+-- strictly here and invalid bytes are an eval error, matching upstream.
 valueToJSON :: (MonadEval m) => NixValue -> m (Text, StringContext)
 valueToJSON VNull = pure ("null", emptyContext)
 valueToJSON (VBool True) = pure ("true", emptyContext)
@@ -2734,7 +2796,9 @@ valueToJSON (VFloat f)
   -- upstream's serializer (nlohmann dump) writes a non-finite float as null
   | isNaN f || isInfinite f = pure ("null", emptyContext)
   | otherwise = pure (formatJsonFloat f, emptyContext)
-valueToJSON (VStr s ctx) = pure (jsonEscapeString s, ctx)
+valueToJSON (VStr s ctx) = do
+  decoded <- decodedText "builtins.toJSON" s
+  pure (jsonEscapeString decoded, ctx)
 valueToJSON (VList cl) = do
   let thunks = map Thunk (clistThunks cl)
   vals <- mapM force thunks
@@ -2755,7 +2819,8 @@ valueToJSON (VAttrs attrs) =
       pure ("{" <> T.intercalate "," pairs <> "}", ctx)
     _ -> do
       (s, ctx) <- coerceToString True force applyValue (VAttrs attrs)
-      pure (jsonEscapeString s, ctx)
+      decoded <- decodedText "builtins.toJSON" s
+      pure (jsonEscapeString decoded, ctx)
   where
     jsonPair attrMap key = case Map.lookup key attrMap of
       Nothing -> pure ("", emptyContext)
@@ -2802,11 +2867,14 @@ hexDigit n
   | otherwise = '?' -- unreachable for valid hex
 
 builtinFromJSON :: (MonadEval m) => NixValue -> m NixValue
-builtinFromJSON (VStr s _) = case parseJSON (T.strip s) of
-  Just (val, rest)
-    | T.null (T.strip rest) -> pure val
-    | otherwise -> throwEvalError "builtins.fromJSON: trailing content after JSON value"
-  Nothing -> throwEvalError "builtins.fromJSON: invalid JSON"
+builtinFromJSON (VStr s _) = do
+  -- JSON input must be valid UTF-8 (upstream's parser rejects it too).
+  decoded <- decodedText "builtins.fromJSON" s
+  case parseJSON (T.strip decoded) of
+    Just (val, rest)
+      | T.null (T.strip rest) -> pure val
+      | otherwise -> throwEvalError "builtins.fromJSON: trailing content after JSON value"
+    Nothing -> throwEvalError "builtins.fromJSON: invalid JSON"
 builtinFromJSON other =
   throwEvalError ("builtins.fromJSON: expected a string, got " <> typeName other)
 
@@ -2922,23 +2990,29 @@ parseJSONObject t = parseJSONObjectEntries (T.stripStart t) Map.empty
 parseJSONObjectEntries :: Text -> Map Text Thunk -> Maybe (NixValue, Text)
 parseJSONObjectEntries t acc = case T.uncons (T.stripStart t) of
   Just ('}', rest) -> Just (VAttrs (attrSetFromMap acc), rest)
-  _ -> case parseJSONString (T.stripStart t) of
-    Just (VStr key _, rest) -> case T.uncons (T.stripStart rest) of
-      Just (':', rest2) -> case parseJSON rest2 of
-        Just (val, rest3) ->
-          let stripped = T.stripStart rest3
-              updated = Map.insert key (evaluated val) acc
-           in case T.uncons stripped of
-                Just (',', rest4) -> parseJSONObjectEntries rest4 updated
-                Just ('}', rest4) -> Just (VAttrs (attrSetFromMap updated), rest4)
-                _ -> Nothing
-        Nothing -> Nothing
-      _ -> Nothing
-    _ -> Nothing
+  -- Keys read via 'parseJSONStringContent' directly: they become attr
+  -- names (Text), not string values.
+  Just ('"', afterQuote) ->
+    let (key, rest) = parseJSONStringContent afterQuote
+     in case T.uncons (T.stripStart rest) of
+          Just (':', rest2) -> case parseJSON rest2 of
+            Just (val, rest3) ->
+              let stripped = T.stripStart rest3
+                  updated = Map.insert key (evaluated val) acc
+               in case T.uncons stripped of
+                    Just (',', rest4) -> parseJSONObjectEntries rest4 updated
+                    Just ('}', rest4) -> Just (VAttrs (attrSetFromMap updated), rest4)
+                    _ -> Nothing
+            Nothing -> Nothing
+          _ -> Nothing
+  _ -> Nothing
 
 builtinHashString :: (MonadEval m) => NixValue -> NixValue -> m NixValue
-builtinHashString (VStr algo _) (VStr input _) =
-  hashBytesWithAlgo "hashString" algo (TE.encodeUtf8 input)
+builtinHashString (VStr algo _) (VStr input _) = do
+  -- The payload IS the hashed bytes - no encode step, so a mid-codepoint
+  -- substring hashes to the sha256 of exactly those bytes, as upstream.
+  algoName <- decodedText "builtins.hashString" algo
+  hashBytesWithAlgo "hashString" algoName input
 builtinHashString (VStr _ _) other =
   throwEvalError ("builtins.hashString: expected a string, got " <> typeName other)
 builtinHashString other _ =
@@ -2969,7 +3043,7 @@ builtinSeq !_first = pure
 builtinTrace :: (MonadEval m) => NixValue -> NixValue -> m NixValue
 builtinTrace msgVal result = do
   msg <- case msgVal of
-    VStr s _ -> pure s
+    VStr s _ -> pure (bytesToTextLossy s)
     other -> pure (showValueForTrace other)
   traceMessage ("trace: " <> msg)
   pure result
@@ -2978,7 +3052,7 @@ builtinTrace msgVal result = do
 builtinWarn :: (MonadEval m) => NixValue -> NixValue -> m NixValue
 builtinWarn msgVal result = do
   msg <- case msgVal of
-    VStr s _ -> pure s
+    VStr s _ -> pure (bytesToTextLossy s)
     other -> pure (showValueForTrace other)
   traceMessage ("warning: " <> msg)
   pure result
@@ -3059,23 +3133,32 @@ keyInList key (seen : rest) = do
 -- ---------------------------------------------------------------------------
 
 -- | Coerce a value to a path 'Text'.  Accepts 'VPath' and 'VStr';
--- throws a type error for anything else.
+-- throws a type error for anything else.  A string operand is a byte
+-- string naming a filesystem path, so it decodes strictly.
 coerceToPath :: (MonadEval m) => Text -> NixValue -> m Text
 coerceToPath _ (VPath p) = pure p
-coerceToPath _ (VStr s _) = pure s
+coerceToPath name (VStr s _) = decodedText ("builtins." <> name) s
 coerceToPath name other =
   throwEvalError ("builtins." <> name <> ": expected a path or string, got " <> typeName other)
 
 builtinImport :: (MonadEval m) => NixValue -> m NixValue
 builtinImport (VPath p) = importFile p
-builtinImport (VStr s _) = importFile s
+builtinImport (VStr s _) = importFile =<< decodedText "import" s
 builtinImport other =
   throwEvalError ("import: expected a path or string, got " <> typeName other)
 
 builtinReadFile :: (MonadEval m) => NixValue -> m NixValue
 builtinReadFile val = do
   p <- coerceToPath "readFile" val
-  mkStr <$> readFileText p
+  bytes <- readFileBytes p
+  -- The value is the file's RAW BYTES, as upstream: no BOM stripping, no
+  -- UTF-16 transcoding, no replacement characters (the auto-decode stays
+  -- on the parser/import path only).  The only rejection is NUL, which a
+  -- Nix string cannot represent upstream.
+  when (BS.elem 0 bytes) $
+    throwEvalError
+      ("builtins.readFile: the contents of the file '" <> p <> "' cannot be represented as a Nix string")
+  pure (mkStrBytes bytes)
 
 builtinPathExists :: (MonadEval m) => NixValue -> m NixValue
 builtinPathExists val = do
@@ -3093,17 +3176,21 @@ builtinReadDir val = do
 -- ---------------------------------------------------------------------------
 
 builtinGetEnv :: (MonadEval m) => NixValue -> m NixValue
-builtinGetEnv (VStr name _) = mkStr <$> getEnvVar name
+builtinGetEnv (VStr name _) = do
+  varName <- decodedText "builtins.getEnv" name
+  mkStr <$> getEnvVar varName
 builtinGetEnv other =
   throwEvalError ("builtins.getEnv: expected a string, got " <> typeName other)
 
 builtinToPath :: (MonadEval m) => NixValue -> m NixValue
 builtinToPath (VPath p) = pure (VPath p)
-builtinToPath (VStr s _) = case T.uncons s of
-  Nothing -> throwEvalError "builtins.toPath: empty path"
-  -- Canonicalized like every other path production site, as upstream.
-  Just ('/', _) -> pure (VPath (canonPath s))
-  Just _ -> throwEvalError ("builtins.toPath: path must be absolute, got " <> s)
+builtinToPath (VStr rawBytes _) = do
+  s <- decodedText "builtins.toPath" rawBytes
+  case T.uncons s of
+    Nothing -> throwEvalError "builtins.toPath: empty path"
+    -- Canonicalized like every other path production site, as upstream.
+    Just ('/', _) -> pure (VPath (canonPath s))
+    Just _ -> throwEvalError ("builtins.toPath: path must be absolute, got " <> s)
 builtinToPath other =
   throwEvalError ("builtins.toPath: expected a string or path, got " <> typeName other)
 
@@ -3112,13 +3199,15 @@ builtinToPath other =
 -- ---------------------------------------------------------------------------
 
 builtinPlaceholder :: (MonadEval m) => NixValue -> m NixValue
-builtinPlaceholder (VStr outputName _) = pure (mkStr (hashPlaceholder outputName))
+builtinPlaceholder (VStr outputName _) = do
+  name <- decodedText "builtins.placeholder" outputName
+  pure (mkStr (hashPlaceholder name))
 builtinPlaceholder other =
   throwEvalError ("builtins.placeholder: expected a string, got " <> typeName other)
 
 builtinStorePath :: (MonadEval m) => NixValue -> m NixValue
 builtinStorePath (VPath p) = validateStorePath p
-builtinStorePath (VStr s _) = validateStorePath s
+builtinStorePath (VStr s _) = validateStorePath =<< decodedText "builtins.storePath" s
 builtinStorePath other =
   throwEvalError ("builtins.storePath: expected a path or string, got " <> typeName other)
 
@@ -3131,7 +3220,7 @@ builtinStorePath other =
 -- the canonical @/nix/store@ text is not the on-disk location.
 validateStorePath :: (MonadEval m) => Text -> m NixValue
 validateStorePath p = case enclosingStorePath p of
-  Just sp -> pure (VStr p (plainContext sp))
+  Just sp -> pure (VStr (TE.encodeUtf8 p) (plainContext sp))
   Nothing -> throwEvalError ("builtins.storePath: not a valid store path: " <> p)
 
 -- | The store path enclosing an absolute path under the store dir, or
@@ -3155,9 +3244,10 @@ enclosingStorePath p = do
 
 builtinFindFile :: (MonadEval m) => NixValue -> NixValue -> m NixValue
 builtinFindFile (VList cl) (VStr name _) = do
+  fileName <- decodedText "builtins.findFile" name
   let searchPath = map Thunk (clistThunks cl)
   entries <- mapM forceSearchEntry searchPath
-  findFirst entries name
+  findFirst entries fileName
 builtinFindFile (VList _) other =
   throwEvalError ("builtins.findFile: expected a string, got " <> typeName other)
 builtinFindFile other _ =
@@ -3178,10 +3268,10 @@ forceSearchEntry thunk = do
       prefixVal <- force prefixThunk
       pathVal <- force pathThunk
       prefix <- case prefixVal of
-        VStr s _ -> pure s
+        VStr s _ -> decodedText "builtins.findFile" s
         _ -> throwEvalError "builtins.findFile: 'prefix' must be a string"
       path <- case pathVal of
-        VStr s _ -> pure s
+        VStr s _ -> decodedText "builtins.findFile" s
         VPath s -> pure s
         _ -> throwEvalError "builtins.findFile: 'path' must be a string or path"
       pure (prefix, path)
@@ -3218,12 +3308,14 @@ findFirst ((prefix, path) : rest) name
 
 builtinToFile :: (MonadEval m) => NixValue -> NixValue -> m NixValue
 builtinToFile (VStr name _) (VStr contents ctx) = do
+  fileName <- decodedText "builtins.toFile" name
   refs <- toFileRefs ctx
-  storePath <- writeToStore name contents refs
+  -- The contents are stored (and hashed) as their raw bytes.
+  storePath <- writeToStore fileName contents refs
   -- Upstream returns a STRING whose context is the new path itself; the
   -- refs travel through the store path computation, not the eval context.
   let selfContext = maybe emptyContext plainContext (parseStorePath defaultStoreDir storePath)
-  pure (VStr storePath selfContext)
+  pure (VStr (TE.encodeUtf8 storePath) selfContext)
 builtinToFile (VStr _ _) other =
   throwEvalError ("builtins.toFile: expected a string, got " <> typeName other)
 builtinToFile other _ =
@@ -3259,7 +3351,9 @@ builtinScopedImport other _ =
 -- ---------------------------------------------------------------------------
 
 builtinFetchurl :: (MonadEval m) => NixValue -> m NixValue
-builtinFetchurl (VStr url _) = fetchUrlSimple url Nothing
+builtinFetchurl (VStr url _) = do
+  urlText <- decodedText "builtins.fetchurl" url
+  fetchUrlSimple urlText Nothing
 builtinFetchurl (VAttrs attrs) = do
   url <- forceAttrStr "builtins.fetchurl" "url" attrs
   sha256 <- forceOptionalAttrStr attrs "sha256"
@@ -3268,7 +3362,9 @@ builtinFetchurl other =
   throwEvalError ("builtins.fetchurl: expected a string or set, got " <> typeName other)
 
 builtinFetchTarball :: (MonadEval m) => NixValue -> m NixValue
-builtinFetchTarball (VStr url _) = fetchAndExtractTarball url Nothing tarballSourceName
+builtinFetchTarball (VStr url _) = do
+  urlText <- decodedText "builtins.fetchTarball" url
+  fetchAndExtractTarball urlText Nothing tarballSourceName
 builtinFetchTarball (VAttrs attrs) = do
   url <- forceAttrStr "builtins.fetchTarball" "url" attrs
   sha256 <- forceOptionalAttrStr attrs "sha256"
@@ -3315,7 +3411,8 @@ fetchAndExtractTarball url mSha256 name = do
     _ -> throwEvalError ("builtins.fetchTarball: " <> errOut)
 
 builtinFetchGit :: (MonadEval m) => NixValue -> m NixValue
-builtinFetchGit (VStr url _) = do
+builtinFetchGit (VStr rawUrl _) = do
+  url <- decodedText "builtins.fetchGit" rawUrl
   sysTmp <- getTempDir
   let urlHash = sha256Hex (TE.encodeUtf8 url)
       cloneDir = sysTmp <> "/nova-nix-fetchgit-" <> urlHash
@@ -3390,8 +3487,17 @@ decodeSha256Pin ctx s
 -- coercion (VStr, VPath, VInt, VBool, VAttrs via __toString/outPath).
 -- A coercion failure (or a throwing attr value) propagates with its own
 -- message, as upstream - swallowing it here once masked user throws.
+-- The Text result decodes strictly: callers use it as a name, URL, or
+-- platform string, none of which may carry invalid UTF-8 here.
 forceAttrStr :: (MonadEval m) => Text -> Text -> AttrSet -> m Text
-forceAttrStr builtin key attrs =
+forceAttrStr builtin key attrs = do
+  bytes <- forceAttrBytes builtin key attrs
+  decodedText builtin bytes
+
+-- | Like 'forceAttrStr' but returns the coerced RAW BYTES - for
+-- derivation fields (builder) that flow byte-exact into the ATerm.
+forceAttrBytes :: (MonadEval m) => Text -> Text -> AttrSet -> m BS.ByteString
+forceAttrBytes builtin key attrs =
   case attrSetLookup key attrs of
     Nothing -> throwEvalError (builtin <> ": missing required attribute '" <> key <> "'")
     Just thunk -> do
@@ -3408,7 +3514,7 @@ forceOptionalAttrStr attrs key =
     Just thunk -> do
       val <- force thunk
       (s, _ctx) <- coerceToString True force applyValue val
-      pure (Just s)
+      Just <$> decodedText "string attribute" s
 
 -- ---------------------------------------------------------------------------
 -- Builtin implementations - derivation construction
@@ -3461,7 +3567,7 @@ derivationModuloHex drv = case drvOutputs drv of
          in pure (bytesToHexText (sha256Digest (TE.encodeUtf8 fixedForm)))
   _ -> do
     inputSubst <- mapM resolveInputModulo (Map.toList (drvInputDrvs drv))
-    pure (bytesToHexText (sha256Digest (TE.encodeUtf8 (toATermForHash False (Just inputSubst) drv))))
+    pure (bytesToHexText (sha256Digest (toATermForHash False (Just inputSubst) drv)))
 
 -- | The full output-name list of an all-outputs (upstream DrvDeep) reference:
 -- every output name of the referenced @.drv@, which upstream's derivationStrict
@@ -3499,10 +3605,12 @@ resolveAllOutputNames sp = do
 -- WHNF never forces this - matching C++ Nix's derivationStrict/derivation split.
 builtinDerivationStrict :: (MonadEval m) => NixValue -> m NixValue
 builtinDerivationStrict (VAttrs attrs) = do
-  -- Extract required attributes
+  -- Extract required attributes.  The name and system are Text (they feed
+  -- store-path and platform machinery); the builder stays raw bytes - it
+  -- lands byte-exact in the ATerm's builder field.
   drvName <- forceAttrStr "derivation" "name" attrs
   system <- forceAttrStr ("derivation \"" <> drvName <> "\"") "system" attrs
-  builder <- forceAttrStr ("derivation \"" <> drvName <> "\"") "builder" attrs
+  builder <- forceAttrBytes ("derivation \"" <> drvName <> "\"") "builder" attrs
 
   -- __ignoreNulls: when true, null-valued attrs are dropped from the
   -- derivation env (stdenv.mkDerivation sets it); when absent or false,
@@ -3596,8 +3704,8 @@ builtinDerivationStrict (VAttrs attrs) = do
           contents =
             mkDrv
               [DerivationOutput "out" foPath algoField foHashHex]
-              (Map.insert "out" foPathText baseEnv)
-          drvSp = makeTextPath drvFileName (sha256Digest (TE.encodeUtf8 (toATerm contents))) drvRefs
+              (Map.insert "out" (TE.encodeUtf8 foPathText) baseEnv)
+          drvSp = makeTextPath drvFileName (sha256Digest (toATerm contents)) drvRefs
           drvText = storePathToText defaultStoreDir drvSp
       cacheDrvHash drvText (bytesToHexText foModulo)
       pure (drvText, drvSp, [("out", foPathText)], contents)
@@ -3606,15 +3714,15 @@ builtinDerivationStrict (VAttrs attrs) = do
       let maskedEnv = foldr (`Map.insert` "") baseEnv outputNames
           maskedDrv = mkDrv (map maskedOutput outputNames) maskedEnv
           -- Masked modulo hash yields this derivation's own output paths.
-          moduloMasked = sha256Digest (TE.encodeUtf8 (toATermForHash True (Just inputSubst) maskedDrv))
+          moduloMasked = sha256Digest (toATermForHash True (Just inputSubst) maskedDrv)
           outStorePaths = [(n, makeOutputPath n moduloMasked drvName) | n <- outputNames]
           outPathTexts = [(n, storePathToText defaultStoreDir sp) | (n, sp) <- outStorePaths]
-          realEnv = foldr (\(n, t) e -> Map.insert n t e) baseEnv outPathTexts
+          realEnv = foldr (\(n, t) e -> Map.insert n (TE.encodeUtf8 t) e) baseEnv outPathTexts
           contents = mkDrv [DerivationOutput n sp "" "" | (n, sp) <- outStorePaths] realEnv
           -- Unmasked modulo hash (real outputs, inputs substituted) cached for
           -- when this derivation is itself an input to another.
-          moduloUnmasked = sha256Digest (TE.encodeUtf8 (toATermForHash False (Just inputSubst) contents))
-          drvSp = makeTextPath drvFileName (sha256Digest (TE.encodeUtf8 (toATerm contents))) drvRefs
+          moduloUnmasked = sha256Digest (toATermForHash False (Just inputSubst) contents)
+          drvSp = makeTextPath drvFileName (sha256Digest (toATerm contents)) drvRefs
           drvText = storePathToText defaultStoreDir drvSp
       cacheDrvHash drvText (bytesToHexText moduloUnmasked)
       pure (drvText, drvSp, outPathTexts, contents)
@@ -3644,8 +3752,8 @@ builtinDerivationStrict (VAttrs attrs) = do
         let outCtx = outPathCtx outName
             outputAttrMap =
               Map.fromList
-                [ ("outPath", evaluated (VStr outP outCtx)),
-                  ("drvPath", evaluated (VStr drvPathText drvPathCtx)),
+                [ ("outPath", evaluated (VStr (TE.encodeUtf8 outP) outCtx)),
+                  ("drvPath", evaluated (VStr (TE.encodeUtf8 drvPathText) drvPathCtx)),
                   ("type", evaluated (mkStr "derivation"))
                 ]
          in evaluated (VAttrs (attrSetFromMap outputAttrMap))
@@ -3654,11 +3762,11 @@ builtinDerivationStrict (VAttrs attrs) = do
   let baseAttrs =
         Map.fromList $
           [ ("type", evaluated (mkStr "derivation")),
-            ("drvPath", evaluated (VStr drvPathText drvPathCtx)),
-            ("outPath", evaluated (VStr mainOutPath (outPathCtx mainOutName))),
+            ("drvPath", evaluated (VStr (TE.encodeUtf8 drvPathText) drvPathCtx)),
+            ("outPath", evaluated (VStr (TE.encodeUtf8 mainOutPath) (outPathCtx mainOutName))),
             ("name", evaluated (mkStr drvName)),
             ("system", evaluated (mkStr system)),
-            ("builder", evaluated (mkStr builder)),
+            ("builder", evaluated (mkStrBytes builder)),
             ("_derivation", evaluated (VDerivation completeDrv))
           ]
             ++ [(outName, mkOutputAttrs outName outP) | (outName, outP) <- outPaths]
@@ -3680,8 +3788,9 @@ detectFixedOutput attrs =
     Just thunk -> do
       val <- force thunk
       case val of
-        VStr ohash _
-          | not (T.null ohash) -> do
+        VStr rawHash _
+          | not (BS.null rawHash) -> do
+              ohash <- decodedText "derivation: outputHash" rawHash
               ohAlgo <- optDrvStrAttr "outputHashAlgo" attrs
               ohMode <- optDrvStrAttr "outputHashMode" attrs
               (algo, digest) <- normalizeFixedHash ohash ohAlgo
@@ -3698,7 +3807,7 @@ optDrvStrAttr key attrs =
     Just thunk -> do
       val <- force thunk
       case val of
-        VStr s _ -> pure s
+        VStr s _ -> decodedText ("derivation: " <> key) s
         _ -> pure ""
 
 -- | Decode a fixed-output hash (SRI @algo-base64@, @algo:hash@, or a bare
@@ -3759,16 +3868,18 @@ builtinDerivationLazy (VAttrs attrs) = do
 builtinDerivationLazy other =
   throwEvalError ("derivation: expected a set, got " <> typeName other)
 
--- | Force a thunk to a Text string via full Nix coercion.
+-- | Force a thunk to a Text string via full Nix coercion (strict decode:
+-- used for output names, which are ASCII-shaped identity components).
 forceToText :: (MonadEval m) => Thunk -> m Text
 forceToText thunk = do
   val <- force thunk
   (s, _ctx) <- coerceToString True force applyValue val
-  pure s
+  decodedText "derivation" s
 
 -- | Collect all derivation attributes into env pairs via full Nix coercion
 -- (__toString, outPath, list-to-space-separated-string), along with the
--- merged string context from all collected values.
+-- merged string context from all collected values.  Values are RAW BYTES:
+-- they flow byte-exact into the ATerm env section (and its hash).
 --
 -- A coercion failure (a thrown attr value, an uncoercible function, a failed
 -- import inside the value) fails the WHOLE derivation, as in C++ Nix.
@@ -3776,7 +3887,7 @@ forceToText thunk = do
 -- a seed derivation with 17 failed src attrs into an empty no-input drv that
 -- "built" successfully.  Null attrs are dropped only under __ignoreNulls;
 -- otherwise null coerces to @""@ like any other coerceMore value.
-collectDrvEnvWithContext :: (MonadEval m) => Bool -> Map Text Thunk -> m ([(Text, Text)], StringContext)
+collectDrvEnvWithContext :: (MonadEval m) => Bool -> Map Text Thunk -> m ([(Text, BS.ByteString)], StringContext)
 collectDrvEnvWithContext ignoreNulls attrs = do
   let pairs = Map.toList attrs
   results <- mapM coerceEnvAttr pairs
@@ -3800,11 +3911,14 @@ collectDrvEnvWithContext ignoreNulls attrs = do
 -- Returns base-16 hex string, matching @builtins.hashString@ output format.
 builtinHashFile :: (MonadEval m) => NixValue -> NixValue -> m NixValue
 builtinHashFile (VStr algo _) (VPath path) = do
+  algoName <- decodedText "builtins.hashFile" algo
   bytes <- readFileBytes path
-  hashBytesWithAlgo "hashFile" algo bytes
+  hashBytesWithAlgo "hashFile" algoName bytes
 builtinHashFile (VStr algo _) (VStr path _) = do
-  bytes <- readFileBytes path
-  hashBytesWithAlgo "hashFile" algo bytes
+  algoName <- decodedText "builtins.hashFile" algo
+  filePath <- decodedText "builtins.hashFile" path
+  bytes <- readFileBytes filePath
+  hashBytesWithAlgo "hashFile" algoName bytes
 builtinHashFile (VStr _ _) other =
   throwEvalError ("builtins.hashFile: expected a path, got " <> typeName other)
 builtinHashFile other _ =
@@ -3823,7 +3937,9 @@ hashBytesWithAlgo ctx algo bytes = case algo of
 -- Returns @"regular"@, @"directory"@, @"symlink"@, or @"unknown"@.
 builtinReadFileType :: (MonadEval m) => NixValue -> m NixValue
 builtinReadFileType (VPath path) = mkStr <$> getFileType path
-builtinReadFileType (VStr path _) = mkStr <$> getFileType path
+builtinReadFileType (VStr path _) = do
+  filePath <- decodedText "builtins.readFileType" path
+  mkStr <$> getFileType filePath
 builtinReadFileType other =
   throwEvalError ("builtins.readFileType: expected a path, got " <> typeName other)
 
@@ -3909,7 +4025,7 @@ requireStrAttr ctx key attrs = case attrSetLookup key attrs of
   Just thunk -> do
     val <- force thunk
     case val of
-      VStr s _ -> pure s
+      VStr s _ -> decodedText ("builtins." <> ctx) s
       _ -> throwEvalError ("builtins." <> ctx <> ": " <> key <> " must be a string")
   Nothing -> throwEvalError ("builtins." <> ctx <> ": missing required attribute '" <> key <> "'")
 
@@ -3952,9 +4068,12 @@ decodeBase64E ctx t = case decodeBase64Pure t of
 -- inline tables, arrays, array-of-tables, and standard tables.
 -- Datetimes are represented as strings (matching real Nix).
 builtinFromTOML :: (MonadEval m) => NixValue -> m NixValue
-builtinFromTOML (VStr s _) = case parseTOML s of
-  Right val -> pure val
-  Left err -> throwEvalError ("builtins.fromTOML: " <> err)
+builtinFromTOML (VStr s _) = do
+  -- TOML is UTF-8 by definition; upstream's parser rejects invalid bytes.
+  decoded <- decodedText "builtins.fromTOML" s
+  case parseTOML decoded of
+    Right val -> pure val
+    Left err -> throwEvalError ("builtins.fromTOML: " <> err)
 builtinFromTOML other =
   throwEvalError ("builtins.fromTOML: expected a string, got " <> typeName other)
 
@@ -4470,19 +4589,23 @@ insertArrayTable (k : ks) m =
 -- | @builtins.toXML val@ - convert a Nix value to its XML representation.
 -- Matches the format defined by the Nix manual: strings, ints, floats,
 -- bools, nulls, lists, and attrsets map to their XML counterparts.
+-- Built over BYTES: upstream's serializer copies string payloads into the
+-- output with only the four ASCII escapes, so invalid UTF-8 passes
+-- through raw rather than erroring (unlike toJSON, whose upstream
+-- serializer validates).
 builtinToXML :: (MonadEval m) => NixValue -> m NixValue
 builtinToXML val = do
   xml <- valueToXML 0 val
-  pure (mkStr ("<?xml version='1.0' encoding='utf-8'?>\n<expr>\n" <> xml <> "</expr>\n"))
+  pure (mkStrBytes ("<?xml version='1.0' encoding='utf-8'?>\n<expr>\n" <> xml <> "</expr>\n"))
 
-valueToXML :: (MonadEval m) => Int -> NixValue -> m Text
+valueToXML :: (MonadEval m) => Int -> NixValue -> m BS.ByteString
 valueToXML depth val = case val of
   VStr s _ ->
     pure (indent depth <> "<string value=" <> xmlQuote s <> " />\n")
   VInt n ->
-    pure (indent depth <> "<int value=\"" <> T.pack (show n) <> "\" />\n")
+    pure (indent depth <> "<int value=\"" <> BC.pack (show n) <> "\" />\n")
   VFloat d ->
-    pure (indent depth <> "<float value=\"" <> formatXmlFloat d <> "\" />\n")
+    pure (indent depth <> "<float value=\"" <> TE.encodeUtf8 (formatXmlFloat d) <> "\" />\n")
   VBool True ->
     pure (indent depth <> "<bool value=\"true\" />\n")
   VBool False ->
@@ -4490,15 +4613,15 @@ valueToXML depth val = case val of
   VNull ->
     pure (indent depth <> "<null />\n")
   VPath p ->
-    pure (indent depth <> "<path value=" <> xmlQuote p <> " />\n")
+    pure (indent depth <> "<path value=" <> xmlQuote (TE.encodeUtf8 p) <> " />\n")
   VList cl -> do
     let thunks = map Thunk (clistThunks cl)
     items <- mapM (force >=> valueToXML (depth + 1)) thunks
-    pure (indent depth <> "<list>\n" <> T.concat items <> indent depth <> "</list>\n")
+    pure (indent depth <> "<list>\n" <> BS.concat items <> indent depth <> "</list>\n")
   VAttrs attrs -> do
     let pairs = attrSetToAscList attrs
     items <- mapM (attrToXML (depth + 1)) pairs
-    pure (indent depth <> "<attrs>\n" <> T.concat items <> indent depth <> "</attrs>\n")
+    pure (indent depth <> "<attrs>\n" <> BS.concat items <> indent depth <> "</attrs>\n")
   VLambda {} ->
     pure (indent depth <> "<function />\n")
   VBuiltin _ _ ->
@@ -4511,19 +4634,19 @@ valueToXML depth val = case val of
     attrToXML d (name, thunk) = do
       v <- force thunk
       inner <- valueToXML d v
-      pure (indent d <> "<attr name=" <> xmlQuote name <> ">\n" <> inner <> indent d <> "</attr>\n")
+      pure (indent d <> "<attr name=" <> xmlQuote (TE.encodeUtf8 name) <> ">\n" <> inner <> indent d <> "</attr>\n")
 
-indent :: Int -> Text
-indent n = T.replicate (n * 2) " "
+indent :: Int -> BS.ByteString
+indent n = BC.replicate (n * 2) ' '
 
-xmlQuote :: Text -> Text
-xmlQuote s = "\"" <> T.concatMap escapeChar s <> "\""
+xmlQuote :: BS.ByteString -> BS.ByteString
+xmlQuote s = "\"" <> BC.concatMap escapeChar s <> "\""
   where
     escapeChar '<' = "&lt;"
     escapeChar '>' = "&gt;"
     escapeChar '&' = "&amp;"
     escapeChar '"' = "&quot;"
-    escapeChar c = T.singleton c
+    escapeChar c = BC.singleton c
 
 -- ---------------------------------------------------------------------------
 -- Builtin implementations - builtins.path
@@ -4543,7 +4666,9 @@ builtinPath (VAttrs attrs) = do
     Just thunk -> do
       pinVal <- force thunk
       case pinVal of
-        VStr pin _ -> Just <$> decodeSha256Pin "builtins.path" pin
+        VStr pin _ -> do
+          pinText <- decodedText "builtins.path" pin
+          Just <$> decodeSha256Pin "builtins.path" pinText
         other -> throwEvalError ("builtins.path: 'sha256' must be a string, got " <> typeName other)
   let name = fromMaybe (extractBaseName pathStr) nameOverride
       pinSubject = "builtins.path: " <> pathStr
@@ -4575,8 +4700,8 @@ builtinPath other =
 sourceResultString :: Text -> NixValue
 sourceResultString storePathText =
   case parseStorePath defaultStoreDir storePathText of
-    Just sp -> VStr storePathText (plainContext sp)
-    Nothing -> VStr storePathText emptyContext
+    Just sp -> VStr (TE.encodeUtf8 storePathText) (plainContext sp)
+    Nothing -> VStr (TE.encodeUtf8 storePathText) emptyContext
 
 -- | Serialise a source tree to a NAR, keeping only entries the Nix filter
 -- function accepts - upstream's addToStore filtering: the filter receives
@@ -4636,7 +4761,8 @@ extractBaseName path =
 -- source's basename as the store name.
 builtinFilterSource :: (MonadEval m) => NixValue -> NixValue -> m NixValue
 builtinFilterSource filterFn (VPath path) = filterSourceInto filterFn path
-builtinFilterSource filterFn (VStr path _) = filterSourceInto filterFn path
+builtinFilterSource filterFn (VStr path _) =
+  filterSourceInto filterFn =<< decodedText "builtins.filterSource" path
 builtinFilterSource _ other =
   throwEvalError ("builtins.filterSource: expected a path, got " <> typeName other)
 

--- a/src/Nix/Eval.hs
+++ b/src/Nix/Eval.hs
@@ -855,9 +855,9 @@ evalSearchPath env name = do
           nixPathVal <- force nixPathThunk
           builtinFindFile nixPathVal (mkStr name)
         Nothing ->
-          throwEvalError ("file '" <> name <> "' was not found in the Nix search path")
+          throwCatchableError ("file '" <> name <> "' was not found in the Nix search path")
     _ ->
-      throwEvalError ("file '" <> name <> "' was not found in the Nix search path")
+      throwCatchableError ("file '" <> name <> "' was not found in the Nix search path")
 
 -- ---------------------------------------------------------------------------
 -- Variables
@@ -3188,9 +3188,12 @@ forceSearchEntry thunk = do
     _ -> throwEvalError "builtins.findFile: search path entry must be a set"
 
 -- | Iterate search path entries, checking for a match.
+-- A miss is a CATCHABLE error (upstream raises ThrownError here):
+-- nixpkgs' impure.nix wraps @<nixpkgs-overlays>@ in @tryEval@ and
+-- relies on catching the miss.
 findFirst :: (MonadEval m) => [(Text, Text)] -> Text -> m NixValue
 findFirst [] name =
-  throwEvalError ("file '" <> name <> "' was not found in the Nix search path")
+  throwCatchableError ("file '" <> name <> "' was not found in the Nix search path")
 findFirst ((prefix, path) : rest) name
   | prefix == name || (not (T.null prefix) && (prefix <> "/") `T.isPrefixOf` name) =
       let suffix = if prefix == name then "" else T.drop (T.length prefix + 1) name

--- a/src/Nix/Eval/IO.hs
+++ b/src/Nix/Eval/IO.hs
@@ -40,7 +40,6 @@ import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Text (Text)
 import qualified Data.Text as T
-import Data.Text.Encoding (decodeUtf8', encodeUtf8)
 import Data.Time.Clock.POSIX (getPOSIXTime)
 import Foreign.Ptr (Ptr, castPtr, nullPtr)
 import Foreign.StablePtr (castPtrToStablePtr, castStablePtrToPtr, deRefStablePtr, freeStablePtr, newStablePtr)
@@ -50,7 +49,7 @@ import Nix.Eval (eval)
 import Nix.Eval.CList (CList (..))
 import Nix.Eval.CThunk (CThunkPtr, cthunkGetAttrs, cthunkGetBcIdx, cthunkGetBool, cthunkGetCtxStr, cthunkGetFloat, cthunkGetInt, cthunkGetLambda, cthunkGetList, cthunkGetPath, cthunkGetStr, cthunkMarkBlackhole, cthunkMarkPending, cthunkPayload, cthunkSetComputed, cthunkSetComputedAttrs, cthunkSetComputedBool, cthunkSetComputedCtxStr, cthunkSetComputedFloat, cthunkSetComputedInt, cthunkSetComputedLambda, cthunkSetComputedList, cthunkSetComputedNull, cthunkSetComputedPath, cthunkSetComputedStr, cthunkState, cthunkValueTag)
 import Nix.Eval.CanonPath (canonBaseName, canonPath)
-import Nix.Eval.Symbol (Symbol (..), symbolIntern, symbolText)
+import Nix.Eval.Symbol (Symbol (..), symbolBytes, symbolIntern, symbolInternBytes, symbolText)
 import Nix.Eval.Types (AttrSet (..), Env (..), MonadEval (..), NixValue (..), Thunk (..), attrSetSize, emptyContext, marshalLambda, marshalStringContext, unmarshalLambdaValue, unmarshalStringContext, pattern ValueAttrs, pattern ValueBool, pattern ValueCtxStr, pattern ValueFloat, pattern ValueInt, pattern ValueLambda, pattern ValueList, pattern ValueNull, pattern ValuePath, pattern ValueStr)
 import Nix.Expr.Types (AttrKey (..), Binding (..), Expr (..), Formal (..), Formals (..), NixAtom (..), StringPart (..))
 import Nix.Hash (bytesToHexText, makeFixedOutputPath, makeTextPath, sha256Digest)
@@ -110,10 +109,11 @@ data EvalState = EvalState
     -- bottom-up by 'builtinDerivationStrict' so input derivations can be
     -- substituted by their content hashes when computing output paths.
     esDrvModuloCache :: !(IORef (Map Text Text)),
-    -- | Accumulated @.drv@ closure (drv store path text to its ATerm), recorded
-    -- bottom-up by 'builtinDerivationStrict'.  The build driver reads this after
-    -- evaluation to write every input @.drv@ to the store before building.
-    esDrvClosure :: !(IORef (Map Text Text)),
+    -- | Accumulated @.drv@ closure (drv store path text to its ATerm bytes),
+    -- recorded bottom-up by 'builtinDerivationStrict'.  The build driver reads
+    -- this after evaluation to write every input @.drv@ to the store before
+    -- building.
+    esDrvClosure :: !(IORef (Map Text BS.ByteString)),
     -- | Cache of source path to its store path (recursive NAR hash), so a path
     -- literal used across many derivations is hashed only once.
     esSourcePathCache :: !(IORef (Map Text Text)),
@@ -173,8 +173,6 @@ instance MonadEval EvalIO where
       Left (NixEvalError ErrorThrown msg) -> pure (Left msg)
       Left err@(NixEvalError ErrorUncatchable _) -> liftIO (throwIO err)
       Right val -> pure (Right val)
-
-  readFileText path = wrapIO (readFileAutoEncoding (T.unpack path))
 
   doesPathExist path = wrapIO (Dir.doesPathExist (T.unpack path))
 
@@ -248,17 +246,15 @@ instance MonadEval EvalIO where
 
   -- Read a .drv from the store on a modulo-hash cache miss (a cross-session or
   -- appendContext reference).  Mirrors the build side's readDrvFromStore: map
-  -- to the on-disk path, read the raw bytes, decode UTF-8, parse the ATerm.
-  -- Any failure - absent file, bad encoding, malformed ATerm - is 'Nothing',
-  -- which the caller turns into a loud modulo-hash error.
+  -- to the on-disk path, read the raw bytes, parse the ATerm byte-level (env
+  -- values keep arbitrary bytes).  Any failure - absent file, malformed ATerm
+  -- - is 'Nothing', which the caller turns into a loud modulo-hash error.
   readStoreDerivation sp = EvalIO $ do
     let filePath = SP.storePathToFilePath SP.defaultStoreDir sp
     result <- liftIO (try (BS.readFile filePath) :: IO (Either SomeException BS.ByteString))
     pure $ case result of
       Left _ -> Nothing
-      Right bytes -> case decodeUtf8' bytes of
-        Left _ -> Nothing
-        Right text -> either (const Nothing) Just (fromATerm text)
+      Right bytes -> either (const Nothing) Just (fromATerm bytes)
 
   -- Look up a derivation recorded earlier this session by its .drv path,
   -- reusing the esDrvClosure ATerm map (populated bottom-up by recordDrvAterm).
@@ -301,15 +297,16 @@ instance MonadEval EvalIO where
       throwEvalError ("writeToStore: name must not contain null bytes: " <> name)
     -- Upstream's text-path scheme via makeTextPath - the same scheme .drv
     -- paths use, so it is parity-validated: type @text:<refs>@, flat
-    -- sha256 of the contents, canonical store dir.  Written as UTF-8
-    -- BYTES: text-mode IO would CRLF-translate on Windows and the stored
-    -- bytes would no longer match the hash that named the path.
-    let sp = makeTextPath name (sha256Digest (encodeUtf8 contents)) refs
+    -- sha256 of the contents, canonical store dir.  The contents are the
+    -- string's RAW BYTES, hashed and written as-is: no encoding step, and
+    -- no text-mode IO (which would CRLF-translate on Windows and store
+    -- bytes that no longer match the hash that named the path).
+    let sp = makeTextPath name (sha256Digest contents) refs
         filePath = SP.storePathToFilePath SP.defaultStoreDir sp
         storePath = SP.storePathToText SP.defaultStoreDir sp
     wrapIO $ do
       Dir.createDirectoryIfMissing True (takeDirectory filePath)
-      BS.writeFile filePath (encodeUtf8 contents)
+      BS.writeFile filePath contents
     pure storePath
 
   scopedImportFile scope rawPath = do
@@ -503,7 +500,7 @@ storeComputed ptr val = case val of
     cthunkSetComputedPath ptr sym
   VStr t ctx
     | ctx == emptyContext -> do
-        Symbol sym <- symbolIntern t
+        Symbol sym <- symbolInternBytes t
         cthunkSetComputedStr ptr sym
     | otherwise -> do
         csptr <- marshalStringContext t ctx
@@ -528,7 +525,7 @@ readComputed ptr = do
     ValueNull -> pure VNull
     ValueStr -> do
       sym <- cthunkGetStr ptr
-      pure (VStr (symbolText (Symbol sym)) emptyContext)
+      pure (VStr (symbolBytes (Symbol sym)) emptyContext)
     ValuePath -> VPath . symbolText . Symbol <$> cthunkGetPath ptr
     ValueList -> do
       listPtr <- cthunkGetList ptr

--- a/src/Nix/Eval/StringInterp.hs
+++ b/src/Nix/Eval/StringInterp.hs
@@ -13,9 +13,13 @@ module Nix.Eval.StringInterp
   )
 where
 
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as BC
 import Data.List (foldl')
 import Data.Text (Text)
 import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
 import Nix.Eval.Types (MonadEval (..), NixValue (..), StringContext, Thunk, attrSetLookup, emptyContext, typeName)
 import Numeric (floatToDigits, showFFloat)
 
@@ -26,31 +30,34 @@ type Force m = Thunk -> m NixValue
 type Apply m = NixValue -> NixValue -> m NixValue
 
 -- | Strip the common indentation from already-evaluated indented-string chunks.
--- Each chunk is @(isLiteral, text, context)@.  Indentation is computed and
+-- Each chunk is @(isLiteral, bytes, context)@.  Indentation is computed and
 -- stripped from the LITERAL chunks only - interpolated chunks are opaque content
 -- - the single leading newline is dropped, and the trailing newline is kept.
 -- This matches C++ Nix, which strips at the string-part level (so a multi-line
--- interpolated value cannot drag the common indent down).
-stripIndentedChunks :: [(Bool, Text, StringContext)] -> (Text, StringContext)
+-- interpolated value cannot drag the common indent down).  The scan is
+-- byte-level via the Char8 view: it only ever compares against space, tab,
+-- and newline, which are single bytes in UTF-8 and never occur inside a
+-- multi-byte sequence, so multi-byte content passes through untouched.
+stripIndentedChunks :: [(Bool, ByteString, StringContext)] -> (ByteString, StringContext)
 stripIndentedChunks chunks =
   let stripped = dropLeadingNL (chunksStrip (chunksMinIndent chunks) chunks)
-   in (T.concat (map snd stripped), mconcat [c | (_, _, c) <- chunks])
+   in (BS.concat (map snd stripped), mconcat [c | (_, _, c) <- chunks])
   where
     dropLeadingNL ((True, t) : rest) =
-      (True, case T.uncons t of { Just ('\n', r) -> r; _ -> t }) : rest
+      (True, case BC.uncons t of { Just ('\n', r) -> r; _ -> t }) : rest
     dropLeadingNL other = other
 
 -- | Common indentation across the LITERAL chunks.  An interpolation at line
 -- start fixes that line's indent at the preceding literal whitespace and counts
 -- as content; whitespace-only lines do not contribute.
-chunksMinIndent :: [(Bool, Text, StringContext)] -> Int
+chunksMinIndent :: [(Bool, ByteString, StringContext)] -> Int
 chunksMinIndent = result . foldl' stepChunk (True, 0, Nothing)
   where
     result (_, _, Nothing) = 0
     result (_, _, Just m) = m
     stepChunk (atStart, cur, mi) (isLit, t, _)
       | not isLit = if atStart then (False, cur, bump mi cur) else (False, cur, mi)
-      | otherwise = T.foldl' stepChar (atStart, cur, mi) t
+      | otherwise = BC.foldl' stepChar (atStart, cur, mi) t
     stepChar (atStart, cur, mi) c
       | atStart && (c == ' ' || c == '\t') = (True, cur + 1, mi)
       | atStart && c == '\n' = (True, 0, mi)
@@ -62,14 +69,14 @@ chunksMinIndent = result . foldl' stepChunk (True, 0, Nothing)
 
 -- | Strip @n@ columns of leading indentation from each line of the literal
 -- chunks; interpolated chunks are emitted verbatim and reset the line position.
-chunksStrip :: Int -> [(Bool, Text, StringContext)] -> [(Bool, Text)]
+chunksStrip :: Int -> [(Bool, ByteString, StringContext)] -> [(Bool, ByteString)]
 chunksStrip n = go True 0
   where
     go _ _ [] = []
     go _ _ ((False, t, _) : rest) = (False, t) : go False 0 rest
     go atStart dropped ((True, t, _) : rest) =
-      let (acc, atStart', dropped') = T.foldl' stepC ([], atStart, dropped) t
-       in (True, T.pack (reverse acc)) : go atStart' dropped' rest
+      let (acc, advancedStart, advancedDrop) = BC.foldl' stepC ([], atStart, dropped) t
+       in (True, BC.pack (reverse acc)) : go advancedStart advancedDrop rest
     stepC (acc, atStart, dropped) c
       | atStart && (c == ' ' || c == '\t') =
           if dropped < n then (acc, True, dropped + 1) else (c : acc, True, dropped + 1)
@@ -78,7 +85,7 @@ chunksStrip n = go True 0
       | c == '\n' = ('\n' : acc, True, 0)
       | otherwise = (c : acc, False, dropped)
 
--- | Coerce a Nix value to a string.
+-- | Coerce a Nix value to a (byte) string.
 --
 -- The @coerceMore@ flag mirrors C++ Nix's @coerceToString@ argument: when
 -- 'True' (e.g. @builtins.toString@, derivation-env values) ints, floats, bools
@@ -86,11 +93,11 @@ chunksStrip n = go True 0
 -- @builtins.concatStringsSep@) those are type errors, matching C++ Nix.
 -- Strings, paths, and attribute sets with @__toString@/@outPath@ coerce in
 -- both modes; lists and bare functions are always errors.
-coerceToString :: (MonadEval m) => Bool -> Force m -> Apply m -> NixValue -> m (Text, StringContext)
+coerceToString :: (MonadEval m) => Bool -> Force m -> Apply m -> NixValue -> m (ByteString, StringContext)
 coerceToString _ _ _ (VStr s ctx) = pure (s, ctx)
-coerceToString _ _ _ (VPath p) = pure (p, emptyContext)
-coerceToString True _ _ (VInt n) = pure (T.pack (show n), emptyContext)
-coerceToString True _ _ (VFloat n) = pure (formatNixFloatFixed n, emptyContext)
+coerceToString _ _ _ (VPath p) = pure (TE.encodeUtf8 p, emptyContext)
+coerceToString True _ _ (VInt n) = pure (BC.pack (show n), emptyContext)
+coerceToString True _ _ (VFloat n) = pure (TE.encodeUtf8 (formatNixFloatFixed n), emptyContext)
 coerceToString True _ _ VNull = pure ("", emptyContext)
 coerceToString True _ _ (VBool True) = pure ("1", emptyContext)
 coerceToString True _ _ (VBool False) = pure ("", emptyContext)

--- a/src/Nix/Eval/Symbol.hs
+++ b/src/Nix/Eval/Symbol.hs
@@ -20,7 +20,9 @@ module Nix.Eval.Symbol
 
     -- * Core operations
     symbolIntern,
+    symbolInternBytes,
     symbolText,
+    symbolBytes,
     symbolLen,
 
     -- * Diagnostics
@@ -28,6 +30,9 @@ module Nix.Eval.Symbol
   )
 where
 
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Unsafe as BSU
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Foreign as TF
@@ -85,16 +90,32 @@ symbolDestroy = c_nn_symbol_destroy
 
 -- | Intern a 'Text' value, returning its 'Symbol'.
 -- If the string was already interned, returns the existing symbol.
--- This is the canonical entry point for Text to C conversion.
+-- This is the canonical entry point for Text to C conversion; the table
+-- stores the UTF-8 bytes, so a 'Text' and its 'Data.Text.Encoding.encodeUtf8'
+-- image intern to the SAME symbol.
 symbolIntern :: Text -> IO Symbol
 symbolIntern txt =
   TF.withCStringLen txt $ \(ptr, len) -> do
     sid <- c_nn_symbol_intern ptr (fromIntegral len)
     pure (Symbol sid)
 
+-- | Intern raw bytes, returning their 'Symbol'.  The C table is
+-- length-prefixed bytes with no encoding assumption, so arbitrary
+-- (even invalid-UTF-8) byte strings intern losslessly.  The canonical
+-- entry point for string VALUES, whose payload is a byte string.
+-- 'BSU.unsafeUseAsCStringLen' is safe here: @nn_symbol_intern@ copies
+-- the bytes into its own arena and never retains the pointer.
+symbolInternBytes :: ByteString -> IO Symbol
+symbolInternBytes bs =
+  BSU.unsafeUseAsCStringLen bs $ \(ptr, len) -> do
+    sid <- c_nn_symbol_intern ptr (fromIntegral len)
+    pure (Symbol sid)
+
 -- | Retrieve the text of an interned symbol.
 -- Returns the original string.  The result is safe to use - it copies
--- from the C arena into a fresh 'Text'.
+-- from the C arena into a fresh 'Text'.  Only valid for symbols interned
+-- from 'Text' (attr names, paths, output names); a symbol holding a raw
+-- byte-string payload must be read with 'symbolBytes' instead.
 symbolText :: Symbol -> Text
 symbolText (Symbol sid)
   | sid == 0 = T.empty
@@ -105,6 +126,19 @@ symbolText (Symbol sid)
         else do
           len <- c_nn_symbol_len sid
           TF.peekCStringLen (ptr, fromIntegral len)
+
+-- | Retrieve the raw bytes of an interned symbol - the exact bytes that
+-- were interned, with no decoding.  The read side of 'symbolInternBytes'.
+symbolBytes :: Symbol -> ByteString
+symbolBytes (Symbol sid)
+  | sid == 0 = BS.empty
+  | otherwise = unsafePerformIO $ do
+      ptr <- c_nn_symbol_text sid
+      if ptr == nullPtr
+        then pure BS.empty
+        else do
+          len <- c_nn_symbol_len sid
+          BS.packCStringLen (ptr, fromIntegral len)
 
 -- | Byte length of a symbol's string.
 symbolLen :: Symbol -> Int

--- a/src/Nix/Eval/Types.hs
+++ b/src/Nix/Eval/Types.hs
@@ -43,6 +43,8 @@ module Nix.Eval.Types
     StringContext (..),
     emptyContext,
     mkStr,
+    mkStrBytes,
+    bytesToTextLossy,
     marshalStringContext,
     unmarshalStringContext,
 
@@ -116,6 +118,8 @@ import qualified Data.Map.Strict as Map
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Text (Text)
+import qualified Data.Text.Encoding as TE
+import Data.Text.Encoding.Error (lenientDecode)
 import Data.Word (Word16, Word32, Word64, Word8)
 import Foreign.Ptr (Ptr, castPtr, nullPtr, ptrToWordPtr)
 import Foreign.StablePtr (castPtrToStablePtr, castStablePtrToPtr, deRefStablePtr, newStablePtr)
@@ -132,7 +136,7 @@ import Nix.Eval.CThunk (CThunkPtr, cthunkGetAttrs, cthunkGetBcIdx, cthunkGetBool
 import Nix.Eval.CanonPath (canonPath)
 import Nix.Eval.Compile (compileExpr, compileFormalsToEval)
 import Nix.Eval.EvalFormals (EvalFormal (..), EvalFormals (..))
-import Nix.Eval.Symbol (Symbol (..), symbolIntern, symbolText)
+import Nix.Eval.Symbol (Symbol (..), symbolBytes, symbolIntern, symbolInternBytes, symbolText)
 import Nix.Expr.Types (CaptureInfo (..), Expr (..), NixAtom (..))
 import Nix.Store.Path (StorePath (..))
 import System.IO.Unsafe (unsafePerformIO)
@@ -142,11 +146,13 @@ import qualified Text.Regex.TDFA as RE
 -- Compiled regex
 -- ---------------------------------------------------------------------------
 
--- | Compiled regex with Eq/Show based on source pattern text.
+-- | Compiled regex with Eq/Show based on the source pattern bytes.
 -- Carries the pre-compiled 'RE.Regex' alongside the original pattern
 -- so that partial application of @builtins.match@ / @builtins.split@
--- avoids recompiling the same pattern on every invocation.
-data CompiledRegex = CompiledRegex !Text RE.Regex
+-- avoids recompiling the same pattern on every invocation.  The pattern
+-- is the raw byte string the regex was compiled from: upstream regexes
+-- run over bytes, so byte-identical patterns are the sharing key.
+data CompiledRegex = CompiledRegex !ByteString RE.Regex
 
 instance Eq CompiledRegex where
   CompiledRegex a _ == CompiledRegex b _ = a == b
@@ -177,9 +183,23 @@ newtype StringContext = StringContext {unStringContext :: Set StringContextEleme
 emptyContext :: StringContext
 emptyContext = mempty
 
--- | Smart constructor for context-free strings.
+-- | Smart constructor for context-free strings from 'Text'.
+-- Encodes to the UTF-8 bytes that ARE the string's value: a Nix string
+-- is a byte string, and every Text-producing site goes through here.
 mkStr :: Text -> NixValue
-mkStr t = VStr t emptyContext
+mkStr t = VStr (TE.encodeUtf8 t) emptyContext
+
+-- | Smart constructor for context-free strings from raw bytes
+-- (@builtins.readFile@, substring slices - anything already byte-shaped).
+mkStrBytes :: ByteString -> NixValue
+mkStrBytes b = VStr b emptyContext
+
+-- | Decode string-value bytes for DISPLAY ONLY (trace output, error
+-- messages, value pretty-printing): invalid UTF-8 becomes U+FFFD.
+-- Never feed the result back into a value, a hash, or an attr name -
+-- identity-bearing boundaries decode strictly and error instead.
+bytesToTextLossy :: ByteString -> Text
+bytesToTextLossy = TE.decodeUtf8With lenientDecode
 
 -- ---------------------------------------------------------------------------
 -- Thunks
@@ -259,7 +279,7 @@ readThunkValue (Thunk ptr) =
           ValueFloat -> VFloat <$> cthunkGetFloat ptr
           ValueBool -> (\b -> VBool (b /= 0)) <$> cthunkGetBool ptr
           ValueNull -> pure VNull
-          ValueStr -> (\sym -> VStr (symbolText (Symbol sym)) emptyContext) <$> cthunkGetStr ptr
+          ValueStr -> (\sym -> VStr (symbolBytes (Symbol sym)) emptyContext) <$> cthunkGetStr ptr
           ValuePath -> VPath . symbolText . Symbol <$> cthunkGetPath ptr
           ValueList -> do
             listPtr <- cthunkGetList ptr
@@ -285,8 +305,13 @@ data NixValue
     VBool !Bool
   | -- | The null value.
     VNull
-  | -- | String with dependency context.
-    VStr !Text !StringContext
+  | -- | String with dependency context.  The payload is a BYTE string,
+    -- as upstream: @stringLength@/@substring@ index bytes, regexes match
+    -- bytes, and @readFile@ carries raw file bytes (so invalid UTF-8 is
+    -- representable).  Text enters via 'mkStr' (UTF-8 encode) and leaves
+    -- through explicit decode at boundaries (attr names strictly, display
+    -- lossily via 'bytesToTextLossy').
+    VStr !ByteString !StringContext
   | -- | Path.
     VPath !Text
   | -- | List of thunks (lazy elements), backed by C array.
@@ -816,10 +841,10 @@ newComputedNullPtr = unsafePerformIO cthunkNewComputedNull
 
 -- | Wrap a context-free string in a pre-computed C thunk (interned symbol, no StablePtr).
 {-# NOINLINE newComputedStrPtr #-}
-newComputedStrPtr :: Text -> CThunkPtr
+newComputedStrPtr :: ByteString -> CThunkPtr
 newComputedStrPtr t =
   unsafePerformIO $ t `seq` do
-    Symbol sym <- symbolIntern t
+    Symbol sym <- symbolInternBytes t
     cthunkNewComputedStr sym
 
 -- | Wrap a path in a pre-computed C thunk (interned symbol, no StablePtr).
@@ -839,9 +864,9 @@ newComputedListPtrC (CList clistPtr) =
       cthunkNewComputedList (castPtr clistPtr)
 
 -- | Wrap a string with context in a pre-computed C thunk (no StablePtr).
--- Interns the text and all StorePath fields as symbols, builds nn_ctxstr_t.
+-- Interns the payload bytes and all StorePath fields as symbols, builds nn_ctxstr_t.
 {-# NOINLINE newComputedCtxStrPtr #-}
-newComputedCtxStrPtr :: Text -> StringContext -> CThunkPtr
+newComputedCtxStrPtr :: ByteString -> StringContext -> CThunkPtr
 newComputedCtxStrPtr t ctx =
   unsafePerformIO $
     t `seq`
@@ -926,10 +951,12 @@ unmarshalLambdaValue rawPtr = do
       let defMaybe = if hasDef /= 0 then Just defIdx else Nothing
       pure (EvalFormal (symbolText (Symbol nameSym)) defMaybe)
 
--- | Marshal Text + StringContext to a C nn_ctxstr_t.
-marshalStringContext :: Text -> StringContext -> IO CCtxStrPtr
+-- | Marshal payload bytes + StringContext to a C nn_ctxstr_t.  The
+-- payload interns byte-level ('symbolInternBytes'); the StorePath and
+-- output-name fields are Text and intern as UTF-8.
+marshalStringContext :: ByteString -> StringContext -> IO CCtxStrPtr
 marshalStringContext textVal (StringContext ctxSet) = do
-  Symbol textSym <- symbolIntern textVal
+  Symbol textSym <- symbolInternBytes textVal
   let elems = Set.toAscList ctxSet
       count = fromIntegral (length elems) :: Word16
   ptr <- cctxstrNew textSym count
@@ -954,12 +981,12 @@ marshalStringContext textVal (StringContext ctxSet) = do
       Symbol nameSym <- symbolIntern n
       cctxstrSetAllOutputs eptr eidx hashSym nameSym
 
--- | Unmarshal a C nn_ctxstr_t back to (Text, StringContext).
-unmarshalStringContext :: CCtxStrPtr -> IO (Text, StringContext)
+-- | Unmarshal a C nn_ctxstr_t back to (payload bytes, StringContext).
+unmarshalStringContext :: CCtxStrPtr -> IO (ByteString, StringContext)
 unmarshalStringContext ptr = do
   textSym <- cctxstrText ptr
   count <- cctxstrCtxCount ptr
-  let textVal = symbolText (Symbol textSym)
+  let textVal = symbolBytes (Symbol textSym)
   -- count - 1 underflows Word16 at 0 (defensive: marshal sites store
   -- only non-empty contexts today).
   elems <-
@@ -1071,7 +1098,6 @@ class (Monad m) => MonadEval m where
   -- (throw\/assert); eval errors and aborts propagate.
   catchEvalError :: m a -> m (Either Text a)
 
-  readFileText :: Text -> m Text
   doesPathExist :: Text -> m Bool
 
   -- | List a directory, returning @(name, fileType)@ pairs.
@@ -1087,12 +1113,13 @@ class (Monad m) => MonadEval m where
   -- | Get the current epoch time (seconds since 1970-01-01).
   getCurrentTime :: m Int64
 
-  -- | Write a named text file to the store at upstream's text-path
+  -- | Write a named file to the store at upstream's text-path
   -- (@text:\<refs\>@ scheme, flat sha256 of the contents), returning the
-  -- canonical store path.  The refs are the contents' plain store-path
-  -- references; they participate in the path computation exactly as
-  -- upstream's addTextToStore.
-  writeToStore :: Text -> Text -> [StorePath] -> m Text
+  -- canonical store path.  The contents are raw bytes (a Nix string's
+  -- payload) - hashed and stored exactly as given.  The refs are the
+  -- contents' plain store-path references; they participate in the path
+  -- computation exactly as upstream's addTextToStore.
+  writeToStore :: Text -> ByteString -> [StorePath] -> m Text
 
   -- | Import a file with a custom scope overlaid on builtins.
   scopedImportFile :: [(Text, Thunk)] -> Text -> m NixValue
@@ -1164,12 +1191,13 @@ class (Monad m) => MonadEval m where
   -- A no-op in pure evaluators (no memoization).
   cacheDrvHash :: Text -> Text -> m ()
 
-  -- | Record a derivation's serialized @.drv@ ATerm under its @.drv@ store
-  -- path, as each derivation is computed (bottom-up).  Unlike 'cacheDrvHash'
-  -- (which stores only the modulo hash), this retains the full ATerm so the
-  -- build driver can materialize the entire input-@.drv@ closure to the store
-  -- before a dependency-aware build.  A no-op in pure evaluators.
-  recordDrvAterm :: Text -> Text -> m ()
+  -- | Record a derivation's serialized @.drv@ ATerm (the exact bytes whose
+  -- hash is its store path) under its @.drv@ store path, as each derivation
+  -- is computed (bottom-up).  Unlike 'cacheDrvHash' (which stores only the
+  -- modulo hash), this retains the full ATerm so the build driver can
+  -- materialize the entire input-@.drv@ closure to the store before a
+  -- dependency-aware build.  A no-op in pure evaluators.
+  recordDrvAterm :: Text -> ByteString -> m ()
 
   -- | Read and parse a derivation from its @.drv@ in the store, or 'Nothing'
   -- if it is absent or unreadable.  Used to resolve an input derivation's
@@ -1226,7 +1254,6 @@ instance MonadEval PureEval where
       Left (PThrow t) -> Right (Left t)
       Left other -> Left other
       Right a -> Right (Right a)
-  readFileText _ = throwEvalError "readFile: not available in pure evaluation"
   doesPathExist _ = pure False
   listDirectory _ = throwEvalError "builtins.readDir: not available in pure evaluation"
   importFile _ = throwEvalError "import: not available in pure evaluation"
@@ -1234,7 +1261,7 @@ instance MonadEval PureEval where
   getCurrentTime = pure 0
   writeToStore _ _ _ = throwEvalError "toFile: not available in pure evaluation"
   scopedImportFile _ _ = throwEvalError "scopedImport: not available in pure evaluation"
-  readFileBytes _ = throwEvalError "hashFile: not available in pure evaluation"
+  readFileBytes _ = throwEvalError "readFile: not available in pure evaluation"
   getFileType _ = throwEvalError "readFileType: not available in pure evaluation"
   runProcess _ _ _ = throwEvalError "runProcess: not available in pure evaluation"
   copyPathToStore _ _ _ = throwEvalError "builtins.path: not available in pure evaluation"
@@ -1275,7 +1302,7 @@ instance MonadEval PureEval where
               ValueNull -> pure VNull
               ValueStr ->
                 let sym = unsafePerformIO (cthunkGetStr ptr)
-                 in pure (VStr (symbolText (Symbol sym)) emptyContext)
+                 in pure (VStr (symbolBytes (Symbol sym)) emptyContext)
               ValuePath ->
                 let sym = unsafePerformIO (cthunkGetPath ptr)
                  in pure (VPath (symbolText (Symbol sym)))

--- a/src/Nix/Store.hs
+++ b/src/Nix/Store.hs
@@ -299,14 +299,14 @@ setReadOnly path = do
 -- materialize the input @.drv@ closure (root plus every transitive input)
 -- before a dependency-aware build: evaluation computes these ATerms but does
 -- no store IO, so the build driver writes them here.
-writeDrvAterm :: Store -> StorePath -> Text -> IO ()
+writeDrvAterm :: Store -> StorePath -> BS.ByteString -> IO ()
 writeDrvAterm store sp aterm = do
   let destPath = storePathToFilePath (stDir store) sp
   createDirectoryIfMissing True (unStoreDir (stDir store))
-  -- UTF-8 bytes, not text-mode IO: the path was computed from the
-  -- UTF-8 serialization, and a locale-dependent or newline-translating
-  -- write would store bytes that no longer match their content address.
-  BS.writeFile destPath (TE.encodeUtf8 aterm)
+  -- Raw bytes, not text-mode IO: the path was computed from exactly these
+  -- bytes, and a locale-dependent or newline-translating write would store
+  -- bytes that no longer match their content address.
+  BS.writeFile destPath aterm
 
 -- | Serialize a derivation to ATerm and write it to the store at the given path.
 writeDrv :: Store -> Derivation -> StorePath -> IO ()

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -6410,53 +6410,53 @@ testByteStringSemantics = do
   sequence
     [ -- stringLength / substring index bytes
       runTest "stringLength counts bytes" $
-        assertEval "len-bytes" "builtins.stringLength \"ä\"" (VInt 2),
+        assertEval "len-bytes" "builtins.stringLength \"\228\"" (VInt 2),
       runTest "substring slices at byte offsets" $
-        assertEval "substr-bytes" "builtins.stringLength (builtins.substring 0 1 \"ä\")" (VInt 1),
+        assertEval "substr-bytes" "builtins.stringLength (builtins.substring 0 1 \"\228\")" (VInt 1),
       runTest "mid-codepoint slices reassemble byte-exactly" $
         assertEval
           "substr-reassemble"
-          "builtins.substring 0 1 \"ä\" + builtins.substring 1 1 \"ä\" == \"ä\""
+          "builtins.substring 0 1 \"\228\" + builtins.substring 1 1 \"\228\" == \"\228\""
           (VBool True),
       -- the hash sees exactly the value's bytes
       runTest "hashString of a mid-codepoint slice is the raw byte's sha256" $
         assertEval
           "hash-midbyte"
-          "builtins.hashString \"sha256\" (builtins.substring 0 1 \"ä\")"
-          (mkStr (Hash.bytesToHexText (sha256Digest (BS.take 1 (TE.encodeUtf8 "ä"))))),
+          "builtins.hashString \"sha256\" (builtins.substring 0 1 \"\228\")"
+          (mkStr (Hash.bytesToHexText (sha256Digest (BS.take 1 (TE.encodeUtf8 "\228"))))),
       runTest "hashString of valid UTF-8 is unchanged by the byte layer" $
         assertEval
           "hash-utf8-stable"
-          "builtins.hashString \"sha256\" \"ä\""
-          (mkStr (Hash.bytesToHexText (sha256Digest (TE.encodeUtf8 "ä")))),
+          "builtins.hashString \"sha256\" \"\228\""
+          (mkStr (Hash.bytesToHexText (sha256Digest (TE.encodeUtf8 "\228")))),
       -- regexes run over bytes ('.' matches ONE byte)
       runTest "match . does not match a 2-byte char" $
-        assertEval "match-one-byte" "builtins.match \".\" \"ä\"" VNull,
+        assertEval "match-one-byte" "builtins.match \".\" \"\228\"" VNull,
       runTest "match .. matches a 2-byte char" $
-        assertEval "match-two-bytes" "builtins.match \"..\" \"ä\" == []" (VBool True),
+        assertEval "match-two-bytes" "builtins.match \"..\" \"\228\" == []" (VBool True),
       runTest "a multibyte pattern matches its own bytes" $
-        assertEval "match-multibyte-pattern" "builtins.match \"ä\" \"ä\" == []" (VBool True),
+        assertEval "match-multibyte-pattern" "builtins.match \"\228\" \"\228\" == []" (VBool True),
       -- replaceStrings with an empty 'from' steps one BYTE
       runTest "replaceStrings empty-from inserts between bytes" $
         assertEval
           "replace-empty-from"
-          "builtins.stringLength (builtins.replaceStrings [\"\"] [\"-\"] \"ä\")"
+          "builtins.stringLength (builtins.replaceStrings [\"\"] [\"-\"] \"\228\")"
           (VInt 5),
       runTest "replaceStrings empty-from result is byte-exact" $
         assertEval
           "replace-empty-from-bytes"
-          "builtins.replaceStrings [\"\"] [\"-\"] \"ä\" == \"-\" + builtins.substring 0 1 \"ä\" + \"-\" + builtins.substring 1 1 \"ä\" + \"-\""
+          "builtins.replaceStrings [\"\"] [\"-\"] \"\228\" == \"-\" + builtins.substring 0 1 \"\228\" + \"-\" + builtins.substring 1 1 \"\228\" + \"-\""
           (VBool True),
       -- strict-decode boundaries reject bytes that are not UTF-8
       runTest "toJSON rejects invalid UTF-8" $
-        assertEvalFail "tojson-invalid" "builtins.toJSON (builtins.substring 0 1 \"ä\")",
+        assertEvalFail "tojson-invalid" "builtins.toJSON (builtins.substring 0 1 \"\228\")",
       runTest "getAttr rejects an invalid-UTF-8 attr name" $
-        assertEvalFail "getattr-invalid" "builtins.getAttr (builtins.substring 0 1 \"ä\") {}",
+        assertEvalFail "getattr-invalid" "builtins.getAttr (builtins.substring 0 1 \"\228\") {}",
       -- toXML passes bytes through raw (upstream's serializer never validates)
       runTest "toXML passes a mid-codepoint byte through" $
         assertEval
           "toxml-bytes"
-          "builtins.stringLength (builtins.toXML (builtins.substring 0 1 \"ä\")) == builtins.stringLength (builtins.toXML \"x\")"
+          "builtins.stringLength (builtins.toXML (builtins.substring 0 1 \"\228\")) == builtins.stringLength (builtins.toXML \"x\")"
           (VBool True),
       -- a search-path miss is a CATCHABLE error (upstream ThrownError;
       -- nixpkgs' impure.nix relies on tryEval catching it)
@@ -6492,7 +6492,7 @@ testByteStringSemanticsIO = do
         BS.writeFile (testDir </> "utf16-ascii.bin") utf16AsciiBytes
         BS.writeFile (testDir </> "invalid.bin") invalidBytes
         BS.writeFile (testDir </> "nul.bin") nulBytes
-        BS.writeFile (testDir </> "umlaut.bin") (TE.encodeUtf8 "ä")
+        BS.writeFile (testDir </> "umlaut.bin") (TE.encodeUtf8 "\228")
     )
     ( do
         exists <- doesDirectoryExist testDir
@@ -6536,7 +6536,7 @@ testByteStringSemanticsIO = do
         runTestIO
           "readFile round-trips a multibyte literal"
           testDir
-          "builtins.readFile ./umlaut.bin == \"ä\""
+          "builtins.readFile ./umlaut.bin == \"\228\""
           (VBool True),
         runTestIOFail
           "readFile rejects an embedded NUL"

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -19,6 +19,7 @@ import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
+import Data.Text.Encoding.Error (lenientDecode)
 import qualified Data.Text.IO as TIO
 import Foreign.Ptr (castPtr)
 import Foreign.StablePtr (StablePtr, castPtrToStablePtr, castStablePtrToPtr, deRefStablePtr, freeStablePtr, newStablePtr)
@@ -97,6 +98,10 @@ assertEqual label expected actual
           <> T.pack (show expected)
           <> " but got "
           <> T.pack (show actual)
+
+-- | Render string-value bytes in a failure message (display-only decode).
+bytesText :: BS.ByteString -> Text
+bytesText = TE.decodeUtf8With lenientDecode
 
 assertRight :: (Show e) => Text -> Either e a -> (a -> TestResult) -> TestResult
 assertRight label result check = case result of
@@ -1997,7 +2002,7 @@ testBatchAIO = do
           result <- evalNixIO testDir "builtins.getEnv \"PATH\""
           runTest "getEnv PATH non-empty (IO)" $ assertRight "getEnv-io" result $ \val ->
             case val of
-              VStr s _ -> if T.null s then Fail "PATH was empty" else Pass
+              VStr s _ -> if BS.null s then Fail "PATH was empty" else Pass
               _ -> Fail ("expected VStr, got " <> T.pack (show val)),
         -- currentTime in IO should be > 0
         do
@@ -2227,28 +2232,28 @@ testBatchG = do
   sequence
     [ runTest "ATerm minimal" $
         let aterm = toATerm minimalDrv
-         in if T.isPrefixOf "Derive(" aterm && T.isSuffixOf ")" aterm
+         in if BS.isPrefixOf "Derive(" aterm && BS.isSuffixOf ")" aterm
               then Pass
-              else Fail ("bad ATerm: " <> aterm),
+              else Fail ("bad ATerm: " <> bytesText aterm),
       runTest "ATerm has output" $
         let aterm = toATerm drvWithOutput
-         in if "\"out\"" `T.isInfixOf` aterm
+         in if "\"out\"" `BS.isInfixOf` aterm
               then Pass
-              else Fail ("missing output in ATerm: " <> aterm),
+              else Fail ("missing output in ATerm: " <> bytesText aterm),
       runTest "ATerm env sorted" $
         let aterm = toATerm drvWithEnv
          in -- "name" should come before "system" in sorted order
-            case (T.breakOn "\"name\"" aterm, T.breakOn "\"system\"" aterm) of
+            case (BS.breakSubstring "\"name\"" aterm, BS.breakSubstring "\"system\"" aterm) of
               ((before1, _), (before2, _)) ->
-                if T.length before1 < T.length before2
+                if BS.length before1 < BS.length before2
                   then Pass
-                  else Fail ("env not sorted in ATerm: " <> aterm),
+                  else Fail ("env not sorted in ATerm: " <> bytesText aterm),
       runTest "ATerm string escaping" $
         let drv = minimalDrv {drvEnv = Map.fromList [("msg", "hello\nworld")]}
             aterm = toATerm drv
-         in if "\\n" `T.isInfixOf` aterm
+         in if "\\n" `BS.isInfixOf` aterm
               then Pass
-              else Fail ("missing escaped newline: " <> aterm),
+              else Fail ("missing escaped newline: " <> bytesText aterm),
       runTest "ATerm deterministic" $
         assertEqual "deterministic" (toATerm minimalDrv) (toATerm minimalDrv),
       -- platformToText
@@ -2283,17 +2288,17 @@ testBatchH = do
         assertRight "drv-drvPath" (evalNix "let d = derivation { name = \"hello\"; system = \"x86_64-linux\"; builder = \"/bin/sh\"; }; in d.drvPath") $ \val ->
           case val of
             VStr p ctx ->
-              if "/nix/store/" `T.isPrefixOf` p && ".drv" `T.isSuffixOf` p && ctx /= emptyContext
+              if "/nix/store/" `BS.isPrefixOf` p && ".drv" `BS.isSuffixOf` p && ctx /= emptyContext
                 then Pass
-                else Fail ("bad drvPath: " <> p)
+                else Fail ("bad drvPath: " <> bytesText p)
             _ -> Fail ("expected VStr with context, got " <> T.pack (show val)),
       runTest "derivation has outPath" $
         assertRight "drv-outPath" (evalNix "let d = derivation { name = \"hello\"; system = \"x86_64-linux\"; builder = \"/bin/sh\"; }; in d.outPath") $ \val ->
           case val of
             VStr p ctx ->
-              if "/nix/store/" `T.isPrefixOf` p && ctx /= emptyContext
+              if "/nix/store/" `BS.isPrefixOf` p && ctx /= emptyContext
                 then Pass
-                else Fail ("bad outPath: " <> p)
+                else Fail ("bad outPath: " <> bytesText p)
             _ -> Fail ("expected VStr with context, got " <> T.pack (show val)),
       -- 'derivation' is lazy (matches C++ Nix): the missing-required-attribute
       -- error fires when a path is forced (.drvPath), not at construction.
@@ -2499,8 +2504,8 @@ testDrvContext = do
           (evalNix "let d = derivation { name = \"test\"; system = \"x86_64-linux\"; builder = \"/bin/sh\"; }; in builtins.elemAt (builtins.attrNames (builtins.getContext d.drvPath)) 0")
         $ \val -> case val of
           VStr key _
-            | "/nix/store/" `T.isPrefixOf` key && not ("\\" `T.isInfixOf` key) -> Pass
-            | otherwise -> Fail ("expected a canonical /nix/store key, got " <> key)
+            | "/nix/store/" `BS.isPrefixOf` key && not ("\\" `BS.isInfixOf` key) -> Pass
+            | otherwise -> Fail ("expected a canonical /nix/store key, got " <> bytesText key)
           _ -> Fail ("expected VStr, got " <> T.pack (show val)),
       -- appendContext: adds context to plain string
       runTest "appendContext adds context" $
@@ -3096,7 +3101,7 @@ testBuildOrchestrator = do
         pure $ case (r1, r2) of
           (Right (VStr a _), Right (VStr b _))
             | a == b -> Pass
-            | otherwise -> Fail ("drvPath not deterministic: " <> a <> " vs " <> b)
+            | otherwise -> Fail ("drvPath not deterministic: " <> bytesText a <> " vs " <> bytesText b)
           _ -> Fail "expected main.drvPath to evaluate to a string under IO eval",
       -- drv1: embedding another derivation's drvPath (an all-outputs ref) adds
       -- it to inputDrvs; the IO evaluator recovers its output names in-session.
@@ -3752,7 +3757,7 @@ testUnpackBuildIO = do
                 drvArgs = [],
                 drvEnv =
                   Map.fromList
-                    [(envSrcs, T.intercalate " " (map T.pack srcFiles))]
+                    [(envSrcs, TE.encodeUtf8 (T.intercalate " " (map T.pack srcFiles)))]
               }
           seedOut = StorePath (T.replicate 31 "0" <> "2") "unpack-seed"
           collideOut = StorePath (T.replicate 31 "0" <> "3") "unpack-collide"
@@ -4845,7 +4850,7 @@ testFromATerm = do
         let sp = StorePath "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" "test.drv"
             destFile = storePathToFilePath (stDir store) sp
         writeDrv store simpleTestDrv sp
-        contents <- TIO.readFile destFile
+        contents <- BS.readFile destFile
         closeStore store
         removeIfExists tmpStore
         pure (assertEqual "writeDrv content" (toATerm simpleTestDrv) contents),
@@ -4885,7 +4890,7 @@ testFromATerm = do
         $ \val -> case val of
           VDerivation drv
             | Just op <- Map.lookup "out" (drvEnv drv),
-              "/nix/store/" `T.isPrefixOf` op,
+              "/nix/store/" `BS.isPrefixOf` op,
               Just nm <- Map.lookup "name" (drvEnv drv),
               nm == "test" ->
                 Pass
@@ -4915,9 +4920,9 @@ mkTestBuildDrv shell outSP script =
       drvInputDrvs = Map.empty,
       drvInputSrcs = [],
       drvPlatform = currentPlatform,
-      drvBuilder = shell,
-      drvArgs = ["-c", script],
-      drvEnv = Map.fromList [("name", "test-build"), ("system", platformToText currentPlatform)]
+      drvBuilder = TE.encodeUtf8 shell,
+      drvArgs = ["-c", TE.encodeUtf8 script],
+      drvEnv = Map.fromList [("name", "test-build"), ("system", TE.encodeUtf8 (platformToText currentPlatform))]
     }
 
 testBuilder :: IO [Bool]
@@ -5116,7 +5121,7 @@ testBuilder = do
                   drvInputDrvs = Map.empty,
                   drvInputSrcs = [],
                   drvPlatform = currentPlatform,
-                  drvBuilder = shell,
+                  drvBuilder = TE.encodeUtf8 shell,
                   drvArgs = ["-c", "mkdir -p $out && echo lib > $out/lib.txt && mkdir -p $dev && echo headers > $dev/include.h"],
                   drvEnv = Map.fromList [("name", "multi")]
                 }
@@ -5411,11 +5416,11 @@ testToJSONPathIO = do
           result <- evalNixIO testDir "builtins.toJSON ./data.txt"
           pure $ case result of
             Right (VStr json ctx) ->
-              if "\"/nix/store/" `T.isPrefixOf` json
-                && "-data.txt\"" `T.isSuffixOf` json
+              if "\"/nix/store/" `BS.isPrefixOf` json
+                && "-data.txt\"" `BS.isSuffixOf` json
                 && ctx /= emptyContext
                 then Pass
-                else Fail ("expected a quoted store path with context, got " <> json)
+                else Fail ("expected a quoted store path with context, got " <> bytesText json)
             Right other -> Fail ("expected VStr, got " <> T.pack (show other))
             Left err -> Fail ("eval error: " <> err)
       ]
@@ -6358,6 +6363,155 @@ testStaticGlobalsSync = do
 -- Main
 -- ---------------------------------------------------------------------------
 
+-- ---------------------------------------------------------------------------
+-- Tests: byte-indexed string semantics (issue #34)
+-- ---------------------------------------------------------------------------
+
+-- | The pinned byte-semantics suite: a Nix string is a byte string, so
+-- lengths, slices, regexes, and replaceStrings all index BYTES, and the
+-- hash of a value is the hash of exactly its bytes.  Multibyte content
+-- enters through source literals here (the parser interns their UTF-8);
+-- arbitrary/invalid bytes enter via readFile in the IO group below.
+testByteStringSemantics :: IO [Bool]
+testByteStringSemantics = do
+  putStrLn "eval/byte-strings"
+  sequence
+    [ -- stringLength / substring index bytes
+      runTest "stringLength counts bytes" $
+        assertEval "len-bytes" "builtins.stringLength \"ä\"" (VInt 2),
+      runTest "substring slices at byte offsets" $
+        assertEval "substr-bytes" "builtins.stringLength (builtins.substring 0 1 \"ä\")" (VInt 1),
+      runTest "mid-codepoint slices reassemble byte-exactly" $
+        assertEval
+          "substr-reassemble"
+          "builtins.substring 0 1 \"ä\" + builtins.substring 1 1 \"ä\" == \"ä\""
+          (VBool True),
+      -- the hash sees exactly the value's bytes
+      runTest "hashString of a mid-codepoint slice is the raw byte's sha256" $
+        assertEval
+          "hash-midbyte"
+          "builtins.hashString \"sha256\" (builtins.substring 0 1 \"ä\")"
+          (mkStr (Hash.bytesToHexText (sha256Digest (BS.take 1 (TE.encodeUtf8 "ä"))))),
+      runTest "hashString of valid UTF-8 is unchanged by the byte layer" $
+        assertEval
+          "hash-utf8-stable"
+          "builtins.hashString \"sha256\" \"ä\""
+          (mkStr (Hash.bytesToHexText (sha256Digest (TE.encodeUtf8 "ä")))),
+      -- regexes run over bytes ('.' matches ONE byte)
+      runTest "match . does not match a 2-byte char" $
+        assertEval "match-one-byte" "builtins.match \".\" \"ä\"" VNull,
+      runTest "match .. matches a 2-byte char" $
+        assertEval "match-two-bytes" "builtins.match \"..\" \"ä\" == []" (VBool True),
+      runTest "a multibyte pattern matches its own bytes" $
+        assertEval "match-multibyte-pattern" "builtins.match \"ä\" \"ä\" == []" (VBool True),
+      -- replaceStrings with an empty 'from' steps one BYTE
+      runTest "replaceStrings empty-from inserts between bytes" $
+        assertEval
+          "replace-empty-from"
+          "builtins.stringLength (builtins.replaceStrings [\"\"] [\"-\"] \"ä\")"
+          (VInt 5),
+      runTest "replaceStrings empty-from result is byte-exact" $
+        assertEval
+          "replace-empty-from-bytes"
+          "builtins.replaceStrings [\"\"] [\"-\"] \"ä\" == \"-\" + builtins.substring 0 1 \"ä\" + \"-\" + builtins.substring 1 1 \"ä\" + \"-\""
+          (VBool True),
+      -- strict-decode boundaries reject bytes that are not UTF-8
+      runTest "toJSON rejects invalid UTF-8" $
+        assertEvalFail "tojson-invalid" "builtins.toJSON (builtins.substring 0 1 \"ä\")",
+      runTest "getAttr rejects an invalid-UTF-8 attr name" $
+        assertEvalFail "getattr-invalid" "builtins.getAttr (builtins.substring 0 1 \"ä\") {}",
+      -- toXML passes bytes through raw (upstream's serializer never validates)
+      runTest "toXML passes a mid-codepoint byte through" $
+        assertEval
+          "toxml-bytes"
+          "builtins.stringLength (builtins.toXML (builtins.substring 0 1 \"ä\")) == builtins.stringLength (builtins.toXML \"x\")"
+          (VBool True),
+      -- a search-path miss is a CATCHABLE error (upstream ThrownError;
+      -- nixpkgs' impure.nix relies on tryEval catching it)
+      runTest "search-path miss is tryEval-catchable" $
+        assertEval
+          "findFile-catchable"
+          "(builtins.tryEval (builtins.findFile builtins.nixPath \"nope-missing\")).success"
+          (VBool False)
+    ]
+
+-- | readFile returns the file's RAW BYTES: BOMs survive, UTF-16 is not
+-- transcoded, invalid UTF-8 is representable, and only NUL is rejected.
+-- The expected hashes are computed from the fixture bytes themselves, so
+-- the assertions pin "hash of the value = hash of the file's bytes".
+testByteStringSemanticsIO :: IO [Bool]
+testByteStringSemanticsIO = do
+  putStrLn "eval/readfile-bytes-io"
+  tmpDir <- getTemporaryDirectory
+  let testDir = tmpDir </> "nova-nix-bytefile-test"
+      bomBytes = BS.pack [0xEF, 0xBB, 0xBF] <> "hi"
+      -- UTF-16LE BOM + U+0101 (both payload bytes nonzero, so no NUL):
+      -- raw passthrough is observable as 4 bytes instead of a decoded char.
+      utf16Bytes = BS.pack [0xFF, 0xFE, 0x01, 0x01]
+      -- UTF-16LE ASCII interleaves NUL bytes - upstream readFile REJECTS it.
+      utf16AsciiBytes = BS.pack [0xFF, 0xFE, 0x68, 0x00, 0x69, 0x00]
+      invalidBytes = "a" <> BS.singleton 0xFF <> "b"
+      nulBytes = "a" <> BS.singleton 0x00 <> "b"
+  bracket_
+    ( do
+        createDirectoryIfMissing True testDir
+        BS.writeFile (testDir </> "bom.bin") bomBytes
+        BS.writeFile (testDir </> "utf16.bin") utf16Bytes
+        BS.writeFile (testDir </> "utf16-ascii.bin") utf16AsciiBytes
+        BS.writeFile (testDir </> "invalid.bin") invalidBytes
+        BS.writeFile (testDir </> "nul.bin") nulBytes
+        BS.writeFile (testDir </> "umlaut.bin") (TE.encodeUtf8 "ä")
+    )
+    ( do
+        exists <- doesDirectoryExist testDir
+        when exists (removeDirectoryRecursive testDir)
+    )
+    $ sequence
+      [ runTestIO
+          "readFile keeps a BOM (raw bytes)"
+          testDir
+          "builtins.stringLength (builtins.readFile ./bom.bin)"
+          (VInt 5),
+        runTestIO
+          "readFile does not transcode UTF-16"
+          testDir
+          "builtins.stringLength (builtins.readFile ./utf16.bin)"
+          (VInt 4),
+        runTestIOFail
+          "readFile rejects UTF-16 ASCII (its NUL bytes)"
+          testDir
+          "builtins.readFile ./utf16-ascii.bin",
+        runTestIO
+          "readFile passes invalid UTF-8 through"
+          testDir
+          "builtins.stringLength (builtins.readFile ./invalid.bin)"
+          (VInt 3),
+        runTestIO
+          "readFile bytes hash as read (BOM file)"
+          testDir
+          "builtins.hashString \"sha256\" (builtins.readFile ./bom.bin)"
+          (mkStr (Hash.bytesToHexText (sha256Digest bomBytes))),
+        runTestIO
+          "readFile bytes hash as read (UTF-16 file)"
+          testDir
+          "builtins.hashString \"sha256\" (builtins.readFile ./utf16.bin)"
+          (mkStr (Hash.bytesToHexText (sha256Digest utf16Bytes))),
+        runTestIO
+          "readFile of invalid UTF-8 hashes its raw bytes"
+          testDir
+          "builtins.hashString \"sha256\" (builtins.readFile ./invalid.bin)"
+          (mkStr (Hash.bytesToHexText (sha256Digest invalidBytes))),
+        runTestIO
+          "readFile round-trips a multibyte literal"
+          testDir
+          "builtins.readFile ./umlaut.bin == \"ä\""
+          (VBool True),
+        runTestIOFail
+          "readFile rejects an embedded NUL"
+          testDir
+          "builtins.readFile ./nul.bin"
+      ]
+
 main :: IO ()
 main = bracket_ arenaInit arenaDestroy $ do
   hSetBuffering stdout LineBuffering
@@ -6441,6 +6595,8 @@ main = bracket_ arenaInit arenaDestroy $ do
           testPhase4,
           testPhase4IO,
           testToJSONPathIO,
+          testByteStringSemantics,
+          testByteStringSemanticsIO,
           testSymbol,
           testCAttrSet,
           testCThunk,

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -3976,6 +3976,38 @@ testUpstreamConformance = do
         assertEvalFail
           "hash-bad-algo"
           "builtins.convertHash { hash = \"00\"; hashAlgo = \"sha3\"; toHashFormat = \"base16\"; }",
+      -- SRI digests get the same decoded-length check as every other
+      -- spelling (upstream checks SRI too), at all three decode sites:
+      -- convertHash, fixed-output outputHash, and the fetch/path pins.
+      runTest "valid SRI digest converts" $
+        assertEval
+          "hash-sri-valid"
+          "builtins.convertHash { hash = \"sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=\"; toHashFormat = \"base16\"; }"
+          (mkStr "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"),
+      runTest "convertHash rejects a truncated SRI digest" $
+        case evalNix "builtins.convertHash { hash = \"sha256-YWJj\"; toHashFormat = \"base16\"; }" of
+          Left err
+            | "wrong length" `T.isInfixOf` err -> Pass
+            | otherwise -> Fail ("expected an SRI length error, got: " <> err)
+          Right val -> Fail ("expected failure, got: " <> T.pack (show val)),
+      runTest "fixed-output outputHash rejects a truncated SRI digest" $
+        case evalNix "(derivation { name = \"t\"; system = \"x86_64-linux\"; builder = \"/bin/sh\"; outputHash = \"sha256-YWJj\"; }).drvPath" of
+          Left err
+            | "wrong length" `T.isInfixOf` err -> Pass
+            | otherwise -> Fail ("expected an SRI length error, got: " <> err)
+          Right val -> Fail ("expected failure, got: " <> T.pack (show val)),
+      runTest "builtins.path pin rejects a truncated SRI digest" $
+        case evalNix "builtins.path { path = ./x; sha256 = \"sha256-YWJj\"; }" of
+          Left err
+            | "wrong length" `T.isInfixOf` err -> Pass
+            | otherwise -> Fail ("expected an SRI length error, got: " <> err)
+          Right val -> Fail ("expected failure, got: " <> T.pack (show val)),
+      runTest "builtins.path pin rejects a non-sha256 SRI digest" $
+        case evalNix ("builtins.path { path = ./x; sha256 = \"sha512-" <> T.replicate 86 "A" <> "==\"; }") of
+          Left err
+            | "should have type 'sha256'" `T.isInfixOf` err -> Pass
+            | otherwise -> Fail ("expected a hash-type error, got: " <> err)
+          Right val -> Fail ("expected failure, got: " <> T.pack (show val)),
       -- toJSON floats: nlohmann's layout - shortest round-trip digits, .0
       -- kept on integral values, scientific outside point positions (-4, 15].
       runTest "toJSON float shortest digits" $


### PR DESCRIPTION
A Nix string is a byte string; nova-nix indexed Data.Text codepoints, so every non-ASCII string diverged from upstream, and a divergent value reaching a name or hash produced a different store path. This flips the representation once (`VStr !ByteString`) and the four findings from #34 fall out, plus two adjacent conformance fixes.

## The representation flip (#34)

- `stringLength`/`substring` count and slice **bytes**; a mid-codepoint slice is representable and hashes as exactly its bytes (pinned against an externally computed sha256 of the raw byte).
- `match`/`split` compile the pattern from its bytes and match the byte view - `.` matches one byte, as upstream.
- `replaceStrings` with an empty `from` element steps one byte.
- `readFile` returns the file's raw bytes, rejecting only NUL (upstream's exact behavior); the BOM/UTF-16 auto-decode stays on the parser/import path only.
- Derivation builder/args/env values are bytes end to end: the ATerm serializer (now Builder-based) and parser are byte-level, so coerced strings reach the `.drv` hash with no encoding step.
- Text enters via `mkStr` (UTF-8 encode) and leaves through explicit boundaries: strict decode with a clean eval error where the implementation needs Text (attr names, filesystem paths, toJSON - which upstream also validates - and the builder spawn env), lossy decode for display/trace only. Symbols intern raw bytes; the C table was already length-prefixed and encoding-agnostic, so there is no C change.

**Identity guard:** `hello.drvPath` against nixpkgs 24.11 is byte-identical before and after the migration (`kgf72hk02jza2ddjzcyy7q2xdbdw3dfl-hello-2.12.1.drv`) - no double-encode anywhere in the hash path.

**Benchmarks** (vs `4c7411b`): nixpkgs attrNames at parity (allocations identical); `hello.drvPath` **-23% mutator time, -7% allocations**, max residency 9.0 -> 10.7 MB. Full RTS stats under `profiling/results/bytestr-*`.

## Search-path miss is catchable (first commit)

Upstream raises ThrownError for a missing `<name>` entry precisely so nixpkgs' `impure.nix` can `tryEval` the `<nixpkgs-overlays>` probe; nova's uncatchable form failed every bare `import <nixpkgs> {}` before evaluation started. This was also the baseline-probe blocker recorded on #34.

## SRI digest-length check (#49)

The three SRI branches (convertHash, fixed-output `outputHash`, fetch/path pins) handed the payload straight to base64 decode with no length check, so a 3-byte digest was accepted as sha256. One shared `decodeSRI` step now enforces the algorithm's digest size at all three sites, and the sha256 pins reject a spelling tagged with a different algorithm instead of discarding the tag.

## Tests

949/949: new `eval/byte-strings` and `eval/readfile-bytes-io` groups pin the four findings, raw-byte hash parity, strict-decode boundaries, and readFile fixtures (BOM, UTF-16, invalid UTF-8, embedded NUL); the conformance group gains the SRI length/type cases and the catchability test.

Fixes #34, fixes #49.