### PR TITLE
Bytecode: spill payload counts past short_arg's 65535 ceiling

### DIFF
--- a/cbits/nn_bytecode.h
+++ b/cbits/nn_bytecode.h
@@ -104,7 +104,13 @@
 typedef struct nn_op {
     uint8_t  opcode;     /* Which Expr constructor */
     uint8_t  flags;      /* Sub-type: BinaryOp, UnaryOp, formal type, etc. */
-    uint16_t short_arg;  /* Small immediate: count, bool flag, etc. */
+    uint16_t short_arg;  /* Small immediate: count, bool flag, etc.
+                            Payload counts use a spill convention so the
+                            op stays 16 bytes: 0xFFFF here means the true
+                            count is the FIRST uint32 of the op's data
+                            region and the payload starts one word later
+                            (emit/decode live on the Haskell side:
+                            Nix.Eval.CBytecode.cbcCountedPayload). */
     uint32_t arg1;       /* Child index, symbol, data offset, lo32, etc. */
     uint32_t arg2;       /* Child index, symbol, hi32, etc. */
     uint32_t arg3;       /* Child index, data offset, etc. */

--- a/src/Nix/Eval.hs
+++ b/src/Nix/Eval.hs
@@ -91,7 +91,7 @@ import Data.Word (Word32, Word64, Word8)
 import Foreign.Ptr (Ptr, castPtr, nullPtr, ptrToWordPtr, wordPtrToPtr)
 import Foreign.Storable (peekElemOff, pokeElemOff)
 import Nix.Derivation (Derivation (..), DerivationOutput (..), textToPlatform, toATerm, toATermForHash)
-import Nix.Eval.CBytecode (cbcArg1, cbcArg2, cbcArg3, cbcData, cbcFlags, cbcOpcode, cbcShortArg, pattern OpApp, pattern OpAssert, pattern OpAttrs, pattern OpBinary, pattern OpHasAttr, pattern OpIf, pattern OpIndStr, pattern OpLambda, pattern OpLet, pattern OpList, pattern OpLitBool, pattern OpLitFloat, pattern OpLitInt, pattern OpLitNull, pattern OpLitPath, pattern OpLitUri, pattern OpResolvedVar, pattern OpSearchPath, pattern OpSelect, pattern OpStr, pattern OpUnary, pattern OpVar, pattern OpWith, pattern OpWithVar)
+import Nix.Eval.CBytecode (cbcArg1, cbcArg2, cbcArg3, cbcCountedPayload, cbcData, cbcFlags, cbcOpcode, cbcShortArg, pattern OpApp, pattern OpAssert, pattern OpAttrs, pattern OpBinary, pattern OpHasAttr, pattern OpIf, pattern OpIndStr, pattern OpLambda, pattern OpLet, pattern OpList, pattern OpLitBool, pattern OpLitFloat, pattern OpLitInt, pattern OpLitNull, pattern OpLitPath, pattern OpLitUri, pattern OpResolvedVar, pattern OpSearchPath, pattern OpSelect, pattern OpStr, pattern OpUnary, pattern OpVar, pattern OpWith, pattern OpWithVar)
 import Nix.Eval.CEnv (cenvPushWith)
 import Nix.Eval.CList (CList (..), clistGet)
 import Nix.Eval.CThunk (CThunkPtr)
@@ -434,8 +434,8 @@ evalShortCircuitImpl env leftIdx rightIdx = do
 -- | Evaluate a string literal from bytecode data buffer.
 evalBcStr :: (MonadEval m) => Env -> Word32 -> m NixValue
 evalBcStr env bcIdx0 = do
-  let count = fromIntegral (unsafePerformIO (cbcShortArg bcIdx0))
-      dataOff = unsafePerformIO (cbcArg1 bcIdx0)
+  let (count, dataOff) =
+        unsafePerformIO (cbcCountedPayload bcIdx0 =<< cbcArg1 bcIdx0)
   chunks <- evalBcStringParts env count dataOff
   pure (VStr (BS.concat [t | (_, t, _) <- chunks]) (mconcat [c | (_, _, c) <- chunks]))
 
@@ -445,8 +445,8 @@ evalBcStr env bcIdx0 = do
 -- C++ Nix.
 evalBcIndStr :: (MonadEval m) => Env -> Word32 -> m NixValue
 evalBcIndStr env bcIdx0 = do
-  let count = fromIntegral (unsafePerformIO (cbcShortArg bcIdx0))
-      dataOff = unsafePerformIO (cbcArg1 bcIdx0)
+  let (count, dataOff) =
+        unsafePerformIO (cbcCountedPayload bcIdx0 =<< cbcArg1 bcIdx0)
   chunks <- evalBcStringParts env count dataOff
   let (text, ctx) = stripIndentedChunks chunks
   pure (VStr text ctx)
@@ -472,8 +472,8 @@ evalBcStringParts env n off = do
 -- | Evaluate a list from bytecode data buffer.
 evalBcList :: (MonadEval m) => Env -> Word32 -> m NixValue
 evalBcList env bcIdx0 =
-  let count = fromIntegral (unsafePerformIO (cbcShortArg bcIdx0)) :: Int
-      dataOff = unsafePerformIO (cbcArg1 bcIdx0)
+  let (count, dataOff) =
+        unsafePerformIO (cbcCountedPayload bcIdx0 =<< cbcArg1 bcIdx0)
       readChildren 0 _ = []
       readChildren n off =
         let childIdx = unsafePerformIO (cbcData off)
@@ -558,9 +558,9 @@ evalBcLambda env bcIdx0 =
 evalBcSelect :: (MonadEval m) => Env -> Word32 -> m NixValue
 evalBcSelect env bcIdx0 = do
   let hasDef = unsafePerformIO (cbcFlags bcIdx0) /= 0
-      pathLen = fromIntegral (unsafePerformIO (cbcShortArg bcIdx0))
       targetIdx = unsafePerformIO (cbcArg1 bcIdx0)
-      pathOff = unsafePerformIO (cbcArg2 bcIdx0)
+      (pathLen, pathOff) =
+        unsafePerformIO (cbcCountedPayload bcIdx0 =<< cbcArg2 bcIdx0)
       defIdx = unsafePerformIO (cbcArg3 bcIdx0)
   targetVal <- evalBytecode env targetIdx
   result <- walkBcAttrPath env pathLen pathOff targetVal
@@ -578,9 +578,9 @@ evalBcSelect env bcIdx0 = do
 -- | Evaluate a hasAttr expression from bytecode.
 evalBcHasAttr :: (MonadEval m) => Env -> Word32 -> m NixValue
 evalBcHasAttr env bcIdx0 = do
-  let pathLen = fromIntegral (unsafePerformIO (cbcShortArg bcIdx0))
-      targetIdx = unsafePerformIO (cbcArg1 bcIdx0)
-      pathOff = unsafePerformIO (cbcArg2 bcIdx0)
+  let targetIdx = unsafePerformIO (cbcArg1 bcIdx0)
+      (pathLen, pathOff) =
+        unsafePerformIO (cbcCountedPayload bcIdx0 =<< cbcArg2 bcIdx0)
   targetVal <- evalBytecode env targetIdx
   result <- walkBcAttrPath env pathLen pathOff targetVal
   pure (VBool (isJust result))
@@ -627,8 +627,8 @@ walkBcAttrPath env n off val = case val of
 evalBcAttrs :: (MonadEval m) => Env -> Word32 -> m NixValue
 evalBcAttrs env bcIdx0 = do
   let isRec = unsafePerformIO (cbcFlags bcIdx0) /= 0
-      bindCount = unsafePerformIO (cbcShortArg bcIdx0)
-      dataOff = unsafePerformIO (cbcArg1 bcIdx0)
+      (bindCount, dataOff) =
+        unsafePerformIO (cbcCountedPayload bcIdx0 =<< cbcArg1 bcIdx0)
       captureOff = unsafePerformIO (cbcArg2 bcIdx0)
       bindings = unsafePerformIO (decodeBcBindings bindCount dataOff)
   if isRec
@@ -696,8 +696,8 @@ evalBcRecAttrs env bindings captureInfo
 -- | Evaluate a let expression from bytecode.
 evalBcLet :: (MonadEval m) => Env -> Word32 -> m NixValue
 evalBcLet env bcIdx0 = do
-  let bindCount = unsafePerformIO (cbcShortArg bcIdx0)
-      dataOff = unsafePerformIO (cbcArg1 bcIdx0)
+  let (bindCount, dataOff) =
+        unsafePerformIO (cbcCountedPayload bcIdx0 =<< cbcArg1 bcIdx0)
       bodyIdx = unsafePerformIO (cbcArg2 bcIdx0)
       captureOff = unsafePerformIO (cbcArg3 bcIdx0)
       bindings = unsafePerformIO (decodeBcBindings bindCount dataOff)

--- a/src/Nix/Eval/CBytecode.hs
+++ b/src/Nix/Eval/CBytecode.hs
@@ -33,6 +33,10 @@ module Nix.Eval.CBytecode
     -- * Read data
     cbcData,
 
+    -- * Counted payloads (short_arg spill)
+    spilledCountSentinel,
+    cbcCountedPayload,
+
     -- * Diagnostics
     cbcOpCount,
     cbcDataCount,
@@ -214,6 +218,32 @@ cbcArg3 = c_nn_bc_arg3
 -- | Read entry @i@ of the bytecode data pool (interned literals, symbols).
 cbcData :: Word32 -> IO Word32
 cbcData = c_nn_bc_data
+
+-- ---------------------------------------------------------------------------
+-- Counted payloads (short_arg spill)
+-- ---------------------------------------------------------------------------
+
+-- | @short_arg@ value marking a spilled payload count: the true count is
+-- the FIRST word of the op's data region and the payload begins one word
+-- later.  Counts below the sentinel travel inline, so @nn_op_t@ stays 16
+-- bytes (four ops per cache line) and only an oversized literal pays the
+-- extra data word.  Must stay in lockstep with the @short_arg@ doc in
+-- @cbits\/nn_bytecode.h@.
+spilledCountSentinel :: Word16
+spilledCountSentinel = 0xFFFF
+
+-- | Read an op's payload count and payload start offset, resolving the
+-- spill convention.  @dataOff@ is the raw offset stored in the op's arg
+-- word (arg1 for most counted ops, arg2 for select\/hasAttr paths).
+-- The inline case costs one compare.
+cbcCountedPayload :: Word32 -> Word32 -> IO (Int, Word32)
+cbcCountedPayload bcIdx dataOff = do
+  inline <- cbcShortArg bcIdx
+  if inline == spilledCountSentinel
+    then do
+      spilled <- cbcData dataOff
+      pure (fromIntegral spilled, dataOff + 1)
+    else pure (fromIntegral inline, dataOff)
 
 -- ---------------------------------------------------------------------------
 -- Diagnostics

--- a/src/Nix/Eval/Compile.hs
+++ b/src/Nix/Eval/Compile.hs
@@ -56,6 +56,7 @@ import Nix.Eval.CBytecode
     formalName,
     formalNamedSet,
     formalSet,
+    spilledCountSentinel,
     strpartInterp,
     strpartLit,
     unaryNegate,
@@ -180,8 +181,7 @@ compileExpr = go
     compileStringParts :: Word8 -> [StringPart] -> IO Word32
     compileStringParts op parts = do
       compiled <- mapM compileOnePart parts
-      dataOff <- emitPairs compiled
-      partCount <- countArg "string with parts" (length parts)
+      (partCount, dataOff) <- emitCounted "string with parts" (length parts) (pairWords compiled)
       cbcEmit op 0 partCount dataOff 0 0
 
     compileOnePart :: StringPart -> IO (Word32, Word32)
@@ -198,9 +198,9 @@ compileExpr = go
 
     compileAttrs :: Bool -> [Binding] -> CaptureInfo -> IO Word32
     compileAttrs isRec bindings captureInfo = do
-      dataOff <- compileBindings bindings
+      bindingWords <- compileBindingWords bindings
       capOff <- compileCaptureInfo captureInfo
-      bindingCount <- countArg "attribute set with bindings" (length bindings)
+      (bindingCount, dataOff) <- emitCounted "attribute set with bindings" (length bindings) bindingWords
       cbcEmit OpAttrs (if isRec then 1 else 0) bindingCount dataOff capOff 0
 
     -- -----------------------------------------------------------------
@@ -210,8 +210,7 @@ compileExpr = go
     compileList :: [Expr] -> IO Word32
     compileList exprs = do
       childIndices <- mapM go exprs
-      dataOff <- emitWordList childIndices
-      elemCount <- countArg "list with elements" (length exprs)
+      (elemCount, dataOff) <- emitCounted "list with elements" (length exprs) childIndices
       cbcEmit OpList 0 elemCount dataOff 0 0
 
     -- -----------------------------------------------------------------
@@ -237,8 +236,7 @@ compileExpr = go
     compileAttrPath :: [AttrKey] -> IO (Word32, Word16)
     compileAttrPath path = do
       compiled <- mapM compileAttrKey path
-      off <- emitPairs compiled
-      pathLen <- countArg "attribute path with segments" (length path)
+      (pathLen, off) <- emitCounted "attribute path with segments" (length path) (pairWords compiled)
       pure (off, pathLen)
 
     compileAttrKey :: AttrKey -> IO (Word32, Word32)
@@ -295,19 +293,20 @@ compileExpr = go
     compileLet :: [Binding] -> Expr -> CaptureInfo -> IO Word32
     compileLet bindings body captureInfo = do
       bodyIdx <- go body
-      dataOff <- compileBindings bindings
+      bindingWords <- compileBindingWords bindings
       capOff <- compileCaptureInfo captureInfo
-      bindingCount <- countArg "let with bindings" (length bindings)
+      (bindingCount, dataOff) <- emitCounted "let with bindings" (length bindings) bindingWords
       cbcEmit OpLet 0 bindingCount dataOff bodyIdx capOff
 
     -- -----------------------------------------------------------------
     -- Bindings (shared by EAttrs and ELet)
     -- -----------------------------------------------------------------
 
-    compileBindings :: [Binding] -> IO Word32
-    compileBindings bindings = do
-      allWords <- mapM compileOneBinding bindings
-      emitWordList (concat allWords)
+    -- \| The flat data words for a binding list; the caller emits them
+    -- (with the count, via emitCounted) so a spilled count can precede
+    -- them contiguously.
+    compileBindingWords :: [Binding] -> IO [Word32]
+    compileBindingWords bindings = concat <$> mapM compileOneBinding bindings
 
     compileOneBinding :: Binding -> IO [Word32]
     compileOneBinding (NamedBinding path expr) = do
@@ -397,15 +396,9 @@ compileExpr = go
     -- Data buffer helpers
     -- -----------------------------------------------------------------
 
-    -- \| Emit pairs of (tag, value) to the data buffer.
-    -- Returns the offset of the first emitted word, or 0 if empty.
-    emitPairs :: [(Word32, Word32)] -> IO Word32
-    emitPairs [] = pure 0
-    emitPairs ((tag, val) : rest) = do
-      off <- cbcEmitData tag
-      _ <- cbcEmitData val
-      mapM_ (\(t, v) -> cbcEmitData t >> cbcEmitData v) rest
-      pure off
+    -- \| Flatten (tag, value) pairs into data-buffer words.
+    pairWords :: [(Word32, Word32)] -> [Word32]
+    pairWords = concatMap (\(tag, val) -> [tag, val])
 
     -- \| Emit a list of uint32 values to the data buffer.
     -- Returns the offset of the first emitted word, or 0 if empty.
@@ -416,13 +409,29 @@ compileExpr = go
       mapM_ cbcEmitData xs
       pure off
 
-    -- \| Convert an element count into the bytecode's 16-bit short_arg,
-    -- failing loudly on overflow: a silent Word16 truncation would make a
-    -- 70000-element list literal report length 4464.
-    countArg :: String -> Int -> IO Word16
+    -- \| Emit an op's counted payload, returning the short_arg and data
+    -- offset to store in the op.  A count below 'spilledCountSentinel'
+    -- travels inline in short_arg; a larger one is written as the first
+    -- data word with the sentinel inline ('cbcCountedPayload' is the
+    -- decode side).  nn_op_t stays 16 bytes either way; only an
+    -- oversized literal pays the extra word.
+    emitCounted :: String -> Int -> [Word32] -> IO (Word16, Word32)
+    emitCounted what n payload
+      | n < fromIntegral spilledCountSentinel = do
+          off <- emitWordList payload
+          pure (fromIntegral n, off)
+      | otherwise = do
+          spilled <- countArg what n
+          off <- emitWordList (spilled : payload)
+          pure (spilledCountSentinel, off)
+
+    -- \| Convert a spilled element count into its 32-bit data word,
+    -- failing loudly at the (unreachable-in-practice) ceiling: a silent
+    -- truncation would make an oversized literal report a wrong length.
+    countArg :: String -> Int -> IO Word32
     countArg what n
-      | n > fromIntegral (maxBound :: Word16) =
-          ioError (userError ("compile: " <> what <> " exceeding the bytecode limit of 65535 (got " <> show n <> ")"))
+      | toInteger n > toInteger (maxBound :: Word32) =
+          ioError (userError ("compile: " <> what <> " exceeding the bytecode limit of 4294967295 (got " <> show n <> ")"))
       | otherwise = pure (fromIntegral n)
 
     -- \| @fromIntegral@ shorthand.
@@ -536,8 +545,9 @@ data BcAttrKey
     BcDynamicKey !Word32
 
 -- | Decode all bindings from the bytecode data buffer.
--- @bindCount@ is the number of bindings, @dataOff@ is the start offset.
-decodeBcBindings :: Word16 -> Word32 -> IO [BcBinding]
+-- @bindCount@ is the number of bindings (already resolved through the
+-- short_arg spill by the caller), @dataOff@ is the start offset.
+decodeBcBindings :: Int -> Word32 -> IO [BcBinding]
 decodeBcBindings 0 _ = pure []
 decodeBcBindings count dataOff = do
   (binding, nextOff) <- decodeOneBinding dataOff

--- a/src/Nix/Parser/Lexer.hs
+++ b/src/Nix/Parser/Lexer.hs
@@ -16,6 +16,7 @@ import Data.Char (isAlpha, isAlphaNum, isDigit, isSpace)
 import Data.Int (Int64)
 import Data.Text (Text)
 import qualified Data.Text as T
+import Data.Text.Foreign (lengthWord8)
 import qualified Data.Text.Lazy as TL
 import qualified Data.Text.Lazy.Builder as TB
 import Nix.Parser.ParseError (ParseError (..))
@@ -127,7 +128,20 @@ data LexState = LexState
     lsCol :: !Int,
     lsModes :: ![LexMode],
     lsBraceDepth :: !Int,
-    lsBraceStack :: ![Int]
+    lsBraceStack :: ![Int],
+    -- | Path-lookahead watermark: every position whose remaining input is
+    -- LONGER than this byte count lies inside an already-scanned
+    -- slash-free path-char run, so 'looksLikePathFrom' answers False
+    -- without rescanning.  Without it, a long dot-and-ident run
+    -- (@x ? p0.p1. ... .p69999@) rescans the rest of the run at every
+    -- token - a quadratic that took minutes at 70000 segments.  The
+    -- input only ever shrinks, so a recorded run end stays comparable.
+    lsNoSlashFloor :: !Int,
+    -- | The same watermark for the URI lookahead: positions inside an
+    -- already-scanned scheme-char run that ended at a NON-colon carry no
+    -- URI, so 'uriSpanFrom' answers Nothing without rescanning.  Dots
+    -- are scheme chars, so the same long dot-run is quadratic without it.
+    lsNoColonFloor :: !Int
   }
 
 -- ---------------------------------------------------------------------------
