### PR TITLE
Audit class B: store-path name validation at construction and write sinks

### DIFF
--- a/src/Nix/Eval.hs
+++ b/src/Nix/Eval.hs
@@ -67,7 +67,7 @@ module Nix.Eval
   )
 where
 
-import Control.Monad (foldM, when, (>=>))
+import Control.Monad (foldM, forM_, when, (>=>))
 import qualified Crypto.Hash as CH
 import qualified Data.Array as Array
 import Data.Bits (complement, xor, (.&.), (.|.))
@@ -152,6 +152,7 @@ import Nix.Eval.Types
     newMinimalEnv,
     readThunkValue,
     runPureEval,
+    storePathOrThrow,
     thunkToCPtr,
     typeName,
     withScopesForCapture,
@@ -165,7 +166,7 @@ import Nix.Expr.Types
     UnaryOp (..),
   )
 import Nix.Hash (base64HashLen, bytesToHexText, hashAlgoBytes, hashPlaceholder, hexHashLen, hexToBytes, makeFixedOutputPath, makeOutputPath, makeTextPath, nix32HashLen, sha256Digest, sha256Hex)
-import Nix.Store.Path (StorePath (..), defaultStoreDir, defaultStoreDirText, parseStorePath, storePathToText)
+import Nix.Store.Path (StorePath (..), StorePathNameError (..), checkStorePathName, defaultStoreDir, defaultStoreDirText, parseStorePath, storePathNameErrorText, storePathNameReasonText, storePathToText)
 import qualified NovaCache.Base32 as Nix32
 import qualified NovaCache.Base64 as B64
 import qualified NovaCache.NAR as NAR
@@ -3436,6 +3437,13 @@ getTempDir = do
 -- | Fetch a URL and optionally verify its hash.
 fetchUrlSimple :: (MonadEval m) => Text -> Maybe Text -> m NixValue
 fetchUrlSimple url mSha256 = do
+  -- The store name derives from the URL alone, so an unusable name fails
+  -- here, before the download side effect.  Upstream rejects the same
+  -- names when it adds the fetched file to the store.
+  let name = urlBaseName url
+  case checkStorePathName name of
+    Left err -> throwEvalError ("builtins.fetchurl: " <> storePathNameErrorText err)
+    Right () -> pure ()
   -- Download to a file, not through the text-mode stdout pipe (which mangles
   -- binary), read the raw bytes, verify the pin if one was given, then store at
   -- the canonical fixed-output path.
@@ -3447,7 +3455,7 @@ fetchUrlSimple url mSha256 = do
     else do
       bytes <- readFileBytes tmpFile
       mapM_ (verifyFetchPin "builtins.fetchurl" url bytes) mSha256
-      storePath <- addFixedOutputFile (urlBaseName url) bytes
+      storePath <- addFixedOutputFile name bytes
       pure (VPath storePath)
 
 -- | Store name for a fetched URL: its basename (minus query/fragment), matching
@@ -3620,6 +3628,15 @@ builtinDerivationStrict (VAttrs attrs) = do
   -- store-path and platform machinery); the builder stays raw bytes - it
   -- lands byte-exact in the ATerm's builder field.
   drvName <- forceAttrStr "derivation" "name" attrs
+  -- The name becomes the store-path name of the .drv and of every output,
+  -- so it must satisfy the store-path name rules.  The path constructors
+  -- re-check what they build; this early check reports the offending
+  -- FIELD rather than a composed path name.
+  case checkStorePathName drvName of
+    Left err ->
+      throwEvalError
+        ("derivation: invalid derivation name '" <> drvName <> "': " <> storePathNameReasonText (spneReason err))
+    Right () -> pure ()
   system <- forceAttrStr ("derivation \"" <> drvName <> "\"") "system" attrs
   builder <- forceAttrBytes ("derivation \"" <> drvName <> "\"") "builder" attrs
 
@@ -3645,6 +3662,23 @@ builtinDerivationStrict (VAttrs attrs) = do
         -- the default output set; without it, null is an error as upstream.
         VNull | ignoreNulls -> pure ["out"]
         _ -> throwEvalError "derivation: 'outputs' must be a list of strings"
+
+  -- Each output name composes into a store-path name (drvName-<output>)
+  -- and names the on-disk location the builder later clears and moves
+  -- onto, so it must satisfy the same store-path name rules (the
+  -- composed length is re-checked at construction).
+  forM_ outputNames $ \outName ->
+    case checkStorePathName outName of
+      Left err ->
+        throwEvalError
+          ( "derivation \""
+              <> drvName
+              <> "\": invalid derivation output name '"
+              <> outName
+              <> "': "
+              <> storePathNameReasonText (spneReason err)
+          )
+      Right () -> pure ()
 
   -- Extract optional args (default []).  Path literals in args (e.g. stdenv's
   -- ./default-builder.sh) are copied into the store; their source paths flow
@@ -3703,10 +3737,15 @@ builtinDerivationStrict (VAttrs attrs) = do
   -- the modulo hashes of their inputs.
   mFixed <- detectFixedOutput attrs
 
+  -- Path construction returns Left on a name the store rules reject; the
+  -- early field checks above make that unreachable here except through
+  -- composition (drvName <> ".drv", drvName-output past the length cap),
+  -- which only the constructors see.
+  let drvContext = "derivation \"" <> drvName <> "\""
   (drvPathText, drvSP, outPaths, completeDrv) <- case mFixed of
     Just (foAlgo, foMode, foDigest) -> do
-      let foPath = makeFixedOutputPath drvName foAlgo foMode foDigest
-          foPathText = storePathToText defaultStoreDir foPath
+      foPath <- storePathOrThrow drvContext (makeFixedOutputPath drvName foAlgo foMode foDigest)
+      let foPathText = storePathToText defaultStoreDir foPath
           algoField = (if foMode == "recursive" then "r:" else "") <> foAlgo
           foHashHex = bytesToHexText foDigest
           foModulo =
@@ -3716,8 +3755,8 @@ builtinDerivationStrict (VAttrs attrs) = do
             mkDrv
               [DerivationOutput "out" foPath algoField foHashHex]
               (Map.insert "out" (TE.encodeUtf8 foPathText) baseEnv)
