### PR TITLE
Audit class A: uint32 count marshalling, live C bounds, checked allocation and emit results

### DIFF
--- a/cbits/nn_bytecode.h
+++ b/cbits/nn_bytecode.h
@@ -128,11 +128,15 @@ void nn_bytecode_destroy(void);
 
 /* --- Emit --- */
 
-/* Append one instruction.  Returns the instruction index. */
+/* Append one instruction.  Returns the instruction index, or
+ * UINT32_MAX when the array cannot grow (allocation failure or the
+ * uint32 index ceiling) - the caller must check before using the
+ * result as an index. */
 uint32_t nn_bc_emit(uint8_t opcode, uint8_t flags, uint16_t short_arg,
                     uint32_t arg1, uint32_t arg2, uint32_t arg3);
 
-/* Append one uint32 to the data buffer.  Returns the data offset. */
+/* Append one uint32 to the data buffer.  Returns the data offset, or
+ * UINT32_MAX on failure (same contract as nn_bc_emit). */
 uint32_t nn_bc_emit_data(uint32_t value);
 
 /* --- Read instructions --- */

--- a/cbits/nn_ctxstr.c
+++ b/cbits/nn_ctxstr.c
@@ -43,10 +43,16 @@ track(nn_ctxstr_t *s)
 /* --- Lifecycle --- */
 
 nn_ctxstr_t *