@@ -145,7 +159,10 @@ tokenize fileName source =
             lsCol = 1,
             lsModes = [ModeNormal],
             lsBraceDepth = 0,
-            lsBraceStack = []
+            lsBraceStack = [],
+            -- No runs scanned yet: nothing may shortcut.
+            lsNoSlashFloor = maxBound,
+            lsNoColonFloor = maxBound
           }
    in lexLoop initialState []
 
@@ -162,128 +179,140 @@ lexLoop st acc = case lsModes st of
 lexNormalMode :: LexState -> [Located] -> Either ParseError [Located]
 lexNormalMode st acc = case T.uncons (lsInput st) of
   Nothing -> Right (reverse (Located (lsLine st) (lsCol st) TokEOF : acc))
-  Just (c, rest) -> case c of
-    _ | isSpace c -> lexNormalMode (skipWhitespace st) acc
-    '#' -> lexNormalMode (skipLineComment st) acc
-    '/'
-      | Just '*' <- safeHead rest ->
-          case skipBlockComment (advanceCol 2 st {lsInput = T.drop 2 (lsInput st)}) of
-            Left err -> Left err
-            Right newSt -> lexNormalMode newSt acc
-    '"' ->
-      let tok = Located (lsLine st) (lsCol st) TokStringOpen
-          newSt = advanceCol 1 st {lsInput = rest, lsModes = ModeString : lsModes st}
-       in lexLoop newSt (tok : acc)
-    '\''
-      | Just '\'' <- safeHead rest ->
-          let tok = Located (lsLine st) (lsCol st) TokIndStringOpen
-              newSt = advanceCol 2 st {lsInput = T.drop 2 (lsInput st), lsModes = ModeIndString : lsModes st}
-           in lexLoop newSt (tok : acc)
-    '.'
-      | Just '.' <- safeHead rest,
-        Just '.' <- safeHead (T.drop 1 rest) ->
-          emit3 st TokEllipsis acc
-    '.'
-      -- Maximal munch, as upstream's PATH regex: a dot-led path-char run
-      -- containing a /-segment is ONE path token (./x, ../x, .github/x,
-      -- even .5/x) - the path reading beats the float and TokDot readings.
-      -- A dot-run with no slash falls through: .5 is a float, x.y selects.
-      | looksLikePath (lsInput st) -> lexPath st acc
-      | Just d <- safeHead rest,
-        isDigit d ->
-          lexLeadingDotFloat st acc
-    '.' -> emit1 st TokDot acc
-    ',' -> emit1 st TokComma acc
-    ';' -> emit1 st TokSemicolon acc
-    ':' -> emit1 st TokColon acc
-    '@' -> emit1 st TokAt acc
-    '?' -> emit1 st TokQuestion acc
-    '(' -> emit1 st TokLParen acc
-    ')' -> emit1 st TokRParen acc
-    '[' -> emit1 st TokLBracket acc
-    ']' -> emit1 st TokRBracket acc
-    '{' ->
-      let tok = Located (lsLine st) (lsCol st) TokLBrace
-          newSt = advanceCol 1 st {lsInput = rest, lsBraceDepth = lsBraceDepth st + 1}
-       in lexNormalMode newSt (tok : acc)
-    '}' ->
-      case lsModes st of
-        -- closing an interpolation: pop back to string/indstring mode and
-        -- restore the enclosing normal-mode context's brace count.
-        (ModeNormal : outerMode : restModes)
-          | lsBraceDepth st == 0,
-            outerMode == ModeString || outerMode == ModeIndString ->
-              let tok = Located (lsLine st) (lsCol st) TokInterpClose
-                  (restoredDepth, restoredStack) = case lsBraceStack st of
-                    (saved : outerSaved) -> (saved, outerSaved)
-                    [] -> (0, [])
-                  newSt =
-                    advanceCol
-                      1
-                      st
-                        { lsInput = rest,
-                          lsModes = outerMode : restModes,
-                          lsBraceDepth = restoredDepth,
-                          lsBraceStack = restoredStack
-                        }
-               in lexLoop newSt (tok : acc)
-        _ ->
-          let depth = lsBraceDepth st
-              newDepth = if depth > 0 then depth - 1 else 0
-              tok = Located (lsLine st) (lsCol st) TokRBrace
-              newSt = advanceCol 1 st {lsInput = rest, lsBraceDepth = newDepth}
-           in lexNormalMode newSt (tok : acc)
-    '+' | Just '+' <- safeHead rest -> emit2 st TokConcat acc
-    '+' -> emit1 st TokPlus acc
-    '*' -> emit1 st TokStar acc
-    '-' | Just '>' <- safeHead rest -> emit2 st TokImpl acc
-    '-' -> emit1 st TokMinus acc
-    '!' | Just '=' <- safeHead rest -> emit2 st TokNeq acc
-    '!' -> emit1 st TokNot acc
-    '&' | Just '&' <- safeHead rest -> emit2 st TokAnd acc
-    '|' | Just '|' <- safeHead rest -> emit2 st TokOr acc
-    '=' | Just '=' <- safeHead rest -> emit2 st TokEq acc
-    '=' -> emit1 st TokAssign acc
-    '<' | Just '=' <- safeHead rest -> emit2 st TokLte acc
-    '<'
-      | maybe False (\ch -> isAlpha ch || ch == '_') (safeHead rest) ->
-          lexSearchPath st acc
-    '<' -> emit1 st TokLt acc
-    '>' | Just '=' <- safeHead rest -> emit2 st TokGte acc
-    '>' -> emit1 st TokGt acc
-    '/' | Just '/' <- safeHead rest -> emit2 st TokUpdate acc
-    '/'
-      -- A '/' that begins a path segment (slash followed by a path char)
-      -- starts a path: /abs/path.  A bare '/' (followed by whitespace) is the
-      -- division operator: a / b.  Relative paths like a/b are caught by the
-      -- path guard further down, before the identifier/number cases.
-      | looksLikePath (lsInput st) -> lexPath st acc
-      | otherwise -> emit1 st TokSlash acc
-    '$'
-      | Just '{' <- safeHead rest ->
-          -- Increment brace depth so the closing } is TokRBrace, not
-          -- TokInterpClose.  Without this, ${name} inside a string
-          -- interpolation like "${env.${name}}" prematurely ends the
-          -- outer interpolation.
-          let tok = Located (lsLine st) (lsCol st) TokInterpOpen
-              newSt = advanceCol 2 st {lsInput = T.drop 1 rest, lsBraceDepth = lsBraceDepth st + 1}
-           in lexNormalMode newSt (tok : acc)
-    '~'
-      | Just '/' <- safeHead rest ->
-          lexPath st acc
-    -- A path-char run that contains a '/' segment is a path, not an
-    -- identifier or number: a/b and 6/2 lex as paths, matching Nix.
-    _ | looksLikePath (lsInput st) -> lexPath st acc
-    _ | isDigit c -> lexNumber st acc
-    _ | isIdentStart c -> lexIdentOrKeyword st acc
-    _ ->
-      Left
-        ParseError
-          { peFile = lsFile st,
-            peLine = lsLine st,
-            peCol = lsCol st,
-            peMessage = "unexpected character: " <> T.singleton c
-          }
+  Just (c, rest) ->
+    -- Lazy: forced only by the three path guards below.  Branches taken
+    -- when the guard says "not a path" continue with 'flooredSt' so a
+    -- freshly recorded slash-free run is remembered, not rescanned.
+    let (startsPath, advancedFloor) = looksLikePathFrom (lsNoSlashFloor st) (lsInput st)
+        flooredSt = st {lsNoSlashFloor = advancedFloor}
+     in lexNormalModeAt st flooredSt startsPath c rest acc
+
+-- | The normal-mode dispatch, after the path lookahead has been prepared.
+-- @st@ is the incoming state; @flooredSt@ carries the advanced path
+-- watermark for the continuations that bypassed a path reading.
+lexNormalModeAt :: LexState -> LexState -> Bool -> Char -> Text -> [Located] -> Either ParseError [Located]
+lexNormalModeAt st flooredSt startsPath c rest acc = case c of
+  _ | isSpace c -> lexNormalMode (skipWhitespace st) acc
+  '#' -> lexNormalMode (skipLineComment st) acc
+  '/'
+    | Just '*' <- safeHead rest ->
+        case skipBlockComment (advanceCol 2 st {lsInput = T.drop 2 (lsInput st)}) of
+          Left err -> Left err
+          Right newSt -> lexNormalMode newSt acc
+  '"' ->
+    let tok = Located (lsLine st) (lsCol st) TokStringOpen
+        newSt = advanceCol 1 st {lsInput = rest, lsModes = ModeString : lsModes st}
+     in lexLoop newSt (tok : acc)
+  '\''
+    | Just '\'' <- safeHead rest ->
+        let tok = Located (lsLine st) (lsCol st) TokIndStringOpen
+            newSt = advanceCol 2 st {lsInput = T.drop 2 (lsInput st), lsModes = ModeIndString : lsModes st}
+         in lexLoop newSt (tok : acc)
+  '.'
+    | Just '.' <- safeHead rest,
+      Just '.' <- safeHead (T.drop 1 rest) ->
+        emit3 st TokEllipsis acc
+  '.'
+    -- Maximal munch, as upstream's PATH regex: a dot-led path-char run
+    -- containing a /-segment is ONE path token (./x, ../x, .github/x,
+    -- even .5/x) - the path reading beats the float and TokDot readings.
+    -- A dot-run with no slash falls through: .5 is a float, x.y selects.
+    | startsPath -> lexPath st acc
+    | Just d <- safeHead rest,
+      isDigit d ->
+        lexLeadingDotFloat flooredSt acc
+  '.' -> emit1 flooredSt TokDot acc
+  ',' -> emit1 st TokComma acc
+  ';' -> emit1 st TokSemicolon acc
+  ':' -> emit1 st TokColon acc
+  '@' -> emit1 st TokAt acc
+  '?' -> emit1 st TokQuestion acc
+  '(' -> emit1 st TokLParen acc
+  ')' -> emit1 st TokRParen acc
+  '[' -> emit1 st TokLBracket acc
+  ']' -> emit1 st TokRBracket acc
+  '{' ->
+    let tok = Located (lsLine st) (lsCol st) TokLBrace
+        newSt = advanceCol 1 st {lsInput = rest, lsBraceDepth = lsBraceDepth st + 1}
+     in lexNormalMode newSt (tok : acc)
+  '}' ->
+    case lsModes st of
+      -- closing an interpolation: pop back to string/indstring mode and
+      -- restore the enclosing normal-mode context's brace count.
+      (ModeNormal : outerMode : restModes)
+        | lsBraceDepth st == 0,
+          outerMode == ModeString || outerMode == ModeIndString ->
+            let tok = Located (lsLine st) (lsCol st) TokInterpClose
+                (restoredDepth, restoredStack) = case lsBraceStack st of
+                  (saved : outerSaved) -> (saved, outerSaved)
+                  [] -> (0, [])
+                newSt =
+                  advanceCol
+                    1
+                    st
+                      { lsInput = rest,
+                        lsModes = outerMode : restModes,
+                        lsBraceDepth = restoredDepth,
+                        lsBraceStack = restoredStack
+                      }
+             in lexLoop newSt (tok : acc)
+      _ ->
+        let depth = lsBraceDepth st
+            newDepth = if depth > 0 then depth - 1 else 0
+            tok = Located (lsLine st) (lsCol st) TokRBrace
+            newSt = advanceCol 1 st {lsInput = rest, lsBraceDepth = newDepth}
+         in lexNormalMode newSt (tok : acc)
+  '+' | Just '+' <- safeHead rest -> emit2 st TokConcat acc
+  '+' -> emit1 st TokPlus acc
+  '*' -> emit1 st TokStar acc
+  '-' | Just '>' <- safeHead rest -> emit2 st TokImpl acc
+  '-' -> emit1 st TokMinus acc
+  '!' | Just '=' <- safeHead rest -> emit2 st TokNeq acc
+  '!' -> emit1 st TokNot acc
+  '&' | Just '&' <- safeHead rest -> emit2 st TokAnd acc
+  '|' | Just '|' <- safeHead rest -> emit2 st TokOr acc
+  '=' | Just '=' <- safeHead rest -> emit2 st TokEq acc
+  '=' -> emit1 st TokAssign acc
+  '<' | Just '=' <- safeHead rest -> emit2 st TokLte acc
+  '<'
+    | maybe False (\ch -> isAlpha ch || ch == '_') (safeHead rest) ->
+        lexSearchPath st acc
+  '<' -> emit1 st TokLt acc
+  '>' | Just '=' <- safeHead rest -> emit2 st TokGte acc
+  '>' -> emit1 st TokGt acc
+  '/' | Just '/' <- safeHead rest -> emit2 st TokUpdate acc
+  '/'
+    -- A '/' that begins a path segment (slash followed by a path char)
+    -- starts a path: /abs/path.  A bare '/' (followed by whitespace) is the
+    -- division operator: a / b.  Relative paths like a/b are caught by the
+    -- path guard further down, before the identifier/number cases.
+    | startsPath -> lexPath st acc
+    | otherwise -> emit1 flooredSt TokSlash acc
+  '$'
+    | Just '{' <- safeHead rest ->
+        -- Increment brace depth so the closing } is TokRBrace, not
+        -- TokInterpClose.  Without this, ${name} inside a string
+        -- interpolation like "${env.${name}}" prematurely ends the
+        -- outer interpolation.
+        let tok = Located (lsLine st) (lsCol st) TokInterpOpen
+            newSt = advanceCol 2 st {lsInput = T.drop 1 rest, lsBraceDepth = lsBraceDepth st + 1}
+         in lexNormalMode newSt (tok : acc)
+  '~'
+    | Just '/' <- safeHead rest ->
+        lexPath st acc
+  -- A path-char run that contains a '/' segment is a path, not an
+  -- identifier or number: a/b and 6/2 lex as paths, matching Nix.
+  _ | startsPath -> lexPath st acc
+  _ | isDigit c -> lexNumber flooredSt acc
+  _ | isIdentStart c -> lexIdentOrKeyword flooredSt acc
+  _ ->
+    Left
+      ParseError
+        { peFile = lsFile st,
+          peLine = lsLine st,
+          peCol = lsCol st,
+          peMessage = "unexpected character: " <> T.singleton c
+        }
 
 -- ---------------------------------------------------------------------------
 -- String modes