-          drvSp = makeTextPath drvFileName (sha256Digest (toATerm contents)) drvRefs
-          drvText = storePathToText defaultStoreDir drvSp
+      drvSp <- storePathOrThrow drvContext (makeTextPath drvFileName (sha256Digest (toATerm contents)) drvRefs)
+      let drvText = storePathToText defaultStoreDir drvSp
       cacheDrvHash drvText (bytesToHexText foModulo)
       pure (drvText, drvSp, [("out", foPathText)], contents)
     Nothing -> do
@@ -3726,15 +3765,18 @@ builtinDerivationStrict (VAttrs attrs) = do
           maskedDrv = mkDrv (map maskedOutput outputNames) maskedEnv
           -- Masked modulo hash yields this derivation's own output paths.
           moduloMasked = sha256Digest (toATermForHash True (Just inputSubst) maskedDrv)
-          outStorePaths = [(n, makeOutputPath n moduloMasked drvName) | n <- outputNames]
-          outPathTexts = [(n, storePathToText defaultStoreDir sp) | (n, sp) <- outStorePaths]
+      outStorePaths <-
+        mapM
+          (\n -> (,) n <$> storePathOrThrow drvContext (makeOutputPath n moduloMasked drvName))
+          outputNames
+      let outPathTexts = [(n, storePathToText defaultStoreDir sp) | (n, sp) <- outStorePaths]
           realEnv = foldr (\(n, t) e -> Map.insert n (TE.encodeUtf8 t) e) baseEnv outPathTexts
           contents = mkDrv [DerivationOutput n sp "" "" | (n, sp) <- outStorePaths] realEnv
           -- Unmasked modulo hash (real outputs, inputs substituted) cached for
           -- when this derivation is itself an input to another.
           moduloUnmasked = sha256Digest (toATermForHash False (Just inputSubst) contents)
-          drvSp = makeTextPath drvFileName (sha256Digest (toATerm contents)) drvRefs
-          drvText = storePathToText defaultStoreDir drvSp
+      drvSp <- storePathOrThrow drvContext (makeTextPath drvFileName (sha256Digest (toATerm contents)) drvRefs)
+      let drvText = storePathToText defaultStoreDir drvSp
       cacheDrvHash drvText (bytesToHexText moduloUnmasked)
       pure (drvText, drvSp, outPathTexts, contents)
 

--- a/src/Nix/Eval/IO.hs
+++ b/src/Nix/Eval/IO.hs
@@ -50,7 +50,7 @@ import Nix.Eval.CList (CList (..))
 import Nix.Eval.CThunk (CThunkPtr, cthunkGetAttrs, cthunkGetBcIdx, cthunkGetBool, cthunkGetCtxStr, cthunkGetFloat, cthunkGetInt, cthunkGetLambda, cthunkGetList, cthunkGetPath, cthunkGetStr, cthunkMarkBlackhole, cthunkMarkPending, cthunkPayload, cthunkSetComputed, cthunkSetComputedAttrs, cthunkSetComputedBool, cthunkSetComputedCtxStr, cthunkSetComputedFloat, cthunkSetComputedInt, cthunkSetComputedLambda, cthunkSetComputedList, cthunkSetComputedNull, cthunkSetComputedPath, cthunkSetComputedStr, cthunkState, cthunkValueTag)
 import Nix.Eval.CanonPath (canonBaseName, canonPath)
 import Nix.Eval.Symbol (Symbol (..), symbolBytes, symbolIntern, symbolInternBytes, symbolText)
-import Nix.Eval.Types (AttrSet (..), Env (..), MonadEval (..), NixValue (..), Thunk (..), attrSetSize, emptyContext, marshalLambda, marshalStringContext, unmarshalLambdaValue, unmarshalStringContext, pattern ValueAttrs, pattern ValueBool, pattern ValueCtxStr, pattern ValueFloat, pattern ValueInt, pattern ValueLambda, pattern ValueList, pattern ValueNull, pattern ValuePath, pattern ValueStr)
+import Nix.Eval.Types (AttrSet (..), Env (..), MonadEval (..), NixValue (..), Thunk (..), attrSetSize, emptyContext, marshalLambda, marshalStringContext, storePathOrThrow, unmarshalLambdaValue, unmarshalStringContext, pattern ValueAttrs, pattern ValueBool, pattern ValueCtxStr, pattern ValueFloat, pattern ValueInt, pattern ValueLambda, pattern ValueList, pattern ValueNull, pattern ValuePath, pattern ValueStr)
 import Nix.Expr.Types (AttrKey (..), Binding (..), Expr (..), Formal (..), Formals (..), NixAtom (..), StringPart (..))
 import Nix.Hash (bytesToHexText, makeFixedOutputPath, makeTextPath, sha256Digest)
 import Nix.Parser (parseNix, readFileAutoEncoding)
@@ -273,36 +273,35 @@ instance MonadEval EvalIO where
       Nothing -> do
         -- Upstream names the copy baseNameOf(canonicalized path); path
         -- values arrive canonicalized, so the last segment is the name.
+        -- The name is checked before the tree read: it derives from the
+        -- path alone, and the tree behind it can be arbitrarily large.
         let name = canonBaseName rawPath
+            copyContext = "cannot copy '" <> rawPath <> "' to the store"
         when (T.null name) $
-          throwEvalError ("cannot copy '" <> rawPath <> "' to the store: the path has no base name")
+          throwEvalError (copyContext <> ": the path has no base name")
+        case SP.checkStorePathName name of
+          Left err -> throwEvalError (copyContext <> ": " <> SP.storePathNameErrorText err)
+          Right () -> pure ()
         entry <- wrapIO (NAR.serialiseFromPath (T.unpack rawPath))
         let narDigest = sha256Digest (NAR.serialise entry)