-nn_ctxstr_new(uint32_t text, uint16_t ctx_count)
+nn_ctxstr_new(uint32_t text, uint32_t ctx_count)
 {
-    size_t size = sizeof(nn_ctxstr_t) + (size_t)ctx_count * sizeof(nn_sce_t);
-    nn_ctxstr_t *s = (nn_ctxstr_t *)malloc(size);
+    /* The count is input-reachable (it scales with the evaluated
+     * expression); computing the size in uint64_t and capping it at the
+     * UINT32_MAX byte limit used across the C layer keeps the malloc
+     * argument from wrapping size_t on any platform. */
+    uint64_t bytes64 = sizeof(nn_ctxstr_t)
+                     + (uint64_t)ctx_count * sizeof(nn_sce_t);
+    if (bytes64 > UINT32_MAX) return NULL;
+    nn_ctxstr_t *s = (nn_ctxstr_t *)malloc((size_t)bytes64);
     if (!s) return NULL;
     s->text = text;
     s->ctx_count = ctx_count;
@@ -70,11 +76,16 @@ nn_ctxstr_free_all(void)
 
 /* --- Element setters --- */
 
+/* Element bounds stay live under NDEBUG: the fill index derives from
+ * input-sized data crossing the FFI, so a violated bound must drop the
+ * write, not run past the sized array. */
+
 void
-nn_ctxstr_set_plain(nn_ctxstr_t *s, uint16_t idx,
+nn_ctxstr_set_plain(nn_ctxstr_t *s, uint32_t idx,
                     uint32_t sp_hash, uint32_t sp_name)
 {
-    NN_ASSERT(idx < s->ctx_count, "nn_ctxstr_set_plain: idx out of bounds");
+    NN_ASSERT(s != NULL && idx < s->ctx_count, "nn_ctxstr_set_plain: idx out of bounds");
+    if (s == NULL || idx >= s->ctx_count) return;
     s->ctx[idx].tag = NN_SCE_PLAIN;
     s->ctx[idx].sp_hash = sp_hash;
     s->ctx[idx].sp_name = sp_name;
@@ -82,11 +93,12 @@ nn_ctxstr_set_plain(nn_ctxstr_t *s, uint16_t idx,
 }
 
 void
-nn_ctxstr_set_drv_output(nn_ctxstr_t *s, uint16_t idx,
+nn_ctxstr_set_drv_output(nn_ctxstr_t *s, uint32_t idx,
                          uint32_t sp_hash, uint32_t sp_name,
                          uint32_t output)
 {
-    NN_ASSERT(idx < s->ctx_count, "nn_ctxstr_set_drv_output: idx out of bounds");
+    NN_ASSERT(s != NULL && idx < s->ctx_count, "nn_ctxstr_set_drv_output: idx out of bounds");
+    if (s == NULL || idx >= s->ctx_count) return;
     s->ctx[idx].tag = NN_SCE_DRV_OUTPUT;
     s->ctx[idx].sp_hash = sp_hash;
     s->ctx[idx].sp_name = sp_name;
@@ -94,10 +106,11 @@ nn_ctxstr_set_drv_output(nn_ctxstr_t *s, uint16_t idx,
 }
 
 void
-nn_ctxstr_set_all_outputs(nn_ctxstr_t *s, uint16_t idx,
+nn_ctxstr_set_all_outputs(nn_ctxstr_t *s, uint32_t idx,
                           uint32_t sp_hash, uint32_t sp_name)
 {
-    NN_ASSERT(idx < s->ctx_count, "nn_ctxstr_set_all_outputs: idx out of bounds");
+    NN_ASSERT(s != NULL && idx < s->ctx_count, "nn_ctxstr_set_all_outputs: idx out of bounds");
+    if (s == NULL || idx >= s->ctx_count) return;
     s->ctx[idx].tag = NN_SCE_ALL_OUTPUTS;
     s->ctx[idx].sp_hash = sp_hash;
     s->ctx[idx].sp_name = sp_name;
@@ -112,36 +125,43 @@ nn_ctxstr_text(const nn_ctxstr_t *s)
     return s->text;
 }
 
-uint16_t
+uint32_t
 nn_ctxstr_ctx_count(const nn_ctxstr_t *s)
 {
     return s->ctx_count;
 }
 
+/* Element reads keep their bound live under NDEBUG (see setters);
+ * a violated bound returns 0 rather than reading out of bounds. */
+
 uint8_t
-nn_ctxstr_elem_tag(const nn_ctxstr_t *s, uint16_t idx)
+nn_ctxstr_elem_tag(const nn_ctxstr_t *s, uint32_t idx)
 {
-    NN_ASSERT(idx < s->ctx_count, "nn_ctxstr_elem_tag: idx out of bounds");
+    NN_ASSERT(s != NULL && idx < s->ctx_count, "nn_ctxstr_elem_tag: idx out of bounds");
+    if (s == NULL || idx >= s->ctx_count) return 0;
     return s->ctx[idx].tag;
 }
 
 uint32_t
-nn_ctxstr_elem_hash(const nn_ctxstr_t *s, uint16_t idx)
+nn_ctxstr_elem_hash(const nn_ctxstr_t *s, uint32_t idx)
 {
-    NN_ASSERT(idx < s->ctx_count, "nn_ctxstr_elem_hash: idx out of bounds");
+    NN_ASSERT(s != NULL && idx < s->ctx_count, "nn_ctxstr_elem_hash: idx out of bounds");
+    if (s == NULL || idx >= s->ctx_count) return 0;
     return s->ctx[idx].sp_hash;
 }
 
 uint32_t
-nn_ctxstr_elem_name(const nn_ctxstr_t *s, uint16_t idx)
+nn_ctxstr_elem_name(const nn_ctxstr_t *s, uint32_t idx)
 {
-    NN_ASSERT(idx < s->ctx_count, "nn_ctxstr_elem_name: idx out of bounds");
+    NN_ASSERT(s != NULL && idx < s->ctx_count, "nn_ctxstr_elem_name: idx out of bounds");
+    if (s == NULL || idx >= s->ctx_count) return 0;
     return s->ctx[idx].sp_name;
 }
 
 uint32_t
-nn_ctxstr_elem_output(const nn_ctxstr_t *s, uint16_t idx)
+nn_ctxstr_elem_output(const nn_ctxstr_t *s, uint32_t idx)
 {
-    NN_ASSERT(idx < s->ctx_count, "nn_ctxstr_elem_output: idx out of bounds");
+    NN_ASSERT(s != NULL && idx < s->ctx_count, "nn_ctxstr_elem_output: idx out of bounds");
+    if (s == NULL || idx >= s->ctx_count) return 0;
     return s->ctx[idx].output;
 }

--- a/cbits/nn_ctxstr.h
+++ b/cbits/nn_ctxstr.h
@@ -44,14 +44,16 @@ typedef struct nn_sce {
 } nn_sce_t;
 
 /* A string with context.  text is an interned nn_symbol_t for the
- * string content.  ctx_count is the number of context elements.
+ * string content.  ctx_count is the number of context elements; it is
+ * a full uint32_t because context sets scale with the evaluated
+ * expression (a narrower count would wrap and undersize the array).
  * ctx[] is a C99 flexible array of context elements, sorted by
  * (tag, sp_hash, sp_name, output) for deterministic comparison.
  *
  * Single contiguous allocation: header + elements. */
 typedef struct nn_ctxstr {
     uint32_t    text;
-    uint16_t    ctx_count;
+    uint32_t    ctx_count;
     nn_sce_t    ctx[];
 } nn_ctxstr_t;
 
@@ -59,8 +61,10 @@ typedef struct nn_ctxstr {
 
 /* Allocate a new nn_ctxstr_t with space for ctx_count elements.
  * Elements are uninitialized - caller must fill via nn_ctxstr_set_*.
- * Tracked globally for bulk cleanup. */
-nn_ctxstr_t *nn_ctxstr_new(uint32_t text, uint16_t ctx_count);
+ * Tracked globally for bulk cleanup.  Returns NULL on allocation
+ * failure or if the element array size would overflow - the caller
+ * must check. */
+nn_ctxstr_t *nn_ctxstr_new(uint32_t text, uint32_t ctx_count);
 
 /* Free all tracked nn_ctxstr_t allocations.  Called during arena
  * teardown, after thunk iteration but before env/symbol cleanup. */
@@ -68,24 +72,30 @@ void nn_ctxstr_free_all(void);
 
 /* --- Element setters --- */
 
-void nn_ctxstr_set_plain(nn_ctxstr_t *s, uint16_t idx,
+/* idx must be < ctx_count.  A NULL struct or out-of-range idx is
+ * dropped (asserts in debug builds) rather than writing out of
+ * bounds - the bound stays live under NDEBUG. */
+
+void nn_ctxstr_set_plain(nn_ctxstr_t *s, uint32_t idx,
                          uint32_t sp_hash, uint32_t sp_name);
 
-void nn_ctxstr_set_drv_output(nn_ctxstr_t *s, uint16_t idx,
+void nn_ctxstr_set_drv_output(nn_ctxstr_t *s, uint32_t idx,
                               uint32_t sp_hash, uint32_t sp_name,
                               uint32_t output);
 
-void nn_ctxstr_set_all_outputs(nn_ctxstr_t *s, uint16_t idx,
+void nn_ctxstr_set_all_outputs(nn_ctxstr_t *s, uint32_t idx,
                                uint32_t sp_hash, uint32_t sp_name);
 
 /* --- Accessors --- */
 
 uint32_t nn_ctxstr_text(const nn_ctxstr_t *s);
-uint16_t nn_ctxstr_ctx_count(const nn_ctxstr_t *s);
+uint32_t nn_ctxstr_ctx_count(const nn_ctxstr_t *s);
 
-uint8_t  nn_ctxstr_elem_tag(const nn_ctxstr_t *s, uint16_t idx);
-uint32_t nn_ctxstr_elem_hash(const nn_ctxstr_t *s, uint16_t idx);
-uint32_t nn_ctxstr_elem_name(const nn_ctxstr_t *s, uint16_t idx);
-uint32_t nn_ctxstr_elem_output(const nn_ctxstr_t *s, uint16_t idx);
+/* Element reads with idx >= ctx_count return 0 (asserts in debug
+ * builds) rather than reading out of bounds. */
+uint8_t  nn_ctxstr_elem_tag(const nn_ctxstr_t *s, uint32_t idx);
+uint32_t nn_ctxstr_elem_hash(const nn_ctxstr_t *s, uint32_t idx);
+uint32_t nn_ctxstr_elem_name(const nn_ctxstr_t *s, uint32_t idx);
+uint32_t nn_ctxstr_elem_output(const nn_ctxstr_t *s, uint32_t idx);
 
 #endif /* NN_CTXSTR_H */

--- a/cbits/nn_env.c
+++ b/cbits/nn_env.c
@@ -147,7 +147,7 @@ nn_env_empty(void)
 nn_env_t *
 nn_env_new(void **slots, uint32_t slot_count,
            void *lazy_scope, nn_env_t *parent,
-           void **with_scopes, uint16_t with_count)
+           void **with_scopes, uint32_t with_count)
 {
     nn_env_t *env = (nn_env_t *)nn_env_alloc_raw((uint32_t)sizeof(nn_env_t));
     if (!env) return NULL;
@@ -178,10 +178,12 @@ nn_env_from_slots(void **slots, uint32_t slot_count,
 nn_env_t *
 nn_env_push_with(nn_env_t *base, void *scope)
 {
-    if (base->with_count >= UINT16_MAX) return NULL;
-    uint16_t new_count = base->with_count + 1;
-    void **new_withs = (void **)nn_env_alloc_raw(
-        (uint32_t)new_count * (uint32_t)sizeof(void *));
+    /* The increment must not wrap.  Counts anywhere near this bound
+     * cannot allocate anyway (the array alloc caps at UINT32_MAX
+     * bytes), so this is the formal guard, not a reachable limit. */
+    if (base->with_count == UINT32_MAX) return NULL;
+    uint32_t new_count = base->with_count + 1;
+    void **new_withs = nn_env_alloc_with_scopes(new_count);
     if (!new_withs) return NULL;
 
     /* New scope at index 0 (innermost) */
@@ -246,7 +248,7 @@ nn_env_with_scopes(const nn_env_t *env)
     return env->with_scopes;
 }
 
-uint16_t
+uint32_t
 nn_env_with_count(const nn_env_t *env)
 {
     return env->with_count;
@@ -291,7 +293,7 @@ nn_env_root_scope(const nn_env_t *env)
 /* --- With-scopes array allocation --- */
 
 void **
-nn_env_alloc_with_scopes(uint16_t count)
+nn_env_alloc_with_scopes(uint32_t count)
 {
     if (count == 0) return NULL;
     uint64_t bytes64 = (uint64_t)count * sizeof(void *);

--- a/cbits/nn_env.h
+++ b/cbits/nn_env.h
@@ -29,7 +29,7 @@ typedef struct nn_env {
     void          *lazy_scope;   /* nn_attrset_t* or NULL */
     struct nn_env *parent;       /* nn_env_t* or NULL */
     void         **with_scopes;  /* array of nn_attrset_t* (or NULL) */
-    uint16_t       with_count;   /* 2 bytes + 6 pad to struct alignment */
+    uint32_t       with_count;   /* 4 bytes + 4 pad to struct alignment */
 } nn_env_t;
 
 /* --- Lifecycle --- */
@@ -57,7 +57,7 @@ nn_env_t *nn_env_empty(void);
 /* Full constructor: set all fields explicitly. */
 nn_env_t *nn_env_new(void **slots, uint32_t slot_count,
                      void *lazy_scope, nn_env_t *parent,
-                     void **with_scopes, uint16_t with_count);
+                     void **with_scopes, uint32_t with_count);
 
 /* Child env with positional slots, inheriting parent's with-scopes.
  * lazy_scope = NULL. */
@@ -78,7 +78,7 @@ uint32_t     nn_env_slot_count(const nn_env_t *env);
 void        *nn_env_lazy_scope(const nn_env_t *env);
 nn_env_t    *nn_env_parent(const nn_env_t *env);
 void       **nn_env_with_scopes(const nn_env_t *env);
-uint16_t     nn_env_with_count(const nn_env_t *env);
+uint32_t     nn_env_with_count(const nn_env_t *env);
 
 /* --- Lookup --- */
 
@@ -95,8 +95,10 @@ void *nn_env_root_scope(const nn_env_t *env);
 /* --- With-scopes array allocation --- */
 
 /* Allocate an arena array of `count` void* pointers for with-scopes.
- * All entries initialized to NULL.  Returns NULL if count is 0. */
-void **nn_env_alloc_with_scopes(uint16_t count);
+ * All entries initialized to NULL.  Returns NULL if count is 0, if the
+ * array size would exceed the allocator's uint32 byte limit, or on
+ * OOM - the caller must check. */
+void **nn_env_alloc_with_scopes(uint32_t count);
 
 /* --- Diagnostics --- */
 

--- a/cbits/nn_lambda.c
+++ b/cbits/nn_lambda.c
@@ -40,8 +40,15 @@ static void nn_lambda_track(nn_lambda_t *lam)
 nn_lambda_t *
 nn_lambda_new(struct nn_env *env, uint32_t body_bc_idx,
               uint8_t formals_type, uint32_t name_sym,
-              uint8_t allow_extra, uint16_t formal_count)
+              uint8_t allow_extra, uint32_t formal_count)
 {
+    /* The count is input-reachable (it scales with the source formal
+     * list); computing the entries size in uint64_t and capping it at
+     * the UINT32_MAX byte limit used across the C layer keeps the
+     * malloc argument from wrapping size_t on any platform. */
+    uint64_t entry_bytes64 = (uint64_t)formal_count * sizeof(nn_formal_entry_t);
+    if (entry_bytes64 > UINT32_MAX) return NULL;
+
     nn_lambda_t *lam = (nn_lambda_t *)malloc(sizeof(nn_lambda_t));
     if (!lam) return NULL;
 
@@ -53,14 +60,12 @@ nn_lambda_new(struct nn_env *env, uint32_t body_bc_idx,
     lam->formal_count = formal_count;
 
     if (formal_count > 0) {
-        lam->entries = (nn_formal_entry_t *)malloc(
-            (size_t)formal_count * sizeof(nn_formal_entry_t));
+        lam->entries = (nn_formal_entry_t *)malloc((size_t)entry_bytes64);
         if (!lam->entries) {
             free(lam);
             return NULL;
         }
-        memset(lam->entries, 0,
-               (size_t)formal_count * sizeof(nn_formal_entry_t));
+        memset(lam->entries, 0, (size_t)entry_bytes64);
     } else {
         lam->entries = NULL;
     }
@@ -70,11 +75,16 @@ nn_lambda_new(struct nn_env *env, uint32_t body_bc_idx,
 }
 
 void
-nn_lambda_set_entry(nn_lambda_t *lam, uint16_t idx,
+nn_lambda_set_entry(nn_lambda_t *lam, uint32_t idx,
                     uint32_t name_sym, uint32_t has_default,
                     uint32_t default_bc_idx)
 {
-    NN_ASSERT(idx < lam->formal_count, "nn_lambda_set_entry: idx out of bounds");
+    /* Bound stays live under NDEBUG: the fill index derives from
+     * input-sized data crossing the FFI, so a violated bound must drop
+     * the write, not run past the sized array. */
+    NN_ASSERT(lam != NULL && lam->entries != NULL && idx < lam->formal_count,
+              "nn_lambda_set_entry: idx out of bounds");
+    if (lam == NULL || lam->entries == NULL || idx >= lam->formal_count) return;
     lam->entries[idx].name_sym       = name_sym;
     lam->entries[idx].has_default    = has_default;
     lam->entries[idx].default_bc_idx = default_bc_idx;
@@ -126,32 +136,38 @@ nn_lambda_allow_extra(const nn_lambda_t *lam)
     return lam->allow_extra;
 }
 
-uint16_t
+uint32_t
 nn_lambda_formal_count(const nn_lambda_t *lam)
 {
     return lam->formal_count;
 }
 
+/* Entry reads keep their bound live under NDEBUG (see set_entry);
+ * a violated bound returns 0 rather than reading out of bounds. */
+
 uint32_t
-nn_lambda_entry_name(const nn_lambda_t *lam, uint16_t idx)
+nn_lambda_entry_name(const nn_lambda_t *lam, uint32_t idx)
 {
-    NN_ASSERT(lam->entries != NULL && idx < lam->formal_count,
+    NN_ASSERT(lam != NULL && lam->entries != NULL && idx < lam->formal_count,
               "nn_lambda_entry_name: idx out of bounds or no formals");
+    if (lam == NULL || lam->entries == NULL || idx >= lam->formal_count) return 0;
     return lam->entries[idx].name_sym;
 }
 
 uint32_t
-nn_lambda_entry_has_default(const nn_lambda_t *lam, uint16_t idx)
+nn_lambda_entry_has_default(const nn_lambda_t *lam, uint32_t idx)
 {
-    NN_ASSERT(lam->entries != NULL && idx < lam->formal_count,
+    NN_ASSERT(lam != NULL && lam->entries != NULL && idx < lam->formal_count,
               "nn_lambda_entry_has_default: idx out of bounds or no formals");
+    if (lam == NULL || lam->entries == NULL || idx >= lam->formal_count) return 0;
     return lam->entries[idx].has_default;
 }
 
 uint32_t
-nn_lambda_entry_default(const nn_lambda_t *lam, uint16_t idx)
+nn_lambda_entry_default(const nn_lambda_t *lam, uint32_t idx)
 {
-    NN_ASSERT(lam->entries != NULL && idx < lam->formal_count,
+    NN_ASSERT(lam != NULL && lam->entries != NULL && idx < lam->formal_count,
               "nn_lambda_entry_default: idx out of bounds or no formals");
+    if (lam == NULL || lam->entries == NULL || idx >= lam->formal_count) return 0;
     return lam->entries[idx].default_bc_idx;
 }

--- a/cbits/nn_lambda.h
+++ b/cbits/nn_lambda.h
@@ -43,14 +43,16 @@ typedef struct nn_formal_entry {
 } nn_formal_entry_t;
 
 /* Lambda closure: env + body + formals specification.
- * Packed for minimal size (pointers first, then uint32s, then small fields).
- * 28 bytes on 64-bit (no padding). */
+ * Packed for minimal size: pointers first, then uint32s, then small
+ * fields - no internal padding.  formal_count is a full uint32_t
+ * because the formal list scales with the source expression (a
+ * narrower count would wrap and undersize the entries array). */
 typedef struct nn_lambda {
     struct nn_env         *env;          /* captured closure environment */
     nn_formal_entry_t     *entries;      /* formal entries (malloc'd, or NULL) */
     uint32_t               body_bc_idx;  /* bytecode index of lambda body */
     uint32_t               name_sym;     /* symbol for Name/NamedSet binding */
-    uint16_t               formal_count; /* number of formal entries */
+    uint32_t               formal_count; /* number of formal entries */
     uint8_t                formals_type; /* NN_FORMALS_NAME/SET/NAMED_SET */
     uint8_t                allow_extra;  /* 1 if ellipsis (...) present */
 } nn_lambda_t;
@@ -60,14 +62,17 @@ typedef struct nn_lambda {
 /* Allocate a new lambda closure.  The entries array is allocated
  * internally (formal_count entries).  Fill entries via
  * nn_lambda_set_entry() after construction.
- * Returns NULL on allocation failure. */
+ * Returns NULL on allocation failure or if the entries array size
+ * would overflow - the caller must check. */
 nn_lambda_t *nn_lambda_new(struct nn_env *env, uint32_t body_bc_idx,
                            uint8_t formals_type, uint32_t name_sym,
-                           uint8_t allow_extra, uint16_t formal_count);
+                           uint8_t allow_extra, uint32_t formal_count);
 
 /* Set a formal entry at the given index (for construction).
- * Index must be < formal_count. */
-void nn_lambda_set_entry(nn_lambda_t *lam, uint16_t idx,
+ * idx must be < formal_count.  A NULL struct or out-of-range idx is
+ * dropped (asserts in debug builds) rather than writing out of
+ * bounds - the bound stays live under NDEBUG. */
+void nn_lambda_set_entry(nn_lambda_t *lam, uint32_t idx,
                          uint32_t name_sym, uint32_t has_default,
                          uint32_t default_bc_idx);
 
@@ -83,11 +88,13 @@ uint32_t       nn_lambda_body(const nn_lambda_t *lam);
 uint8_t        nn_lambda_formals_type(const nn_lambda_t *lam);
 uint32_t       nn_lambda_name_sym(const nn_lambda_t *lam);
 uint8_t        nn_lambda_allow_extra(const nn_lambda_t *lam);
-uint16_t       nn_lambda_formal_count(const nn_lambda_t *lam);
+uint32_t       nn_lambda_formal_count(const nn_lambda_t *lam);
 
-/* Read formal entry fields by index (must be < formal_count). */
-uint32_t nn_lambda_entry_name(const nn_lambda_t *lam, uint16_t idx);
-uint32_t nn_lambda_entry_has_default(const nn_lambda_t *lam, uint16_t idx);
-uint32_t nn_lambda_entry_default(const nn_lambda_t *lam, uint16_t idx);
+/* Read formal entry fields by index (must be < formal_count).
+ * Out-of-range reads return 0 (asserts in debug builds) rather than
+ * reading out of bounds. */
+uint32_t nn_lambda_entry_name(const nn_lambda_t *lam, uint32_t idx);
+uint32_t nn_lambda_entry_has_default(const nn_lambda_t *lam, uint32_t idx);
+uint32_t nn_lambda_entry_default(const nn_lambda_t *lam, uint32_t idx);
 
 #endif /* NN_LAMBDA_H */

--- a/src/Nix/Eval.hs
+++ b/src/Nix/Eval.hs
@@ -130,7 +130,7 @@ import Nix.Eval.Types
     buildCSlots,
     bytesToTextLossy,
     cheapThunkBc,
-    checkedEnvPtr,
+    checkedCPtr,
     clistFromThunks,
     clistLen,
     clistThunks,
@@ -953,7 +953,7 @@ pushLazyWithScope (Thunk thunkPtr) =
 {-# NOINLINE pushWithScopeRaw #-}
 pushWithScopeRaw :: Ptr () -> Env -> Env
 pushWithScopeRaw ptr (Env envPtr) =
-  Env (checkedEnvPtr "pushWithScopeRaw" (unsafePerformIO (cenvPushWith envPtr ptr)))
+  Env (checkedCPtr "pushWithScopeRaw" (unsafePerformIO (cenvPushWith envPtr ptr)))
 
 -- ---------------------------------------------------------------------------
 -- Formals matching + env helpers (used by evalBcApp, applyValue, etc.)

--- a/src/Nix/Eval/CBytecode.hs
+++ b/src/Nix/Eval/CBytecode.hs
@@ -176,11 +176,28 @@ cbcDestroy = c_nn_bytecode_destroy
 
 -- | Append one instruction.  Returns the instruction index.
 cbcEmit :: Word8 -> Word8 -> Word16 -> Word32 -> Word32 -> Word32 -> IO Word32
-cbcEmit = c_nn_bc_emit
+cbcEmit opcode flags shortArg arg1 arg2 arg3 =
+  checkedEmit "nn_bc_emit" =<< c_nn_bc_emit opcode flags shortArg arg1 arg2 arg3
 
 -- | Append one uint32 to the data buffer.  Returns the data offset.
 cbcEmitData :: Word32 -> IO Word32
-cbcEmitData = c_nn_bc_emit_data
+cbcEmitData value = checkedEmit "nn_bc_emit_data" =<< c_nn_bc_emit_data value
+
+-- | @UINT32_MAX@ from a C emit function signals a failed append (realloc
+-- exhaustion or the uint32 index ceiling), not a valid index.  Must stay
+-- in lockstep with the emit docs in @cbits\/nn_bytecode.h@.
+emitFailedSentinel :: Word32
+emitFailedSentinel = 0xFFFFFFFF
+
+-- | Reject the failure sentinel before it can flow onward as an index:
+-- the bytecode arrays are global C state, so a failed append leaves
+-- nothing to recover, and the read-side bounds on a sentinel index do
+-- not survive a release build.
+checkedEmit :: String -> Word32 -> IO Word32
+checkedEmit site idx
+  | idx == emitFailedSentinel =
+      ioError (userError (site <> ": bytecode append failed (allocation failure or index ceiling)"))
+  | otherwise = pure idx
 
 -- ---------------------------------------------------------------------------
 -- Read instructions

--- a/src/Nix/Eval/CCtxStr.hs
+++ b/src/Nix/Eval/CCtxStr.hs
@@ -32,7 +32,7 @@ module Nix.Eval.CCtxStr
   )
 where
 
-import Data.Word (Word16, Word32, Word8)
+import Data.Word (Word32, Word8)
 import Foreign.Ptr (Ptr)
 
 -- | Phantom type for C-side @nn_ctxstr_t@.
@@ -46,37 +46,37 @@ type CCtxStrPtr = Ptr NnCtxStr
 -- ---------------------------------------------------------------------------
 
 foreign import ccall unsafe "nn_ctxstr_new"
-  c_nn_ctxstr_new :: Word32 -> Word16 -> IO CCtxStrPtr
+  c_nn_ctxstr_new :: Word32 -> Word32 -> IO CCtxStrPtr
 
 foreign import ccall unsafe "nn_ctxstr_free_all"
   c_nn_ctxstr_free_all :: IO ()
 
 foreign import ccall unsafe "nn_ctxstr_set_plain"
-  c_nn_ctxstr_set_plain :: CCtxStrPtr -> Word16 -> Word32 -> Word32 -> IO ()
+  c_nn_ctxstr_set_plain :: CCtxStrPtr -> Word32 -> Word32 -> Word32 -> IO ()
 
 foreign import ccall unsafe "nn_ctxstr_set_drv_output"
-  c_nn_ctxstr_set_drv_output :: CCtxStrPtr -> Word16 -> Word32 -> Word32 -> Word32 -> IO ()
+  c_nn_ctxstr_set_drv_output :: CCtxStrPtr -> Word32 -> Word32 -> Word32 -> Word32 -> IO ()
 
 foreign import ccall unsafe "nn_ctxstr_set_all_outputs"
-  c_nn_ctxstr_set_all_outputs :: CCtxStrPtr -> Word16 -> Word32 -> Word32 -> IO ()
+  c_nn_ctxstr_set_all_outputs :: CCtxStrPtr -> Word32 -> Word32 -> Word32 -> IO ()
 
 foreign import ccall unsafe "nn_ctxstr_text"
   c_nn_ctxstr_text :: CCtxStrPtr -> IO Word32
 
 foreign import ccall unsafe "nn_ctxstr_ctx_count"
-  c_nn_ctxstr_ctx_count :: CCtxStrPtr -> IO Word16
+  c_nn_ctxstr_ctx_count :: CCtxStrPtr -> IO Word32
 
 foreign import ccall unsafe "nn_ctxstr_elem_tag"
-  c_nn_ctxstr_elem_tag :: CCtxStrPtr -> Word16 -> IO Word8
+  c_nn_ctxstr_elem_tag :: CCtxStrPtr -> Word32 -> IO Word8
 
 foreign import ccall unsafe "nn_ctxstr_elem_hash"
-  c_nn_ctxstr_elem_hash :: CCtxStrPtr -> Word16 -> IO Word32
+  c_nn_ctxstr_elem_hash :: CCtxStrPtr -> Word32 -> IO Word32
 
 foreign import ccall unsafe "nn_ctxstr_elem_name"
-  c_nn_ctxstr_elem_name :: CCtxStrPtr -> Word16 -> IO Word32
+  c_nn_ctxstr_elem_name :: CCtxStrPtr -> Word32 -> IO Word32
 
 foreign import ccall unsafe "nn_ctxstr_elem_output"
-  c_nn_ctxstr_elem_output :: CCtxStrPtr -> Word16 -> IO Word32
+  c_nn_ctxstr_elem_output :: CCtxStrPtr -> Word32 -> IO Word32
 
 -- ---------------------------------------------------------------------------
 -- Lifecycle
@@ -84,7 +84,9 @@ foreign import ccall unsafe "nn_ctxstr_elem_output"
 
 -- | Allocate a new context string with space for @ctxCount@ elements.
 -- Elements are uninitialized - caller must fill via set functions.
-cctxstrNew :: Word32 -> Word16 -> IO CCtxStrPtr
+-- Returns 'Foreign.Ptr.nullPtr' on allocation failure or if the
+-- element array size would overflow - the caller must check.
+cctxstrNew :: Word32 -> Word32 -> IO CCtxStrPtr
 cctxstrNew = c_nn_ctxstr_new
 
 -- | Free all tracked nn_ctxstr_t allocations (arena-style cleanup).
@@ -97,17 +99,17 @@ cctxstrFreeAll = c_nn_ctxstr_free_all
 
 -- | Set context element @i@ to a plain store-path reference (@SCPlain@),
 -- identified by its name and hash symbols.
-cctxstrSetPlain :: CCtxStrPtr -> Word16 -> Word32 -> Word32 -> IO ()
+cctxstrSetPlain :: CCtxStrPtr -> Word32 -> Word32 -> Word32 -> IO ()
 cctxstrSetPlain = c_nn_ctxstr_set_plain
 
 -- | Set context element @i@ to a derivation-output reference (@SCDrvOutput@):
 -- name and hash symbols plus the output-name symbol.
-cctxstrSetDrvOutput :: CCtxStrPtr -> Word16 -> Word32 -> Word32 -> Word32 -> IO ()
+cctxstrSetDrvOutput :: CCtxStrPtr -> Word32 -> Word32 -> Word32 -> Word32 -> IO ()
 cctxstrSetDrvOutput = c_nn_ctxstr_set_drv_output
 
 -- | Set context element @i@ to an all-outputs reference (@SCAllOutputs@),
 -- identified by its name and hash symbols.
-cctxstrSetAllOutputs :: CCtxStrPtr -> Word16 -> Word32 -> Word32 -> IO ()
+cctxstrSetAllOutputs :: CCtxStrPtr -> Word32 -> Word32 -> Word32 -> IO ()
 cctxstrSetAllOutputs = c_nn_ctxstr_set_all_outputs
 
 -- ---------------------------------------------------------------------------
@@ -119,21 +121,21 @@ cctxstrText :: CCtxStrPtr -> IO Word32
 cctxstrText = c_nn_ctxstr_text
 
 -- | The number of context elements attached to the string.
-cctxstrCtxCount :: CCtxStrPtr -> IO Word16
+cctxstrCtxCount :: CCtxStrPtr -> IO Word32
 cctxstrCtxCount = c_nn_ctxstr_ctx_count
 
 -- | The tag of context element @i@ (plain / drv-output / all-outputs).
-cctxstrElemTag :: CCtxStrPtr -> Word16 -> IO Word8
+cctxstrElemTag :: CCtxStrPtr -> Word32 -> IO Word8
 cctxstrElemTag = c_nn_ctxstr_elem_tag
 
 -- | The store-path-hash symbol of context element @i@.
-cctxstrElemHash :: CCtxStrPtr -> Word16 -> IO Word32
+cctxstrElemHash :: CCtxStrPtr -> Word32 -> IO Word32
 cctxstrElemHash = c_nn_ctxstr_elem_hash
 
 -- | The store-path-name symbol of context element @i@.
-cctxstrElemName :: CCtxStrPtr -> Word16 -> IO Word32
+cctxstrElemName :: CCtxStrPtr -> Word32 -> IO Word32
 cctxstrElemName = c_nn_ctxstr_elem_name
 
 -- | The output-name symbol of context element @i@ (drv-output elements only).
-cctxstrElemOutput :: CCtxStrPtr -> Word16 -> IO Word32
+cctxstrElemOutput :: CCtxStrPtr -> Word32 -> IO Word32
 cctxstrElemOutput = c_nn_ctxstr_elem_output

--- a/src/Nix/Eval/CEnv.hs
+++ b/src/Nix/Eval/CEnv.hs
@@ -43,7 +43,7 @@ module Nix.Eval.CEnv
   )
 where
 
-import Data.Word (Word16, Word32)
+import Data.Word (Word32)
 import Foreign.C.Types (CInt (..))
 import Foreign.Ptr (Ptr)
 import Nix.Eval.CThunk (CThunkPtr)
@@ -78,7 +78,7 @@ foreign import ccall unsafe "nn_env_new"
     Ptr () ->
     Ptr NnEnv ->
     Ptr (Ptr ()) ->
-    Word16 ->
+    Word32 ->
     IO (Ptr NnEnv)
 
 foreign import ccall unsafe "nn_env_from_slots"
@@ -107,7 +107,7 @@ foreign import ccall unsafe "nn_env_with_scopes"
   c_nn_env_with_scopes :: Ptr NnEnv -> IO (Ptr (Ptr ()))
 
 foreign import ccall unsafe "nn_env_with_count"
-  c_nn_env_with_count :: Ptr NnEnv -> IO Word16
+  c_nn_env_with_count :: Ptr NnEnv -> IO Word32
 
 foreign import ccall unsafe "nn_env_lookup_resolved"
   c_nn_env_lookup_resolved :: Ptr NnEnv -> CInt -> CInt -> IO CThunkPtr
@@ -116,7 +116,7 @@ foreign import ccall unsafe "nn_env_root_scope"
   c_nn_env_root_scope :: Ptr NnEnv -> IO (Ptr ())
 
 foreign import ccall unsafe "nn_env_alloc_with_scopes"
-  c_nn_env_alloc_with_scopes :: Word16 -> IO (Ptr (Ptr ()))
+  c_nn_env_alloc_with_scopes :: Word32 -> IO (Ptr (Ptr ()))
 
 -- ---------------------------------------------------------------------------
 -- Lifecycle
@@ -155,7 +155,7 @@ cenvNew ::
   Ptr () ->
   Ptr NnEnv ->
   Ptr (Ptr ()) ->
-  Word16 ->
+  Word32 ->
   IO (Ptr NnEnv)
 cenvNew = c_nn_env_new
 
@@ -196,7 +196,7 @@ cenvWithScopes :: Ptr NnEnv -> IO (Ptr (Ptr ()))
 cenvWithScopes = c_nn_env_with_scopes
 
 -- | Read the with-scope count from a C env.
-cenvWithCount :: Ptr NnEnv -> IO Word16
+cenvWithCount :: Ptr NnEnv -> IO Word32
 cenvWithCount = c_nn_env_with_count
 
 -- ---------------------------------------------------------------------------
@@ -219,5 +219,7 @@ cenvRootScope = c_nn_env_root_scope
 -- ---------------------------------------------------------------------------
 
 -- | Allocate an arena array for with-scopes.  Zero-initialized.
-cenvAllocWithScopes :: Word16 -> IO (Ptr (Ptr ()))
+-- Returns 'Foreign.Ptr.nullPtr' if the count is 0 or the allocation
+-- fails - the caller must check.
+cenvAllocWithScopes :: Word32 -> IO (Ptr (Ptr ()))
 cenvAllocWithScopes = c_nn_env_alloc_with_scopes

--- a/src/Nix/Eval/CLambda.hs
+++ b/src/Nix/Eval/CLambda.hs
@@ -30,7 +30,7 @@ module Nix.Eval.CLambda
   )
 where
 
-import Data.Word (Word16, Word32, Word8)
+import Data.Word (Word32, Word8)
 import Foreign.Ptr (Ptr)
 import Nix.Eval.CEnv (NnEnv)
 
@@ -45,10 +45,10 @@ type CLambdaPtr = Ptr NnLambda
 -- ---------------------------------------------------------------------------
 
 foreign import ccall unsafe "nn_lambda_new"
-  c_nn_lambda_new :: Ptr NnEnv -> Word32 -> Word8 -> Word32 -> Word8 -> Word16 -> IO CLambdaPtr
+  c_nn_lambda_new :: Ptr NnEnv -> Word32 -> Word8 -> Word32 -> Word8 -> Word32 -> IO CLambdaPtr
 
 foreign import ccall unsafe "nn_lambda_set_entry"
-  c_nn_lambda_set_entry :: CLambdaPtr -> Word16 -> Word32 -> Word32 -> Word32 -> IO ()
+  c_nn_lambda_set_entry :: CLambdaPtr -> Word32 -> Word32 -> Word32 -> Word32 -> IO ()
 
 foreign import ccall unsafe "nn_lambda_free_all"
   c_nn_lambda_free_all :: IO ()
@@ -69,16 +69,16 @@ foreign import ccall unsafe "nn_lambda_allow_extra"
   c_nn_lambda_allow_extra :: CLambdaPtr -> IO Word8
 
 foreign import ccall unsafe "nn_lambda_formal_count"
-  c_nn_lambda_formal_count :: CLambdaPtr -> IO Word16
+  c_nn_lambda_formal_count :: CLambdaPtr -> IO Word32
 
 foreign import ccall unsafe "nn_lambda_entry_name"
-  c_nn_lambda_entry_name :: CLambdaPtr -> Word16 -> IO Word32
+  c_nn_lambda_entry_name :: CLambdaPtr -> Word32 -> IO Word32
 
 foreign import ccall unsafe "nn_lambda_entry_has_default"
-  c_nn_lambda_entry_has_default :: CLambdaPtr -> Word16 -> IO Word32
+  c_nn_lambda_entry_has_default :: CLambdaPtr -> Word32 -> IO Word32
 
 foreign import ccall unsafe "nn_lambda_entry_default"
-  c_nn_lambda_entry_default :: CLambdaPtr -> Word16 -> IO Word32
+  c_nn_lambda_entry_default :: CLambdaPtr -> Word32 -> IO Word32
 
 -- ---------------------------------------------------------------------------
 -- Lifecycle
@@ -86,11 +86,13 @@ foreign import ccall unsafe "nn_lambda_entry_default"
 
 -- | Allocate a new lambda closure with space for @formalCount@ entries.
 -- Fill entries via 'clambdaSetEntry' after construction.
-clambdaNew :: Ptr NnEnv -> Word32 -> Word8 -> Word32 -> Word8 -> Word16 -> IO CLambdaPtr
+-- Returns 'Foreign.Ptr.nullPtr' on allocation failure or if the
+-- entries array size would overflow - the caller must check.
+clambdaNew :: Ptr NnEnv -> Word32 -> Word8 -> Word32 -> Word8 -> Word32 -> IO CLambdaPtr
 clambdaNew = c_nn_lambda_new
 
 -- | Set a formal entry at the given index.
-clambdaSetEntry :: CLambdaPtr -> Word16 -> Word32 -> Word32 -> Word32 -> IO ()
+clambdaSetEntry :: CLambdaPtr -> Word32 -> Word32 -> Word32 -> Word32 -> IO ()
 clambdaSetEntry = c_nn_lambda_set_entry
 
 -- | Free all tracked lambda structs (arena-style cleanup).
@@ -122,17 +124,17 @@ clambdaAllowExtra :: CLambdaPtr -> IO Word8
 clambdaAllowExtra = c_nn_lambda_allow_extra
 
 -- | Read the number of formal entries.
-clambdaFormalCount :: CLambdaPtr -> IO Word16
+clambdaFormalCount :: CLambdaPtr -> IO Word32
 clambdaFormalCount = c_nn_lambda_formal_count
 
 -- | Read a formal entry's name symbol.
-clambdaEntryName :: CLambdaPtr -> Word16 -> IO Word32
+clambdaEntryName :: CLambdaPtr -> Word32 -> IO Word32
 clambdaEntryName = c_nn_lambda_entry_name
 
 -- | Read whether a formal entry has a default.
-clambdaEntryHasDefault :: CLambdaPtr -> Word16 -> IO Word32
+clambdaEntryHasDefault :: CLambdaPtr -> Word32 -> IO Word32
 clambdaEntryHasDefault = c_nn_lambda_entry_has_default
 
 -- | Read a formal entry's default bytecode index.
-clambdaEntryDefault :: CLambdaPtr -> Word16 -> IO Word32
+clambdaEntryDefault :: CLambdaPtr -> Word32 -> IO Word32
 clambdaEntryDefault = c_nn_lambda_entry_default

--- a/src/Nix/Eval/Types.hs
+++ b/src/Nix/Eval/Types.hs
@@ -59,7 +59,7 @@ module Nix.Eval.Types
     lookupWithScopes,
     withScopesForCapture,
     envWithScopesRaw,
-    checkedEnvPtr,
+    checkedCPtr,
     newCEnv,
     newMinimalEnv,
 
@@ -120,7 +120,7 @@ import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text.Encoding as TE
 import Data.Text.Encoding.Error (lenientDecode)
-import Data.Word (Word16, Word32, Word64, Word8)
+import Data.Word (Word32, Word64, Word8)
 import Foreign.Ptr (Ptr, castPtr, nullPtr, ptrToWordPtr)
 import Foreign.StablePtr (castPtrToStablePtr, castStablePtrToPtr, deRefStablePtr, newStablePtr)
 import Foreign.Storable (peekElemOff, pokeElemOff)
@@ -512,22 +512,23 @@ instance Show Env where
 emptyEnv :: Env
 emptyEnv = Env (unsafePerformIO cenvEmpty)
 
--- | Fail loudly when a C env constructor returns NULL (arena OOM or the
--- with-scope count limit).  The C side signals failure deliberately;
--- deferring the NULL to the next lookup would be undefined behavior in a
--- release build, so convert it into a clean Haskell exception here.
-checkedEnvPtr :: String -> Ptr NnEnv -> Ptr NnEnv
-checkedEnvPtr site ptr
-  | ptr == nullPtr = error (site ++ ": C env allocation failed (arena OOM or with-scope limit)")
+-- | Fail loudly when a C allocator returns NULL (arena or malloc
+-- exhaustion, or a rejected over-large size).  The C side signals
+-- failure deliberately; deferring the NULL to the next dereference
+-- would be undefined behavior in a release build, so convert it into
+-- a clean Haskell exception here.
+checkedCPtr :: String -> Ptr a -> Ptr a
+checkedCPtr site ptr
+  | ptr == nullPtr = error (site ++ ": C allocation failed")
   | otherwise = ptr
 
 -- | General C-backed env constructor.
 -- Takes Haskell-level types; converts Maybe to nullPtr internally.
 {-# NOINLINE newCEnv #-}
-newCEnv :: Ptr CThunkPtr -> Int -> Maybe AttrSet -> Maybe Env -> Ptr (Ptr ()) -> Word16 -> Env
+newCEnv :: Ptr CThunkPtr -> Int -> Maybe AttrSet -> Maybe Env -> Ptr (Ptr ()) -> Word32 -> Env
 newCEnv slots slotCount lazyScope parent withs withCount =
   Env
-    ( checkedEnvPtr "newCEnv" $
+    ( checkedCPtr "newCEnv" $
         unsafePerformIO
           ( cenvNew
               slots
@@ -543,7 +544,7 @@ newCEnv slots slotCount lazyScope parent withs withCount =
 {-# NOINLINE newMinimalEnv #-}
 newMinimalEnv :: Ptr CThunkPtr -> Int -> Env
 newMinimalEnv slots n =
-  Env (checkedEnvPtr "newMinimalEnv" (unsafePerformIO (cenvNewMinimal slots (fromIntegral n))))
+  Env (checkedCPtr "newMinimalEnv" (unsafePerformIO (cenvNewMinimal slots (fromIntegral n))))
 
 -- | Look up a resolved variable by level and index.  Single C call:
 -- O(level) parent hops in C, then O(1) array read.
@@ -583,7 +584,7 @@ envLookup name (Env envPtr) = lexicalLookup envPtr
 -- (barrier) binding or a static global, both found on the parent chain
 -- before this fallback fires ('EVar' also blocks closure trimming, so
 -- the chain is always intact) - but keep it for safety.
-lookupWithScopesC :: Text -> Ptr (Ptr ()) -> Word16 -> Maybe Thunk
+lookupWithScopesC :: Text -> Ptr (Ptr ()) -> Word32 -> Maybe Thunk
 lookupWithScopesC _ _ 0 = Nothing
 lookupWithScopesC name withArr count = unsafePerformIO $ go 0
   where
@@ -610,18 +611,18 @@ lookupWithScopes name (scope : rest) =
 {-# NOINLINE envFromSlots #-}
 envFromSlots :: Ptr CThunkPtr -> Int -> Env -> Env
 envFromSlots slotsPtr slotCount (Env parentPtr) =
-  Env (checkedEnvPtr "envFromSlots" (unsafePerformIO (cenvFromSlots slotsPtr (fromIntegral slotCount) parentPtr)))
+  Env (checkedCPtr "envFromSlots" (unsafePerformIO (cenvFromSlots slotsPtr (fromIntegral slotCount) parentPtr)))
 
 -- | Push a with-scope onto the scope chain (innermost position).
 -- Allocates a new C env struct with extended with-scopes array.
 {-# NOINLINE pushWithScope #-}
 pushWithScope :: AttrSet -> Env -> Env
 pushWithScope (AttrSet cset) (Env envPtr) =
-  Env (checkedEnvPtr "pushWithScope" (unsafePerformIO (cenvPushWith envPtr (castPtr cset))))
+  Env (checkedCPtr "pushWithScope" (unsafePerformIO (cenvPushWith envPtr (castPtr cset))))
 
 -- | Read with-scopes array pointer and count from a C env.
 {-# NOINLINE envWithScopesRaw #-}
-envWithScopesRaw :: Env -> (Ptr (Ptr ()), Word16)
+envWithScopesRaw :: Env -> (Ptr (Ptr ()), Word32)
 envWithScopesRaw (Env envPtr) = unsafePerformIO $ do
   withs <- cenvWithScopes envPtr
   count <- cenvWithCount envPtr
@@ -632,7 +633,7 @@ envWithScopesRaw (Env envPtr) = unsafePerformIO $ do
 -- outermost entry so 'EWithVar' can fall back to builtins without
 -- retaining the parent chain.  Returns C array + count.
 {-# NOINLINE withScopesForCapture #-}
-withScopesForCapture :: Env -> (Ptr (Ptr ()), Word16)
+withScopesForCapture :: Env -> (Ptr (Ptr ()), Word32)
 withScopesForCapture (Env envPtr) = unsafePerformIO $ do
   rootPtr <- cenvRootScope envPtr
   existingWiths <- cenvWithScopes envPtr
@@ -640,8 +641,10 @@ withScopesForCapture (Env envPtr) = unsafePerformIO $ do
   if rootPtr == nullPtr
     then pure (existingWiths, existingCount)
     else do
+      -- existingCount sits far below 2^32 (the C side caps the array
+      -- allocation at UINT32_MAX bytes), so the increment cannot wrap.
       let newCount = existingCount + 1
-      arr <- cenvAllocWithScopes newCount
+      arr <- checkedCPtr "withScopesForCapture" <$> cenvAllocWithScopes newCount
       -- Copy existing with-scopes
       forM_ [0 .. fromIntegral existingCount - 1] $ \i -> do
         val <- peekElemOff existingWiths i
@@ -889,19 +892,19 @@ marshalLambda :: Ptr NnEnv -> EvalFormals -> Word32 -> IO (Ptr ())
 marshalLambda envPtr formals bodyBcIdx = case formals of
   EFName name -> do
     Symbol nameSym <- symbolIntern name
-    lam <- clambdaNew envPtr bodyBcIdx 0 nameSym 0 0
+    lam <- checkedCPtr "marshalLambda" <$> clambdaNew envPtr bodyBcIdx 0 nameSym 0 0
     pure (castPtr lam)
   EFSet entries allowExtra -> do
-    let count = fromIntegral (length entries) :: Word16
+    let count = fromIntegral (length entries) :: Word32
         extraFlag = if allowExtra then 1 else 0 :: Word8
-    lam <- clambdaNew envPtr bodyBcIdx 1 0 extraFlag count
+    lam <- checkedCPtr "marshalLambda" <$> clambdaNew envPtr bodyBcIdx 1 0 extraFlag count
     fillEntries lam 0 entries
     pure (castPtr lam)
   EFNamedSet name entries allowExtra -> do
     Symbol nameSym <- symbolIntern name
-    let count = fromIntegral (length entries) :: Word16
+    let count = fromIntegral (length entries) :: Word32
         extraFlag = if allowExtra then 1 else 0 :: Word8
-    lam <- clambdaNew envPtr bodyBcIdx 2 nameSym extraFlag count
+    lam <- checkedCPtr "marshalLambda" <$> clambdaNew envPtr bodyBcIdx 2 nameSym extraFlag count
     fillEntries lam 0 entries
     pure (castPtr lam)
   where
@@ -940,7 +943,7 @@ unmarshalLambdaValue rawPtr = do
   pure (VLambda (Env envPtr) formals bodyIdx)
   where
     -- Zero-formal set patterns ({}:, { ... }:) store count 0 and a NULL
-    -- entries array; count - 1 would underflow Word16 to 65535.
+    -- entries array; count - 1 would underflow Word32.
     readLambdaEntries lamPtr count
       | count == 0 = pure []
       | otherwise = mapM (readOneEntry lamPtr) [0 .. count - 1]
@@ -958,8 +961,8 @@ marshalStringContext :: ByteString -> StringContext -> IO CCtxStrPtr
 marshalStringContext textVal (StringContext ctxSet) = do
   Symbol textSym <- symbolInternBytes textVal
   let elems = Set.toAscList ctxSet
-      count = fromIntegral (length elems) :: Word16
-  ptr <- cctxstrNew textSym count
+      count = fromIntegral (length elems) :: Word32
+  ptr <- checkedCPtr "marshalStringContext" <$> cctxstrNew textSym count
   fillElems ptr 0 elems
   pure ptr
   where
@@ -987,7 +990,7 @@ unmarshalStringContext ptr = do
   textSym <- cctxstrText ptr
   count <- cctxstrCtxCount ptr
   let textVal = symbolBytes (Symbol textSym)
-  -- count - 1 underflows Word16 at 0 (defensive: marshal sites store
+  -- count - 1 underflows Word32 at 0 (defensive: marshal sites store
   -- only non-empty contexts today).
   elems <-
     if count == 0

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -551,9 +551,9 @@ testEvalLambda = do
         assertEval "set-pat" "({ a, b }: a + b) { a = 1; b = 2; }" (VInt 3),
       runTest "default param" $
         assertEval "default" "({ a ? 10 }: a) { }" (VInt 10),
-      -- Regression: zero-formal set patterns marshal count 0 / entries NULL;
-      -- the second force of the same lambda thunk re-reads the entries and
-      -- must not underflow the unsigned count (crashed pre-fix).
+      -- Zero-formal set patterns marshal count 0 / entries NULL; the
+      -- second force of the same lambda thunk re-reads the entries and
+      -- must not underflow the unsigned count.
       runTest "empty formals forced twice" $
         assertEval "empty-formals" "let f = {}: 1; in f {} + f {}" (VInt 2),
       runTest "ellipsis-only formals forced twice" $
@@ -6067,13 +6067,12 @@ testBytecodeCountSpill = do
           (VBool False)
     ]
 
--- | C value structs carry element counts as a full uint32: a lambda's
--- formal list and a string's context set marshal past the old uint16
--- ceiling intact.  A narrower count wraps at 65536 and sizes the C
--- array smaller than the fill loop that follows it.  Each case forces
--- the value twice - the first force writes the C struct (the marshal
--- side), the second reads it back off the computed thunk cell (the
--- unmarshal side).
+-- | C value structs carry element counts as a full uint32; a narrower
+-- count would wrap at 65536 and size the C array smaller than the fill
+-- loop that follows it.  Both cases marshal counts past that boundary
+-- and force the value twice - the first force writes the C struct (the
+-- marshal side), the second reads it back off the computed thunk cell
+-- (the unmarshal side).
 testValueCountWidths :: IO [Bool]
 testValueCountWidths = do
   putStrLn "value/count-widths"

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -553,7 +553,7 @@ testEvalLambda = do
         assertEval "default" "({ a ? 10 }: a) { }" (VInt 10),
       -- Regression: zero-formal set patterns marshal count 0 / entries NULL;
       -- the second force of the same lambda thunk re-reads the entries and
-      -- must not underflow the Word16 count (crashed pre-fix).
+      -- must not underflow the unsigned count (crashed pre-fix).
       runTest "empty formals forced twice" $
         assertEval "empty-formals" "let f = {}: 1; in f {} + f {}" (VInt 2),
       runTest "ellipsis-only formals forced twice" $
@@ -6067,6 +6067,37 @@ testBytecodeCountSpill = do
           (VBool False)
     ]
 
+-- | C value structs carry element counts as a full uint32: a lambda's
+-- formal list and a string's context set marshal past the old uint16
+-- ceiling intact.  A narrower count wraps at 65536 and sizes the C
+-- array smaller than the fill loop that follows it.  Each case forces
+-- the value twice - the first force writes the C struct (the marshal
+-- side), the second reads it back off the computed thunk cell (the
+-- unmarshal side).
+testValueCountWidths :: IO [Bool]
+testValueCountWidths = do
+  putStrLn "value/count-widths"
+  let formalsBody = T.intercalate ", " [T.pack ("a" <> show i) | i <- [0 :: Int .. 69999]]
+  sequence
+    [ runTest "lambda with 70000 formals round-trips through the C closure" $
+        assertEval
+          "width-lambda-formals"
+          ( "let f = { "
+              <> formalsBody
+              <> " }: 1; in builtins.seq (builtins.functionArgs f) (builtins.length (builtins.attrNames (builtins.functionArgs f)))"
+          )
+          (VInt 70000),
+      runTest "string context with 70000 elements round-trips through the C thunk" $
+        assertEval
+          "width-ctxstr-elems"
+          ( "let s = builtins.appendContext \"x\" (builtins.listToAttrs (builtins.genList (i: { "
+              <> "name = \"/nix/store/00000000000000000000000000000000-p\" + builtins.toString i; "
+              <> "value = { path = true; }; }) 70000)); "
+              <> "in builtins.seq s (builtins.length (builtins.attrNames (builtins.getContext s)))"
+          )
+          (VInt 70000)
+    ]
+
 testBytecodeCompile :: IO [Bool]
 testBytecodeCompile = do
   putStrLn "bytecode"
@@ -6904,6 +6935,7 @@ main = bracket_ arenaInit arenaDestroy $ do
           testCThunk,
           testBytecodeCompile,
           testBytecodeCountSpill,
+          testValueCountWidths,
           testClassIFollowups,
           testClassIFollowupsIO
         ]


### PR DESCRIPTION
Closes #38.

Three C value structs carried element counts as uint16_t while the marshal
sites truncated real list lengths into them: a string context, formal list,
or with-scope chain past 65535 elements wrapped the count, sized the C array
to the wrapped value, and the fill loop then ran past the allocation - the
only bound was an NN_ASSERT that compiles out under NDEBUG. nn_bc_emit's
UINT32_MAX failure sentinel was likewise used as an index unchecked.

- ctx_count (nn_ctxstr_t), formal_count (nn_lambda_t), and with_count
  (nn_env_t) are now uint32_t end to end: struct field, C API, FFI imports,
  and marshal sites. Each field sits next to existing padding, so no struct
  grows. Counts past 2^32 are unreachable by memory, so the wrapped state is
  unrepresentable rather than checked-for.
- Allocation sizes are computed in uint64_t and capped at the UINT32_MAX
  byte limit the C layer already uses (the nn_env_alloc_slots idiom), so
  the malloc argument cannot wrap size_t on any platform.
- Element setters and readers keep NN_ASSERT and gain a live branch (drop
  the write / return 0) following the nn_env_lookup_resolved precedent, so
  every bound holds in release builds.
- checkedEnvPtr generalized to checkedCPtr :: String -> Ptr a -> Ptr a and
  now also guards cctxstrNew, clambdaNew, and cenvAllocWithScopes, whose
  NULL results were previously dereferenced in C on allocation failure.
- withScopesForCapture's increment can no longer wrap (previously, +1 in
  Word16 at exactly 65535 with-scopes produced a count-0 NULL array that
  the copy loop wrote through); nn_env_push_with reuses
  nn_env_alloc_with_scopes instead of duplicating unguarded size math.
- cbcEmit / cbcEmitData reject the UINT32_MAX emit sentinel centrally
  before it can flow onward as an index; nn_bytecode.h now documents the
  failure return.
- New value/count-widths test group: a 70000-formal lambda and a
  70000-element string context (fabricated via appendContext), each forced
  twice so both the marshal and the read-back cross the widened boundary.

Class sweep: attrset, list, env slots, thunk, and bytecode counts were
already uint32; symbol intern takes size_t; the remaining Word16s are the
short_arg instruction field, whose oversized counts spill per the existing
convention.

Bench (nixpkgs attrNames, -M4G): allocation and max residency identical to
baseline (+0.01% / -0.08%); MUT time and productivity within the baseline's
own run-to-run spread.