@@ -628,7 +657,8 @@ lexIdentOrKeyword :: LexState -> [Located] -> Either ParseError [Located]
 lexIdentOrKeyword st acc =
   let input = lsInput st
       (ident, after) = T.span isIdentChar input
-   in case uriSpan input of
+      (uriReading, advancedFloor) = uriSpanFrom (lsNoColonFloor st) input
+   in case uriReading of
         -- Flex maximal munch: the URI rule beats identifiers AND keywords
         -- whenever it matches more characters, so @x:y@ is the URI "x:y"
         -- (the classic reason the identity function must be written
@@ -640,7 +670,7 @@ lexIdentOrKeyword st acc =
                in lexNormalMode newSt (tok : acc)
         _ ->
           let tok = Located (lsLine st) (lsCol st) (identToToken ident)
-              newSt = advanceCol (T.length ident) st {lsInput = after}
+              newSt = advanceCol (T.length ident) st {lsInput = after, lsNoColonFloor = advancedFloor}
            in lexNormalMode newSt (tok : acc)
 
 -- | Match upstream's URI token at the start of the input:
@@ -648,16 +678,27 @@ lexIdentOrKeyword st acc =
 -- with a letter (never @_@), and one URI char after the colon suffices -
 -- scheme-only URIs like @mailto:x@ count.  Returns the URI text and the
 -- remaining input.
-uriSpan :: Text -> Maybe (Text, Text)
-uriSpan input = case T.uncons input of
-  Just (schemeStart, _)
-    | isAlpha schemeStart,
-      (scheme, afterScheme) <- T.span isSchemeChar input,
-      Just afterColon <- T.stripPrefix ":" afterScheme,
-      (body, afterUri) <- T.span isUriChar afterColon,
-      not (T.null body) ->
-        Just (scheme <> ":" <> body, afterUri)
-  _ -> Nothing
+--
+-- Threads the 'lsNoColonFloor' watermark: when the scheme-char run ends
+-- at a NON-colon, no position inside that run can start a URI (a suffix
+-- of the run spans to the same terminator), so the run's end is recorded
+-- and later positions inside it answer Nothing in O(1).  A run ending at
+-- @:@ records nothing - a shorter suffix of it may itself be a URI.
+uriSpanFrom :: Int -> Text -> (Maybe (Text, Text), Int)
+uriSpanFrom noColonFloor input
+  | lengthWord8 input > noColonFloor = (Nothing, noColonFloor)
+  | otherwise = case T.uncons input of
+      Just (schemeStart, _)
+        | isAlpha schemeStart ->
+            let (scheme, afterScheme) = T.span isSchemeChar input
+             in case T.stripPrefix ":" afterScheme of
+                  Just afterColon
+                    | (body, afterUri) <- T.span isUriChar afterColon,
+                      not (T.null body) ->
+                        (Just (scheme <> ":" <> body, afterUri), noColonFloor)
+                  Just _ -> (Nothing, noColonFloor)
+                  Nothing -> (Nothing, lengthWord8 input - lengthWord8 scheme)
+      _ -> (Nothing, noColonFloor)
 
 identToToken :: Text -> Token
 identToToken "if" = TokIf
@@ -753,12 +794,26 @@ isPathChar c = isAlphaNum c || c `elem` ("/.~_-+" :: [Char])
 -- as a path rather than an identifier, number, or division operator -
 -- matching Nix, where @a/b@ and @/abs/path@ are paths, @a / b@ (slash
 -- surrounded by whitespace) is division, and @a // b@ is the update operator.
-looksLikePath :: Text -> Bool
-looksLikePath input =
-  case T.break (== '/') (T.takeWhile isPathChar input) of
-    (_, slashAndRest) -> case T.uncons (T.drop 1 slashAndRest) of
-      Just (afterSlash, _) -> isPathChar afterSlash && afterSlash /= '/'
-      Nothing -> False
+--
+-- Threads the 'lsNoSlashFloor' watermark: a position inside an
+-- already-scanned SLASH-FREE run answers False in O(1), and a freshly
+-- scanned slash-free run records its end (no position within it can start
+-- a path, since the run's characters and its terminator are the same
+-- bytes every later check would rescan).  A run that CONTAINS a slash
+-- records nothing: a later position inside it can legitimately answer
+-- differently (@a//b.c/d@ is update-then-path).  'lengthWord8' is the
+-- O(1) position measure; byte counts, so it is monotone under suffixing.
+looksLikePathFrom :: Int -> Text -> (Bool, Int)
+looksLikePathFrom noSlashFloor input
+  | lengthWord8 input > noSlashFloor = (False, noSlashFloor)
+  | otherwise =
+      let run = T.takeWhile isPathChar input
+          (_, slashAndRest) = T.break (== '/') run
+       in if T.null slashAndRest
+            then (False, lengthWord8 input - lengthWord8 run)
+            else case T.uncons (T.drop 1 slashAndRest) of
+              Just (afterSlash, _) -> (isPathChar afterSlash && afterSlash /= '/', noSlashFloor)
+              Nothing -> (False, noSlashFloor)
 
 isSearchPathChar :: Char -> Bool
 isSearchPathChar c = isAlphaNum c || c `elem` ("/.~_-+" :: [Char])

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -5797,6 +5797,54 @@ testCThunk = do
 -- Bytecode compilation tests
 -- ---------------------------------------------------------------------------
 
+-- | Bytecode short_arg spill: op-level payload counts at or above the
+-- 0xFFFF sentinel move to the first data word, so literals are no longer
+-- capped at 65535 elements.  The two exact-boundary list cases pin the
+-- inline maximum (65534) and the first spilled count (65535); the rest
+-- drive each counted-op kind (list, attrs, let, string parts, attr path)
+-- well past the old ceiling.
+testBytecodeCountSpill :: IO [Bool]
+testBytecodeCountSpill = do
+  putStrLn "bytecode/count-spill"
+  let listOf n = "builtins.length [ " <> T.unwords (replicate n "1") <> " ]"
+      bigAttrsBody = T.concat [T.pack ("a" <> show i <> " = " <> show i <> "; ") | i <- [0 :: Int .. 69999]]
+  sequence
+    [ runTest "list literal at the inline count maximum (65534)" $
+        assertEval "spill-list-inline-max" (listOf 65534) (VInt 65534),
+      runTest "list literal at the first spilled count (65535)" $
+        assertEval "spill-list-first-spill" (listOf 65535) (VInt 65535),
+      runTest "spilled list preserves element order" $
+        assertEval
+          "spill-list-order"
+          ("builtins.elemAt [ " <> T.unwords (map (T.pack . show) [0 :: Int .. 69999]) <> " ] 69999")
+          (VInt 69999),
+      runTest "spilled attrset literal binds every attribute" $
+        assertEval
+          "spill-attrs-count"
+          ("builtins.length (builtins.attrNames { " <> bigAttrsBody <> "})")
+          (VInt 70000),
+      runTest "spilled attrset lookup reads the right value" $
+        assertEval
+          "spill-attrs-lookup"
+          ("{ " <> bigAttrsBody <> "}.a69999")
+          (VInt 69999),
+      runTest "spilled let binds every name" $
+        assertEval
+          "spill-let"
+          ("let " <> T.concat [T.pack ("v" <> show i <> " = " <> show i <> "; ") | i <- [0 :: Int .. 69999]] <> "in v69999")
+          (VInt 69999),
+      runTest "spilled interpolated string keeps every part" $
+        assertEval
+          "spill-string-parts"
+          ("builtins.stringLength \"" <> T.concat (replicate 70000 "${\"x\"}") <> "\"")
+          (VInt 70000),
+      runTest "spilled attr path walks (set ? long.path)" $
+        assertEval
+          "spill-attrpath"
+          ("{ } ? " <> T.intercalate "." (map (\i -> T.pack ("p" <> show i)) [0 :: Int .. 69999]))
+          (VBool False)
+    ]
+
 testBytecodeCompile :: IO [Bool]
 testBytecodeCompile = do
   putStrLn "bytecode"
@@ -6632,7 +6680,8 @@ main = bracket_ arenaInit arenaDestroy $ do
           testSymbol,
           testCAttrSet,
           testCThunk,
-          testBytecodeCompile
+          testBytecodeCompile,
+          testBytecodeCountSpill
         ]
   let total = length results
       passed = length (filter id results)


### PR DESCRIPTION
`nn_op_t.short_arg` is a `uint16_t`, so every count that travels through it - interpolated-string parts, attrset literal bindings, list literal elements, attr path segments, let bindings - capped at 65535. The compiler failed loudly at the ceiling, but machine-generated .nix files (lock files, package lists, hash tables) can plausibly exceed it, and it stood between the evaluator and the full-nixpkgs milestone (#29) as a silent-blocker class.

## The spill layout

Of the two layouts sketched on #30, this takes the spill: `nn_op_t` stays exactly 16 bytes (four ops per cache line). A count below 0xFFFF travels inline in `short_arg` as before; a larger count is written as the FIRST word of the op's data region, with the sentinel 0xFFFF inline telling the decoder to read it from there and start the payload one word later. Only an oversized literal pays the extra data word. The convention lives in one shared helper per side - `emitCounted` (compile) and `cbcCountedPayload` (decode) - plus a doc note on the struct field; there is no C code or layout change. `countArg` stays as the loud backstop at the new ceiling (a spilled count must fit its 32-bit data word).

Boundary tests pin the inline maximum (65534) and the first spilled count (65535), then drive every counted-op kind past the old ceiling: 70000-element list, attrset, let, interpolated string, and `?` attr path.

## The lexer quadratics the tests exposed (first commit)

The 70000-segment attr path took SIX MINUTES to lex - a pre-existing O(n^2) pair, reachable before this PR at 65534 segments. Both speculative lookaheads rescanned the maximal character run at every token: `looksLikePath` hunting a `/` through path chars, and `uriSpan` hunting a `:` through scheme chars (dots and alnums belong to both alphabets, so a long dotted run is the worst case for each). Each lookahead now records an O(1) watermark when its run ends without the distinguished character - no position inside such a run can start a path/URI, since a suffix spans to the same terminator - and positions under the watermark answer in O(1). Runs that do contain the character record nothing (`a//b.c/d` is update-then-path, and a later position inside it legitimately answers differently). 376s to instant; the count-spill test group doubles as the regression canary.

## Verification

957/957 tests (8 new boundary cases), `-Werror` build clean, ormolu/hlint clean. Benchmarks vs main: nixpkgs attrNames and hello.drvPath at parity within run noise, +1.2% allocations (the per-op count read), identical max residency, and `hello.drvPath` remains byte-identical.

Fixes #30.