-            sp = makeFixedOutputPath name "sha256" "recursive" narDigest
-            spText = SP.storePathToText SP.defaultStoreDir sp
+        sp <- storePathOrThrow copyContext (makeFixedOutputPath name "sha256" "recursive" narDigest)
+        let spText = SP.storePathToText SP.defaultStoreDir sp
         EvalIO (liftIO (modifyIORef' ref (Map.insert rawPath spText)))
         pure spText
 
   getCurrentTime = EvalIO (asks esTimestamp)
 
   writeToStore name contents refs = do
-    -- Validate name to prevent path traversal
-    when (T.any (== '/') name) $
-      throwEvalError ("writeToStore: name must not contain '/': " <> name)
-    when (T.any (== '\\') name) $
-      throwEvalError ("writeToStore: name must not contain '\\': " <> name)
-    when (T.isInfixOf ".." name) $
-      throwEvalError ("writeToStore: name must not contain '..': " <> name)
-    when (T.any (== '\0') name) $
-      throwEvalError ("writeToStore: name must not contain null bytes: " <> name)
     -- Upstream's text-path scheme via makeTextPath - the same scheme .drv
     -- paths use, so it is parity-validated: type @text:<refs>@, flat
-    -- sha256 of the contents, canonical store dir.  The contents are the
-    -- string's RAW BYTES, hashed and written as-is: no encoding step, and
-    -- no text-mode IO (which would CRLF-translate on Windows and store
-    -- bytes that no longer match the hash that named the path).
-    let sp = makeTextPath name (sha256Digest contents) refs
-        filePath = SP.storePathToFilePath SP.defaultStoreDir sp
+    -- sha256 of the contents, canonical store dir.  Construction also
+    -- validates the name, so the write below never targets a path
+    -- outside the store root.  The contents are the string's RAW BYTES,
+    -- hashed and written as-is: no encoding step, and no text-mode IO
+    -- (which would CRLF-translate on Windows and store bytes that no
+    -- longer match the hash that named the path).
+    sp <- storePathOrThrow "builtins.toFile" (makeTextPath name (sha256Digest contents) refs)
+    let filePath = SP.storePathToFilePath SP.defaultStoreDir sp
         storePath = SP.storePathToText SP.defaultStoreDir sp
     wrapIO $ do
       Dir.createDirectoryIfMissing True (takeDirectory filePath)
@@ -355,15 +354,12 @@ instance MonadEval EvalIO where
     pure (code, T.pack stdoutStr, T.pack stderrStr)
 
   copyPathToStore srcPath name expectedSha256 = do
-    -- Validate name to prevent path traversal (matches writeToStore)
-    when (T.any (== '/') name) $
-      throwEvalError ("copyPathToStore: name must not contain '/': " <> name)
-    when (T.any (== '\\') name) $
-      throwEvalError ("copyPathToStore: name must not contain '\\': " <> name)
-    when (T.isInfixOf ".." name) $
-      throwEvalError ("copyPathToStore: name must not contain '..': " <> name)
-    when (T.any (== '\0') name) $
-      throwEvalError ("copyPathToStore: name must not contain null bytes: " <> name)
+    -- The name is checked before the tree read: it arrives independently
+    -- of the source, and the tree can be arbitrarily large.
+    let copyContext = "cannot copy '" <> srcPath <> "' to the store"
+    case SP.checkStorePathName name of
+      Left err -> throwEvalError (copyContext <> ": " <> SP.storePathNameErrorText err)
+      Right () -> pure ()
     -- Content-addressed like upstream addToStore: recursive NAR sha256
     -- under the caller's name.  Same content means same path, so the
     -- existence check in copyToStoreIfMissing is sound - changed source
@@ -382,8 +378,8 @@ instance MonadEval EvalIO where
                   <> bytesToHexText narDigest
               )
       _ -> pure ()
-    let sp = makeFixedOutputPath name "sha256" "recursive" narDigest
-        destFilePath = SP.storePathToFilePath SP.defaultStoreDir sp
+    sp <- storePathOrThrow copyContext (makeFixedOutputPath name "sha256" "recursive" narDigest)
+    let destFilePath = SP.storePathToFilePath SP.defaultStoreDir sp
         destPath = SP.storePathToText SP.defaultStoreDir sp
     wrapIO (copyToStoreIfMissing (T.unpack srcPath) destFilePath (takeDirectory destFilePath))
     pure destPath
@@ -399,8 +395,8 @@ instance MonadEval EvalIO where
       -- boundary rather than trusting the round trip.
       Left err -> throwEvalError ("builtins.path: internal NAR round-trip error: " <> T.pack err)
       Right entry -> do
-        let sp = makeFixedOutputPath name "sha256" "recursive" (sha256Digest narBytes)
-            destFilePath = SP.storePathToFilePath SP.defaultStoreDir sp
+        sp <- storePathOrThrow "builtins.path" (makeFixedOutputPath name "sha256" "recursive" (sha256Digest narBytes))
+        let destFilePath = SP.storePathToFilePath SP.defaultStoreDir sp
             destPath = SP.storePathToText SP.defaultStoreDir sp
         wrapIO $ do
           alreadyThere <- Dir.doesPathExist destFilePath
@@ -413,8 +409,8 @@ instance MonadEval EvalIO where
   addFixedOutputFile name bytes = do
     -- Canonical fixed-output path: a sha256-pinned fetch must land at the same
     -- store path C++ Nix computes, so it stays reproducible and cache-compatible.
-    let sp = makeFixedOutputPath name "sha256" "flat" (sha256Digest bytes)
-        filePath = SP.storePathToFilePath SP.defaultStoreDir sp
+    sp <- storePathOrThrow "builtins.fetchurl" (makeFixedOutputPath name "sha256" "flat" (sha256Digest bytes))
+    let filePath = SP.storePathToFilePath SP.defaultStoreDir sp
         storePath = SP.storePathToText SP.defaultStoreDir sp
     wrapIO $ do
       Dir.createDirectoryIfMissing True (takeDirectory filePath)

--- a/src/Nix/Eval/Types.hs
+++ b/src/Nix/Eval/Types.hs
@@ -106,6 +106,7 @@ module Nix.Eval.Types
     MonadEval (..),
     PureEval,
     runPureEval,
+    storePathOrThrow,
   )
 where
 
@@ -138,7 +139,7 @@ import Nix.Eval.Compile (compileExpr, compileFormalsToEval)
 import Nix.Eval.EvalFormals (EvalFormal (..), EvalFormals (..))
 import Nix.Eval.Symbol (Symbol (..), symbolBytes, symbolIntern, symbolInternBytes, symbolText)
 import Nix.Expr.Types (CaptureInfo (..), Expr (..), NixAtom (..))
-import Nix.Store.Path (StorePath (..))
+import Nix.Store.Path (StorePath (..), StorePathNameError, storePathNameErrorText)
 import System.IO.Unsafe (unsafePerformIO)
 import qualified Text.Regex.TDFA as RE
 
@@ -1224,6 +1225,16 @@ class (Monad m) => MonadEval m where
   -- performing the copy.  Used when a path literal is coerced in a derivation
   -- argument or environment value.  Unavailable in pure evaluation.
   storeSourcePath :: Text -> m Text
+
+-- | Unwrap a store-path construction result (the @makeStorePath@ family
+-- in "Nix.Hash"), converting a rejected name into an eval error under
+-- the given context prefix (e.g. @builtins.toFile@).  Every eval-side
+-- path construction goes through this or a bespoke equivalent, so a
+-- name rejection always surfaces as a clean eval error rather than an
+-- unchecked write path.
+storePathOrThrow :: (MonadEval m) => Text -> Either StorePathNameError StorePath -> m StorePath
+storePathOrThrow context =
+  either (throwEvalError . ((context <> ": ") <>) . storePathNameErrorText) pure
 
 -- | Error raised during pure evaluation.  'PThrow' (@builtins.throw@, a
 -- failed @assert@) is the only kind 'tryEval' catches; 'PError' (type

--- a/src/Nix/Hash.hs
+++ b/src/Nix/Hash.hs
@@ -68,7 +68,7 @@ import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Text.Encoding (encodeUtf8)
 import Data.Word (Word8)
-import Nix.Store.Path (StoreDir (..), StorePath (..), defaultStoreDir, storePathToText)
+import Nix.Store.Path (StoreDir (..), StorePath (..), StorePathNameError, checkStorePathName, defaultStoreDir, storePathToText)
 import NovaCache.Base32 (encode)
 import NovaCache.Hash (formatNixHash, hashBytes, parseNixHash)
 
@@ -204,25 +204,36 @@ base64HashLen n = 4 * ((n + 2) `div` 3)
 -- The @type@ string varies by caller: @\"text\"@ (+ references) for @.drv@
 -- and @toFile@ paths, @\"output:<id>\"@ for derivation outputs, @\"source\"@
 -- for recursive fixed-output paths.
-makeStorePath :: StoreDir -> Text -> BS.ByteString -> Text -> StorePath
+--
+-- 'Left' when the name breaks the store-path name rules
+-- ('checkStorePathName').  Construction validates like the parse boundary
+-- does, so every 'StorePath' that exists has a clean name: the write sinks
+-- downstream (store copies, the builder's delete-and-move) never see a
+-- path that resolves outside the store root, and no sink needs its own
+-- ad hoc name check.
+makeStorePath :: StoreDir -> Text -> BS.ByteString -> Text -> Either StorePathNameError StorePath
 makeStorePath (StoreDir dir) typ innerDigest name =
-  let preimage =
-        typ
-          <> ":sha256:"
-          <> bytesToHexText innerDigest
-          <> ":"
-          <> T.pack dir
-          <> ":"
-          <> name
-      compressed = compressHash storePathHashBytes (BS.unpack (sha256Digest (encodeUtf8 preimage)))
-   in StorePath (encode (BS.pack compressed)) name
+  case checkStorePathName name of
+    Left err -> Left err
+    Right () ->
+      let preimage =
+            typ
+              <> ":sha256:"
+              <> bytesToHexText innerDigest
+              <> ":"
+              <> T.pack dir
+              <> ":"
+              <> name
+          compressed = compressHash storePathHashBytes (BS.unpack (sha256Digest (encodeUtf8 preimage)))
+       in Right (StorePath (encode (BS.pack compressed)) name)
 
 -- | Construct a text store path (used for @.drv@ files and @builtins.toFile@).
 -- The references are embedded in the @type@ string - @\"text\"@ followed by
 -- each referenced store path - which is why a derivation's @.drv@ path depends
 -- on the paths of all its inputs.  @contentsDigest@ is the SHA-256 of the file
--- contents (the ATerm, for a @.drv@).
-makeTextPath :: Text -> BS.ByteString -> [StorePath] -> StorePath
+-- contents (the ATerm, for a @.drv@).  'Left' on an invalid name, as
+-- 'makeStorePath'.
+makeTextPath :: Text -> BS.ByteString -> [StorePath] -> Either StorePathNameError StorePath
 makeTextPath name contentsDigest refs =
   let sortedRefs = Set.toAscList (Set.fromList refs)
       typ = "text" <> T.concat [":" <> storePathToText defaultStoreDir r | r <- sortedRefs]
@@ -234,7 +245,9 @@ makeTextPath name contentsDigest refs =
 --
 -- * @sha256@ + @recursive@ yields @makeStorePath \"source\" foHash name@
 -- * otherwise, @makeStorePath \"output:out\" sha256(\"fixed:out:\" prefix algo \":\" hex \":\") name@
-makeFixedOutputPath :: Text -> Text -> Text -> BS.ByteString -> StorePath
+--
+-- 'Left' on an invalid name, as 'makeStorePath'.
+makeFixedOutputPath :: Text -> Text -> Text -> BS.ByteString -> Either StorePathNameError StorePath
 makeFixedOutputPath name algo mode foHashDigest
   | algo == "sha256" && mode == "recursive" =
       makeStorePath defaultStoreDir "source" foHashDigest name
@@ -246,8 +259,11 @@ makeFixedOutputPath name algo mode foHashDigest
 
 -- | Construct an input-addressed output store path.  @moduloDigest@ is the raw
 -- bytes of @hashDerivationModulo@ (masked).  Mirrors C++ Nix @makeOutputPath@:
--- the path name gets an @-<output>@ suffix for non-@out@ outputs.
-makeOutputPath :: Text -> BS.ByteString -> Text -> StorePath
+-- the path name gets an @-<output>@ suffix for non-@out@ outputs.  The
+-- composed name is what gets validated - a name and output each clean on
+-- their own can still compose past the length limit, so the check belongs
+-- here, after composition.  'Left' as 'makeStorePath'.
+makeOutputPath :: Text -> BS.ByteString -> Text -> Either StorePathNameError StorePath
 makeOutputPath outName moduloDigest drvName =
   let pathName = if outName == "out" then drvName else drvName <> "-" <> outName
    in makeStorePath defaultStoreDir ("output:" <> outName) moduloDigest pathName

--- a/src/Nix/Store.hs
+++ b/src/Nix/Store.hs
@@ -52,6 +52,9 @@ module Nix.Store
     writeDrv,
     writeDrvAterm,
 
+    -- * NAR entry-name safety
+    isSafeNarName,
+
     -- * Re-exports
     module Nix.Store.Path,
     module Nix.Store.DB,
@@ -61,6 +64,7 @@ where
 import Control.Exception (IOException, SomeException, catch, try)
 import Control.Monad (filterM, unless, when)
 import qualified Data.ByteString as BS
+import Data.Char (isDigit)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
@@ -421,14 +425,56 @@ createSymlink linkPath target = do
             )
         )
 
--- | Validate that a NAR entry name is safe (no path traversal).
+-- | Whether a NAR directory entry name is safe to materialize on every
+-- platform the store targets.  Two rejection classes:
+--
+-- 1. Path escapes: empty, @.@, @..@, a separator, a NUL (truncates the
+--    name in any NUL-terminated API downstream), or a @:@ - a
+--    drive-prefixed name like @C:evil@ makes 'System.FilePath.</>'
+--    discard the store prefix entirely.
+--
+-- 2. Names the Win32 path layer silently REWRITES rather than refuses,
+--    landing the bytes somewhere other than the named entry so the
+--    on-disk tree no longer reproduces the NAR hash that named it: an
+--    alternate-data-stream @:@ diverts the contents into a stream of
+--    another file, a reserved device stem (CON, PRN, AUX, NUL,
+--    COM0-COM9, LPT0-LPT9, plus the superscript-digit forms) addresses
+--    the device instead of a file, and a trailing dot or space is
+--    stripped on create, folding distinct NAR names onto one on-disk
+--    name.
+--
+-- Characters Windows merely REFUSES (@\"@, @*@, @<@, @>@, @|@) stay
+-- allowed: the create call fails loudly and the unpack loop surfaces
+-- the failure, which cannot misplace or corrupt anything.
 isSafeNarName :: Text -> Bool
 isSafeNarName name =
   not (T.null name)
     && name /= ".."
     && name /= "."
-    && not (T.isInfixOf "/" name)
-    && not (T.isInfixOf "\\" name)
+    && not (T.any escapesTree name)
+    && not (trailingRewritten name)
+    && not (reservedDeviceStem name)
+  where
+    escapesTree c = c == '/' || c == '\\' || c == ':' || c == '\0'
+    trailingRewritten n = case T.unsnoc n of
+      Just (_, end) -> end == '.' || end == ' '
+      Nothing -> False
+    -- Win32 device parsing takes the name up to the first dot as the
+    -- stem and ignores trailing spaces there ("NUL .txt" still
+    -- addresses NUL), so the stem is space-trimmed before comparison.
+    reservedDeviceStem n =
+      let stem = T.toUpper (T.dropWhileEnd (== ' ') (T.takeWhile (/= '.') n))
+       in stem == "CON"
+            || stem == "PRN"
+            || stem == "AUX"
+            || stem == "NUL"
+            || numberedDeviceStem stem
+    numberedDeviceStem stem = case T.unpack stem of
+      [a, b, c, digit] -> ([a, b, c] == "COM" || [a, b, c] == "LPT") && deviceDigit digit
+      _ -> False
+    -- Digits 0-9 plus the superscript forms ('\185' '\178' '\179') the
+    -- platform also reserves.
+    deviceDigit c = isDigit c || c == '\185' || c == '\178' || c == '\179'
 
 -- ---------------------------------------------------------------------------
 -- Eval source materialization
@@ -476,7 +522,7 @@ adoptedTreeMatches dest sp = do
   pure $ case result of
     Left (_ :: SomeException) -> False
     Right entry ->
-      makeFixedOutputPath (spName sp) "sha256" "recursive" (sha256Digest (NAR.serialise entry)) == sp
+      makeFixedOutputPath (spName sp) "sha256" "recursive" (sha256Digest (NAR.serialise entry)) == Right sp
 
 -- | Recursively copy a file or directory tree to a destination path.
 -- A symlink is replicated as a symlink: the store path's name came from a

--- a/src/Nix/Store/Path.hs
+++ b/src/Nix/Store/Path.hs
@@ -44,6 +44,14 @@ module Nix.Store.Path
     parseStorePath,
     parseStorePathBaseName,
 
+    -- * Name validation
+    StorePathNameError (..),
+    StorePathNameReason (..),
+    checkStorePathName,
+    validStorePathName,
+    storePathNameErrorText,
+    storePathNameReasonText,
+
     -- * Constants
     storePathHashLen,
   )
@@ -152,19 +160,48 @@ isNixBase32Char c =
   isDigit c
     || (isAsciiLower c && c /= 'e' && c /= 'o' && c /= 'u' && c /= 't')
 
--- | Upstream's store path name rules (its checkName parse boundary):
+-- | A rejected store-path name: the name itself plus the first rule it
+-- broke, so every boundary reports the same diagnosis.
+data StorePathNameError = StorePathNameError
+  { -- | The rejected name.
+    spneName :: !Text,
+    -- | The rule it broke.
+    spneReason :: !StorePathNameReason
+  }
+  deriving (Eq, Show)
+
+-- | The store-path name rules, one constructor per rule.
+data StorePathNameReason
+  = -- | The name is empty.
+    NameEmpty
+  | -- | The name exceeds 'maxStorePathNameLen'; carries the actual length.
+    NameTooLong !Int
+  | -- | The name contains a character outside @[A-Za-z0-9+._?=-]@.
+    NameIllegalChar !Char
+  | -- | The first dash-separated component is the carried @.@ or @..@,
+    -- which would name a dot segment on disk.
+    NameDotSegment !Text
+  deriving (Eq, Show)
+
+-- | Upstream's store path name rules (its checkName boundary):
 -- 1-211 characters from @[A-Za-z0-9+._?=-]@, and the first dash-separated
 -- component may not be @.@ or @..@.  One rule rejects the traversal names
 -- and their @.-@ / @..-@ prefixed forms alike, while other dot-leading
 -- names (@.config-1.0@) stay valid.
-validStorePathName :: Text -> Bool
-validStorePathName name =
-  not (T.null name)
-    && T.length name <= maxStorePathNameLen
-    && firstDashComponent /= "."
-    && firstDashComponent /= ".."
-    && T.all isStorePathNameChar name
+--
+-- Enforced at BOTH boundaries: parse ('parseStorePathBaseName') and
+-- construction (the @makeStorePath@ family in "Nix.Hash"), so an unclean
+-- name cannot become a 'StorePath' from either side - in particular, no
+-- write sink can be handed a path that resolves outside the store root.
+checkStorePathName :: Text -> Either StorePathNameError ()
+checkStorePathName name
+  | T.null name = broke NameEmpty
+  | T.length name > maxStorePathNameLen = broke (NameTooLong (T.length name))
+  | firstDashComponent == "." || firstDashComponent == ".." = broke (NameDotSegment firstDashComponent)
+  | Just c <- T.find (not . isStorePathNameChar) name = broke (NameIllegalChar c)
+  | otherwise = Right ()
   where
+    broke = Left . StorePathNameError name
     firstDashComponent = T.takeWhile (/= '-') name
     isStorePathNameChar c =
       isAsciiLower c
@@ -176,6 +213,29 @@ validStorePathName name =
         || c == '?'
         || c == '='
         || c == '-'
+
+-- | Boolean form of 'checkStorePathName', for the parse boundary.
+validStorePathName :: Text -> Bool
+validStorePathName = either (const False) (const True) . checkStorePathName
+
+-- | Render a rejection as @invalid store path name '<name>': <rule>@.
+storePathNameErrorText :: StorePathNameError -> Text
+storePathNameErrorText (StorePathNameError name reason) =
+  "invalid store path name '" <> name <> "': " <> storePathNameReasonText reason
+
+-- | Render just the broken rule, for callers that frame the name
+-- themselves (e.g. @invalid derivation output name@).
+storePathNameReasonText :: StorePathNameReason -> Text
+storePathNameReasonText reason = case reason of
+  NameEmpty -> "the name is empty"
+  NameTooLong len ->
+    "the name is "
+      <> T.pack (show len)
+      <> " characters, above the "
+      <> T.pack (show maxStorePathNameLen)
+      <> " maximum"
+  NameIllegalChar c -> "contains the illegal character " <> T.pack (show c)
+  NameDotSegment seg -> "the first dash-separated component may not be '" <> seg <> "'"
 
 -- | Upstream's maximum store path name length.
 maxStorePathNameLen :: Int

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -46,7 +46,7 @@ import qualified Nix.Hash as Hash
 import Nix.Parser (parseNix)
 import Nix.Parser.Lexer (Located (..), Token (..), tokenize)
 import Nix.Push (checkRecordedNarHash, computeClosure, loadApiKeyFile, mkNarInfo, narFileName, planMissing, storePathBasename, stripHashPrefix)
-import Nix.Store (Store (..), addToStore, closeStore, isValid, materializeEvalSources, openStore, pathExists, scanReferences, scanTempReferences, setReadOnly, writeDrv)
+import Nix.Store (Store (..), addToStore, closeStore, isSafeNarName, isValid, materializeEvalSources, openStore, pathExists, scanReferences, scanTempReferences, setReadOnly, writeDrv)
 import Nix.Store.DB (PathInfo (..), PathRegistration (..), closeStoreDB, isValidPath, openStoreDB, queryDeriver, queryPathInfo, queryReferences, registerPath, registerPaths)
 import Nix.Store.Path (StoreDir (..), StorePath (..), defaultStoreDir, parseStorePath, platformStoreDirText, storePathToFilePath, storePathToText, windowsStoreDir)
 import qualified Nix.Substituter as Subst
@@ -4575,21 +4575,23 @@ testStoreOps = do
           createDirectoryIfMissing True srcDir
           TIO.writeFile (srcDir </> "data.txt") "real content"
           entry <- NAR.serialiseFromPath srcDir
-          let sp = makeFixedOutputPath "nova-nix-test-adopt-src" "sha256" "recursive" (sha256Digest (NAR.serialise entry))
-              spText = storePathToText defaultStoreDir sp
-              dest = storePathToFilePath (stDir store) sp
-          -- Fake an interrupted earlier copy: wrong partial content.
-          removeIfExists dest
-          createDirectoryIfMissing True dest
-          TIO.writeFile (dest </> "data.txt") "partial garbage"
-          materializeEvalSources store (Map.fromList [(T.pack srcDir, spText)])
-          adopted <- TIO.readFile (dest </> "data.txt")
-          registered <- isValid store sp
-          removeIfExists srcDir
-          pure $
-            if adopted == "real content" && registered
-              then Pass
-              else Fail ("expected re-copied content, got: " <> adopted),
+          case makeFixedOutputPath "nova-nix-test-adopt-src" "sha256" "recursive" (sha256Digest (NAR.serialise entry)) of
+            Left err -> pure (Fail ("test store path rejected: " <> T.pack (show err)))
+            Right sp -> do
+              let spText = storePathToText defaultStoreDir sp
+                  dest = storePathToFilePath (stDir store) sp
+              -- Fake an interrupted earlier copy: wrong partial content.
+              removeIfExists dest
+              createDirectoryIfMissing True dest
+              TIO.writeFile (dest </> "data.txt") "partial garbage"
+              materializeEvalSources store (Map.fromList [(T.pack srcDir, spText)])
+              adopted <- TIO.readFile (dest </> "data.txt")
+              registered <- isValid store sp
+              removeIfExists srcDir
+              pure $
+                if adopted == "real content" && registered
+                  then Pass
+                  else Fail ("expected re-copied content, got: " <> adopted),
         -- A tree that DOES reproduce its store path is adopted untouched.
         -- The source is deleted before the call: adoption never reads it,
         -- so a wrongful re-copy attempt throws and fails the test.
@@ -4600,16 +4602,18 @@ testStoreOps = do
           createDirectoryIfMissing True srcDir
           TIO.writeFile (srcDir </> "data.txt") "same bytes"
           entry <- NAR.serialiseFromPath srcDir
-          let sp = makeFixedOutputPath "nova-nix-test-adopt-ok" "sha256" "recursive" (sha256Digest (NAR.serialise entry))
-              spText = storePathToText defaultStoreDir sp
-              dest = storePathToFilePath (stDir store) sp
-          removeIfExists dest
-          createDirectoryIfMissing True dest
-          TIO.writeFile (dest </> "data.txt") "same bytes"
-          removeIfExists srcDir
-          materializeEvalSources store (Map.fromList [(T.pack srcDir, spText)])
-          registered <- isValid store sp
-          pure (if registered then Pass else Fail "matching tree was not adopted and registered"),
+          case makeFixedOutputPath "nova-nix-test-adopt-ok" "sha256" "recursive" (sha256Digest (NAR.serialise entry)) of
+            Left err -> pure (Fail ("test store path rejected: " <> T.pack (show err)))
+            Right sp -> do
+              let spText = storePathToText defaultStoreDir sp
+                  dest = storePathToFilePath (stDir store) sp
+              removeIfExists dest
+              createDirectoryIfMissing True dest
+              TIO.writeFile (dest </> "data.txt") "same bytes"
+              removeIfExists srcDir
+              materializeEvalSources store (Map.fromList [(T.pack srcDir, spText)])
+              registered <- isValid store sp
+              pure (if registered then Pass else Fail "matching tree was not adopted and registered"),
         -- scanReferences finds the canonical /nix/store text eval injects
         -- into builder envs, independent of the platform store dir (the
         -- bare hash is the needle, matching upstream Nix).
@@ -6097,6 +6101,159 @@ testValueCountWidths = do
           (VInt 70000)
     ]
 
+-- ---------------------------------------------------------------------------
+-- Tests: Class B name validation at write sinks (issue #39)
+-- ---------------------------------------------------------------------------
+
+-- | Class B (issue #39): the store-path name rules hold at path
+-- CONSTRUCTION, not only at parse.  Derivation names, output names, and
+-- fetchurl basenames reject exactly what the parse boundary rejects,
+-- before any write path is built from them - and names the old ad hoc
+-- sink checks over-rejected (an interior @..@) are valid again.
+testStoreNameSinks :: IO [Bool]
+testStoreNameSinks = do
+  putStrLn "store/name-sinks"
+  let drvWith nameLit =
+        "(derivation { name = " <> nameLit <> "; system = \"x86_64-linux\"; builder = \"/bin/sh\"; }).drvPath"
+      drvOutPath nameLit =
+        "(derivation { name = " <> nameLit <> "; system = \"x86_64-linux\"; builder = \"/bin/sh\"; }).outPath"
+      drvWithOutputs outsLit =
+        "(derivation { name = \"p\"; system = \"x86_64-linux\"; builder = \"/bin/sh\"; outputs = " <> outsLit <> "; }).drvPath"
+      failsWith label source needle = case evalNix source of
+        Left err
+          | parseErrorTag `T.isPrefixOf` err -> Fail (label <> ": did not parse: " <> err)
+          | needle `T.isInfixOf` err -> Pass
+          | otherwise -> Fail (label <> ": wrong error: " <> err)
+        Right val -> Fail (label <> ": expected an eval error, got " <> T.pack (show val))
+      succeedsWithSuffix label source suffix = case evalNix source of
+        Left err -> Fail (label <> ": unexpected error: " <> err)
+        Right (VStr s _) ->
+          if TE.encodeUtf8 suffix `BS.isSuffixOf` s
+            then Pass
+            else Fail (label <> ": expected suffix " <> suffix <> ", got " <> bytesText s)
+        Right other -> Fail (label <> ": expected VStr, got " <> T.pack (show other))
+  sequence
+    [ runTest "derivation name with a space is rejected" $
+        failsWith "name-space" (drvWith "\"a b\"") "invalid derivation name",
+      runTest "derivation name with a slash is rejected" $
+        failsWith "name-slash" (drvWith "\"a/b\"") "invalid derivation name",
+      runTest "derivation name with a backslash is rejected" $
+        failsWith "name-backslash" (drvWith "\"a\\\\b\"") "invalid derivation name",
+      runTest "derivation name with a drive colon is rejected" $
+        failsWith "name-colon" (drvWith "\"C:x\"") "invalid derivation name",
+      runTest "empty derivation name is rejected" $
+        failsWith "name-empty" (drvWith "\"\"") "the name is empty",
+      runTest "212-character derivation name is rejected" $
+        failsWith "name-long" (drvWith ("\"" <> T.replicate 212 "a" <> "\"")) "above the 211 maximum",
+      runTest "derivation name '..' is rejected" $
+        failsWith "name-dotdot" (drvWith "\"..\"") "dash-separated component",
+      runTest "derivation name '.-x' is rejected" $
+        failsWith "name-dotdash" (drvWith "\".-x\"") "dash-separated component",
+      runTest "dotfile derivation name stays valid" $
+        succeedsWithSuffix "name-dotfile" (drvWith "\".foo-1.0\"") "-.foo-1.0.drv",
+      runTest "interior '..' in a derivation name stays valid" $
+        succeedsWithSuffix "name-interior-dots" (drvOutPath "\"x..y\"") "-x..y",
+      runTest "derivation output name with a traversal is rejected" $
+        failsWith "out-traversal" (drvWithOutputs "[ \"out\" \"../x\" ]") "invalid derivation output name",
+      runTest "derivation output name with a colon is rejected" $
+        failsWith "out-colon" (drvWithOutputs "[ \"a:b\" ]") "invalid derivation output name",
+      -- Both fields clean on their own, only the COMPOSED drvName-output
+      -- crosses the length cap: the construction-side check catches what
+      -- the field-level checks cannot.
+      runTest "composed name-output past the length cap is rejected" $
+        failsWith
+          "composed-long"
+          ( "(derivation { name = \""
+              <> T.replicate 208 "a"
+              <> "\"; system = \"x86_64-linux\"; builder = \"/bin/sh\"; outputs = [ \"dev\" ]; }).drvPath"
+          )
+          "invalid store path name",
+      -- fetchurl derives the store name from the URL alone, so a bad
+      -- basename fails BEFORE the download: under PureEval a reachable
+      -- download would surface as "runProcess: not available" instead.
+      runTest "fetchurl rejects a backslash basename before fetching" $
+        failsWith "fetchurl-backslash" "builtins.fetchurl \"http://e/a\\\\b\"" "invalid store path name",
+      runTest "fetchurl rejects a dot-segment basename before fetching" $
+        failsWith "fetchurl-dotdot" "builtins.fetchurl \"http://e/..\"" "invalid store path name"
+    ]
+
+-- | The NAR entry-name check: rejects what escapes the tree and what the
+-- Win32 path layer silently rewrites (stream colons, device stems,
+-- trailing dot or space); ordinary names pass, including ones Windows
+-- merely refuses loudly.
+testNarNameSafety :: IO [Bool]
+testNarNameSafety = do
+  putStrLn "store/nar-name-safety"
+  let rejects name = if isSafeNarName name then Fail ("expected rejection: " <> T.pack (show name)) else Pass
+      accepts name = if isSafeNarName name then Pass else Fail ("expected acceptance: " <> T.pack (show name))
+      allOf = foldr keepFirstFail Pass
+      keepFirstFail Pass acc = acc
+      keepFirstFail failure _ = failure
+  sequence
+    [ runTest "empty and dot names are rejected" $
+        allOf [rejects "", rejects ".", rejects ".."],
+      runTest "separators are rejected" $
+        allOf [rejects "a/b", rejects "a\\b"],
+      runTest "an embedded NUL is rejected" $
+        rejects "a\NULb",
+      runTest "colons are rejected (drive prefix and stream form)" $
+        allOf [rejects "C:evil", rejects "a:b", rejects ":"],
+      runTest "reserved device stems are rejected case-insensitively" $
+        allOf [rejects "NUL", rejects "nul.txt", rejects "CON", rejects "com3", rejects "COM0.log", rejects "lpt9"],
+      runTest "a space-padded device stem is rejected" $
+        rejects "Nul .txt",
+      runTest "a superscript-digit device stem is rejected" $
+        rejects "COM\185",
+      runTest "a trailing dot or space is rejected" $
+        allOf [rejects "x.", rejects "x "],
+      runTest "ordinary names pass" $
+        allOf [accepts "a", accepts ".hidden", accepts "a.b", accepts "a b", accepts " a"],
+      runTest "near-miss device names pass" $
+        allOf [accepts "com10", accepts "COM", accepts "NULx", accepts "xNUL.txt"],
+      runTest "a loud-refuse character stays allowed" $
+        accepts "a\"b"
+    ]
+
+-- | IO-evaluator write sinks reject an invalid name BEFORE any write:
+-- every case here errors out against a scratch dir with no store traffic.
+testStoreNameSinksIO :: IO [Bool]
+testStoreNameSinksIO = do
+  putStrLn "store/name-sinks-io"
+  tmpBase <- getTemporaryDirectory
+  let testDir = tmpBase </> "nova-nix-test-name-sinks"
+      needleTest label source needle = do
+        result <- evalNixIO testDir source
+        runTest label $ case result of
+          Left err
+            | needle `T.isInfixOf` err -> Pass
+            | otherwise -> Fail (label <> ": wrong error: " <> err)
+          Right val -> Fail (label <> ": expected an eval error, got " <> T.pack (show val))
+  bracket_
+    ( do
+        createDirectoryIfMissing True (testDir </> "tree")
+        TIO.writeFile (testDir </> "tree" </> "f.txt") "payload\n"
+    )
+    ( do
+        exists <- doesDirectoryExist testDir
+        when exists (removeDirectoryRecursive testDir)
+    )
+    $ sequence
+      [ needleTest "toFile rejects a stream-colon name" "builtins.toFile \"a:b\" \"x\"" "invalid store path name",
+        needleTest "toFile rejects a dot-segment name" "builtins.toFile \"..\" \"x\"" "invalid store path name",
+        needleTest
+          "path rejects a traversal name override"
+          "builtins.path { path = ./tree; name = \"../../evil\"; }"
+          "invalid store path name",
+        needleTest
+          "path with a filter rejects a drive-prefixed name"
+          "builtins.path { path = ./tree; name = \"C:evil\"; filter = (_: _: true); }"
+          "invalid store path name",
+        needleTest
+          "source coercion rejects a basename outside the name rules"
+          "\"${./. + \"/sp ace\"}\""
+          "invalid store path name"
+      ]
+
 testBytecodeCompile :: IO [Bool]
 testBytecodeCompile = do
   putStrLn "bytecode"
@@ -6935,6 +7092,9 @@ main = bracket_ arenaInit arenaDestroy $ do
           testBytecodeCompile,
           testBytecodeCountSpill,
           testValueCountWidths,
+          testStoreNameSinks,
+          testNarNameSafety,
+          testStoreNameSinksIO,
           testClassIFollowups,
           testClassIFollowupsIO
         ]


### PR DESCRIPTION
Closes #39.

Store-path names were validated only where paths are PARSED; the
construction side trusted its callers, and the write sinks each carried
(or lacked) their own ad hoc check.  A name like ../../x or C:x reaching
builtins.path, fetchurl, or a derivation's output list produced a path
that resolves outside the store root - and the builder clears and moves
onto output paths, so an unvalidated output name directed that
delete-and-move at an out-of-store location (H2, N7, N8).  The NAR
entry-name check missed NUL, drive prefixes, stream colons, device
names, and trailing dot/space, so a crafted NAR could unpack entries
outside the tree or onto silently rewritten on-disk names whose bytes no
longer reproduce the declared NAR hash (H3, P4-win1).

- checkStorePathName is the one canonical validator (upstream's
  checkName rules: 1-211 chars of [A-Za-z0-9+._?=-], first
  dash-separated component not . or ..), now enforced at BOTH
  boundaries: parseStorePathBaseName keeps using it, and the
  makeStorePath family returns Either, so no construction can skip it
  and every StorePath that exists has a clean name.  makeOutputPath
  validates the COMPOSED drvName-output name, which field-level checks
  cannot cover (each side clean, composition past the length cap).
- derivationStrict validates the name and each output name at the field
  level for precise errors ("invalid derivation name 'a b'") before any
  hashing; fetchurl validates the URL basename before the download side
  effect.
- writeToStore and copyPathToStore drop their ad hoc checks for the
  shared one.  The ad hoc infix-'..' rejection was also stricter than
  upstream: interior dots (x..y) are valid store names again.
- isSafeNarName now rejects the two classes that matter: names that
  escape the tree (separators, NUL, drive-prefix colon) and names the
  Win32 path layer silently rewrites rather than refuses (stream
  colons, reserved device stems including space-padded and
  superscript-digit forms, trailing dot or space).  Characters Windows
  merely refuses loudly stay allowed - the create fails and the unpack
  loop surfaces it.
- The nova-cache checkName side of the same class is
  Novavero-AI/nova-cache#17.

Tests: store/name-sinks (field, construction, and composition
rejections plus the accept cases upstream allows), store/nar-name-safety
(the entry-name matrix), store/name-sinks-io (every IO sink errors
before any write).

Bench (nixpkgs attrNames, -M4G): allocation +0.009%, max residency
-0.08% vs baseline; productivity and GC time within the run-to-run
spread.