### PR TITLE
Audit class D: bound input-sized materialization

### DIFF
--- a/src/Nix/Builder.hs
+++ b/src/Nix/Builder.hs
@@ -48,7 +48,6 @@ where
 import Control.Exception (IOException, SomeException, displayException, finally, try)
 import Control.Monad (filterM, when)
 import qualified Data.ByteString as BS
-import qualified Data.ByteString.Lazy as LBS
 import Data.Char (toLower)
 import Data.Either (fromRight)
 import Data.Map.Strict (Map)
@@ -62,11 +61,11 @@ import qualified Data.Text.IO as TIO
 import qualified Network.HTTP.Client as HTTP
 import qualified Network.HTTP.Client.TLS as HTTPS
 import qualified Network.HTTP.Types.Status as HTTP
-import Nix.Builder.Unpack (builtinUnpackBuilder, runBuiltinUnpack)
+import Nix.Builder.Unpack (UnpackLimits, builtinUnpackBuilder, defaultUnpackLimits, runBuiltinUnpack)
 import Nix.DependencyGraph (DepGraph, TopoResult (..), buildDepGraph, topoSort)
 import qualified Nix.DependencyGraph
 import Nix.Derivation (Derivation (..), DerivationOutput (..), fromATerm)
-import Nix.Hash (bytesToHexText, hexToBytes, rawHashWithAlgo)
+import Nix.Hash (IncrementalHash, bytesToHexText, hashFinalizeBytes, hashInitWithAlgo, hashUpdateChunk, hexToBytes, rawHashWithAlgo)
 import Nix.Store (PathRegistration, Store (..), isValid, placeInStore, registerPaths, scanReferences, scanTempReferences)
 import Nix.Store.Path (StoreDir (..), StorePath (..), storePathToFilePath)
 import Nix.Substituter (CacheConfig, SubstResult (..), trySubstitute)
@@ -149,7 +148,9 @@ data BuildConfig = BuildConfig
     -- | Enable sandboxing (not yet implemented on Windows).
     bcSandbox :: !Bool,
     -- | Binary caches to try before building (checked in priority order).
-    bcCaches :: ![CacheConfig]
+    bcCaches :: ![CacheConfig],
+    -- | Extraction budget for @builtin:unpack@ builds.
+    bcUnpackLimits :: !UnpackLimits
   }
   deriving (Eq, Show)
 
@@ -167,7 +168,8 @@ defaultBuildConfig dir =
           then "bash" -- rely on PATH (MSYS2/Git Bash)
           else "/bin/bash",
       bcSandbox = False,
-      bcCaches = []
+      bcCaches = [],
+      bcUnpackLimits = defaultUnpackLimits
     }
 
 -- | Result of a build attempt.
@@ -227,7 +229,7 @@ buildDerivationInner config store drv = do
         exitResult <- case drvBuilder drv of
           b
             | b == builtinFetchurlBuilder -> runBuiltinFetchurl drv outputDirs
-            | b == builtinUnpackBuilder -> runBuiltinUnpack drv outputDirs
+            | b == builtinUnpackBuilder -> runBuiltinUnpack (bcUnpackLimits config) drv outputDirs
           _ -> case decodeBuilderStrings drv of
             Left errMsg -> pure (Left (1, errMsg))
             Right (builderText, argTexts, decodedEnv) ->
@@ -492,13 +494,19 @@ runBuiltinFetchurl drv outputDirs =
     (_, _, Nothing) -> pure (Left (1, "builtin:fetchurl: 'out' output has no fixed-output hash"))
     (Just urlBytes, Just outPath, Just out) -> case TE.decodeUtf8' urlBytes of
       Left _ -> pure (Left (1, "builtin:fetchurl: 'url' contains invalid UTF-8"))
-      Right url -> do
-        downloaded <- downloadUrl url
-        case downloaded of
-          Left err -> pure (Left (1, "builtin:fetchurl: " <> err))
-          Right body -> do
-            BS.writeFile outPath body
-            pure (verifyFetchHash url out body)
+      Right url
+        -- Mode and algorithm reject before any network traffic.
+        | recursive -> pure (Left (1, recursiveUnsupportedMessage))
+        | otherwise -> case hashInitWithAlgo algo of
+            Nothing ->
+              pure (Left (1, "builtin:fetchurl: unsupported hash algorithm '" <> algo <> "'"))
+            Just ctx -> do
+              downloaded <- downloadUrlTo url outPath ctx
+              case downloaded of
+                Left err -> pure (Left (1, "builtin:fetchurl: " <> err))
+                Right digest -> pure (verifyFetchedDigest url out digest)
+        where
+          (recursive, algo) = splitHashMode (doHashAlgo out)
   where
     -- builtin:fetchurl derivations are always fixed-output; the expected hash
     -- lives in the canonical output spec (doHashAlgo + doHash), not the env.
@@ -506,12 +514,15 @@ runBuiltinFetchurl drv outputDirs =
       (out : _) | not (T.null (doHashAlgo out)) -> Just out
       _ -> Nothing
 
--- | Download a URL to a strict 'BS.ByteString' using nova-nix's own linked
--- HTTP client (the same 'Network.HTTP.Client' the substituter uses) - no
--- external @curl@, which is what makes this a genuine builtin.  Any network
--- exception is turned into a 'Left' so it becomes a clean build failure.
-downloadUrl :: Text -> IO (Either Text BS.ByteString)
-downloadUrl url = do
+-- | Download a URL to a file using nova-nix's own linked HTTP client
+-- (the same 'Network.HTTP.Client' the substituter uses) - no external
+-- @curl@, which is what makes this a genuine builtin.  The body streams
+-- to disk through the incremental hash chunk by chunk, so memory stays
+-- at chunk size no matter the download's size, and the returned digest
+-- is of exactly the written bytes.  Any network exception is turned
+-- into a 'Left' so it becomes a clean build failure.
+downloadUrlTo :: Text -> FilePath -> IncrementalHash -> IO (Either Text BS.ByteString)
+downloadUrlTo url outPath ctx0 = do
   attempt <- try fetch
   pure $ case attempt of
     Left (e :: SomeException) -> Left ("download error: " <> T.pack (show e))
@@ -522,13 +533,19 @@ downloadUrl url = do
       manager <- HTTP.newManager HTTPS.tlsManagerSettings
       request0 <- HTTP.parseRequest (T.unpack url)
       let request = request0 {HTTP.requestHeaders = ("User-Agent", fetchUserAgent) : HTTP.requestHeaders request0}
-      response <- HTTP.httpLbs request manager
-      pure (bodyOrError response)
-    bodyOrError response
-      | code == httpStatusOk = Right (LBS.toStrict (HTTP.responseBody response))
-      | otherwise = Left ("HTTP " <> T.pack (show code) <> " fetching " <> url)
-      where
-        code = HTTP.statusCode (HTTP.responseStatus response)
+      HTTP.withResponse request manager $ \response -> do
+        let code = HTTP.statusCode (HTTP.responseStatus response)
+        if code /= httpStatusOk
+          then pure (Left ("HTTP " <> T.pack (show code) <> " fetching " <> url))
+          else System.IO.withBinaryFile outPath System.IO.WriteMode $ \handle ->
+            let consume !ctx = do
+                  chunk <- HTTP.brRead (HTTP.responseBody response)
+                  if BS.null chunk
+                    then pure (Right (hashFinalizeBytes ctx))
+                    else do
+                      BS.hPut handle chunk
+                      consume (hashUpdateChunk ctx chunk)
+             in consume ctx0
 
 -- | Verify the fetched bytes against the derivation's fixed-output hash, read
 -- from the canonical output spec.  @doHashAlgo@ is @sha256@/@sha512@/... (or
@@ -538,32 +555,52 @@ downloadUrl url = do
 -- the download - and fail with a clear message rather than a wrong result.
 verifyFetchHash :: Text -> DerivationOutput -> BS.ByteString -> Either (Int, Text) ()
 verifyFetchHash url out body
-  | recursive =
-      Left (1, "builtin:fetchurl: recursive outputHashMode (unpack/executable) not yet supported; fetch flat and unpack in a build phase")
+  | recursive = Left (1, recursiveUnsupportedMessage)
   | otherwise = case (hexToBytes (doHash out), rawHashWithAlgo algo body) of
-      (Nothing, _) -> Left (1, "builtin:fetchurl: malformed expected hash for " <> url)
+      (Nothing, _) -> Left (1, malformedExpectedHash url)
       (_, Nothing) -> Left (1, "builtin:fetchurl: unsupported hash algorithm '" <> algo <> "'")
-      (Just expected, Just got)
-        | expected == got -> Right ()
-        | otherwise ->
-            Left
-              ( 1,
-                "builtin:fetchurl: hash mismatch for "
-                  <> url
-                  <> "\n  expected: "
-                  <> algoField
-                  <> ":"
-                  <> doHash out
-                  <> "\n  got:      "
-                  <> algoField
-                  <> ":"
-                  <> bytesToHexText got
-              )
+      (Just _, Just got) -> verifyFetchedDigest url out got
+  where
+    (recursive, algo) = splitHashMode (doHashAlgo out)
+
+-- | Compare an already-computed digest of the fetched bytes against the
+-- derivation's fixed-output hash - the streaming twin of
+-- 'verifyFetchHash', which hashes a buffered body.
+verifyFetchedDigest :: Text -> DerivationOutput -> BS.ByteString -> Either (Int, Text) ()
+verifyFetchedDigest url out got = case hexToBytes (doHash out) of
+  Nothing -> Left (1, malformedExpectedHash url)
+  Just expected
+    | expected == got -> Right ()
+    | otherwise ->
+        Left
+          ( 1,
+            "builtin:fetchurl: hash mismatch for "
+              <> url
+              <> "\n  expected: "
+              <> algoField
+              <> ":"
+              <> doHash out
+              <> "\n  got:      "
+              <> algoField
+              <> ":"
+              <> bytesToHexText got
+          )
   where
     algoField = doHashAlgo out
-    (recursive, algo) = case T.stripPrefix "r:" algoField of
-      Just rest -> (True, rest)
-      Nothing -> (False, algoField)
+
+-- | Split @outputHashAlgo@ into the recursive-mode marker and the bare
+-- algorithm name (@r:sha256@ is recursive @sha256@).
+splitHashMode :: Text -> (Bool, Text)
+splitHashMode algoField = case T.stripPrefix "r:" algoField of
+  Just rest -> (True, rest)
+  Nothing -> (False, algoField)
+
+recursiveUnsupportedMessage :: Text
+recursiveUnsupportedMessage =
+  "builtin:fetchurl: recursive outputHashMode (unpack/executable) not yet supported; fetch flat and unpack in a build phase"
+
+malformedExpectedHash :: Text -> Text
+malformedExpectedHash url = "builtin:fetchurl: malformed expected hash for " <> url
 
 -- ---------------------------------------------------------------------------
 -- Output registration

--- a/src/Nix/Builder/Unpack.hs
+++ b/src/Nix/Builder/Unpack.hs
@@ -39,6 +39,10 @@ module Nix.Builder.Unpack
     -- * Derivation environment keys
     envSrcs,
 
+    -- * Extraction budget
+    UnpackLimits (..),
+    defaultUnpackLimits,
+
     -- * Running
     runBuiltinUnpack,
 
@@ -57,6 +61,7 @@ import Data.Bits ((.&.))
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BL
 import Data.Char (toLower)
+import Data.Int (Int64)
 import Data.List (isPrefixOf, isSuffixOf)
 import qualified Data.Map.Strict as Map
 import Data.Text (Text)
@@ -69,6 +74,7 @@ import System.Directory
     doesDirectoryExist,
     doesFileExist,
     doesPathExist,
+    getFileSize,
     getPermissions,
     listDirectory,
     setOwnerExecutable,
@@ -97,6 +103,37 @@ envSrcs = "srcs"
 -- | Name of the output the merged tree is extracted into.
 unpackOutputName :: Text
 unpackOutputName = "out"
+
+-- | Extraction budget for one @builtin:unpack@ build, across every
+-- archive in @srcs@: total bytes materialized and total filesystem
+-- entries created.  Archive bytes decompress and expand with no
+-- relation to their compressed size, so extraction without a budget
+-- lets a small input produce an output with no upper bound.
+data UnpackLimits = UnpackLimits
+  { ulMaxBytes :: !Int64,
+    ulMaxEntries :: !Int
+  }
+  deriving (Eq, Show)
+
+-- | Default extraction budget: 4 GiB and one million entries.  The
+-- MSYS2 toolchain seed decompresses to well under half of either, and
+-- 4 GiB matches the largest NAR nova-cache's server accepts.
+defaultUnpackLimits :: UnpackLimits
+defaultUnpackLimits =
+  UnpackLimits
+    { ulMaxBytes = 4 * 1024 * 1024 * 1024,
+      ulMaxEntries = 1000000
+    }
+
+-- | Charge one created entry plus its bytes against the remaining
+-- budget; a breached budget is a loud extraction failure.
+chargeBudget :: Text -> Int64 -> UnpackLimits -> Either Text UnpackLimits
+chargeBudget label bytes (UnpackLimits remainingBytes remainingEntries)
+  | remainingEntries < 1 =
+      Left ("extraction exceeds the entry budget at: " <> label)
+  | bytes > remainingBytes =
+      Left ("extraction exceeds the size budget at: " <> label)
+  | otherwise = Right (UnpackLimits (remainingBytes - bytes) (remainingEntries - 1))
 
 -- | Owner-execute bit of a tar header's mode field (octal @0o100@).
 ownerExecuteMode :: TarEntry.Permissions
@@ -139,8 +176,8 @@ type DecodeError = Either Tar.FormatError Tar.DecodeLongNamesError
 -- @Either (exit, msg) ()@ shape as the process runner, so the shared
 -- output-validation and registration path in "Nix.Builder" is reused
 -- unchanged.
-runBuiltinUnpack :: Derivation -> [(Text, FilePath)] -> IO (Either (Int, Text) ())
-runBuiltinUnpack drv outputDirs =
+runBuiltinUnpack :: UnpackLimits -> Derivation -> [(Text, FilePath)] -> IO (Either (Int, Text) ())
+runBuiltinUnpack limits drv outputDirs =
   case (Map.lookup envSrcs (drvEnv drv), lookup unpackOutputName outputDirs) of
     (Nothing, _) -> failure "derivation has no 'srcs'"
     (Just srcsBytes, mOutDir) -> case TE.decodeUtf8' srcsBytes of
@@ -152,7 +189,7 @@ runBuiltinUnpack drv outputDirs =
             Nothing -> failure "derivation defines no 'out' output"
             Just outDir -> do
               createDirectoryIfMissing True outDir
-              result <- unpackAll outDir (sourcePaths srcs)
+              result <- unpackAll outDir limits (sourcePaths srcs)
               pure $ case result of
                 Left msg -> Left (1, "builtin:unpack: " <> msg)
                 Right () -> Right ()
@@ -160,21 +197,24 @@ runBuiltinUnpack drv outputDirs =
     failure msg = pure (Left (1, "builtin:unpack: " <> msg))
     sourcePaths = map T.unpack . T.words
 
--- | Extract archives in order, stopping at the first failure.
-unpackAll :: FilePath -> [FilePath] -> IO (Either Text ())
-unpackAll _ [] = pure (Right ())
-unpackAll outDir (archive : rest) = do
-  result <- unpackArchive outDir archive
+-- | Extract archives in order, stopping at the first failure.  One
+-- budget spans all of them: the caps bound the BUILD's output, not any
+-- single archive.
+unpackAll :: FilePath -> UnpackLimits -> [FilePath] -> IO (Either Text ())
+unpackAll _ _ [] = pure (Right ())
+unpackAll outDir budget (archive : rest) = do
+  result <- unpackArchive outDir budget archive
   case result of
     Left err -> pure (Left err)
-    Right () -> unpackAll outDir rest
+    Right remaining -> unpackAll outDir remaining rest
 
--- | Unpack one archive into @outDir@.  The decompressor is chosen by file
--- extension; the tar stream is decoded (GNU + pax long names) and extracted
--- entry by entry.  Decompression errors surface lazily mid-stream, so the
--- whole extraction is exception-wrapped into a clean failure.
-unpackArchive :: FilePath -> FilePath -> IO (Either Text ())
-unpackArchive outDir archivePath = do
+-- | Unpack one archive into @outDir@, returning the budget left for the
+-- archives after it.  The decompressor is chosen by file extension; the
+-- tar stream is decoded (GNU + pax long names) and extracted entry by
+-- entry.  Decompression errors surface lazily mid-stream, so the whole
+-- extraction is exception-wrapped into a clean failure.
+unpackArchive :: FilePath -> UnpackLimits -> FilePath -> IO (Either Text UnpackLimits)
+unpackArchive outDir budget archivePath = do
   attempt <- try run
   pure $ case attempt of
     Left (e :: SomeException) ->
@@ -185,7 +225,7 @@ unpackArchive outDir archivePath = do
       Nothing -> pure (Left ("unsupported archive format: " <> T.pack archivePath))
       Just decoder -> do
         raw <- BL.readFile archivePath
-        extractEntries outDir (Tar.decodeLongNames (Tar.read (decoder raw)))
+        extractEntries outDir budget (Tar.decodeLongNames (Tar.read (decoder raw)))
 
 -- | Choose a decompressor from the archive file name.  @.tar.zst@ (MSYS2
 -- packages) and plain @.tar@ are supported.  MSYS2's zstd frames do not
@@ -203,48 +243,58 @@ decoderFor path
 -- Entry extraction
 -- ---------------------------------------------------------------------------
 
--- | Walk the entry stream, extracting each entry under @outDir@.
-extractEntries :: FilePath -> DecodedEntries -> IO (Either Text ())
+-- | Walk the entry stream, extracting each entry under @outDir@ and
+-- threading the remaining extraction budget.
+extractEntries :: FilePath -> UnpackLimits -> DecodedEntries -> IO (Either Text UnpackLimits)
 extractEntries outDir = go
   where
-    go stream = case stream of
-      Tar.Done -> pure (Right ())
+    go budget stream = case stream of
+      Tar.Done -> pure (Right budget)
       Tar.Fail err -> pure (Left ("malformed archive: " <> T.pack (show err)))
       Tar.Next entry rest -> do
-        result <- extractEntry outDir entry
+        result <- extractEntry outDir budget entry
         case result of
           Left err -> pure (Left err)
-          Right () -> go rest
+          Right remaining -> go remaining rest
 
 -- | Extract a single entry, after validating its path stays inside the
 -- archive root and skipping pacman package metadata.
-extractEntry :: FilePath -> DecodedEntry -> IO (Either Text ())
-extractEntry outDir entry =
+extractEntry :: FilePath -> UnpackLimits -> DecodedEntry -> IO (Either Text UnpackLimits)
+extractEntry outDir budget entry =
   case entryComponents (TarEntry.entryTarPath entry) of
     Left err -> pure (Left err)
     -- The archive root itself (an entry for "." or "./").
-    Right [] -> pure (Right ())
+    Right [] -> pure (Right budget)
     Right comps
-      | isPackageMetadata comps -> pure (Right ())
-      | otherwise -> extractContent outDir comps entry
+      | isPackageMetadata comps -> pure (Right budget)
+      | otherwise -> extractContent outDir budget comps entry
 
--- | Extract a path-validated entry's content.  @comps@ is non-empty (the
+-- | Extract a path-validated entry's content, charging every created
+-- entry and its bytes against the budget.  @comps@ is non-empty (the
 -- empty case is consumed by 'extractEntry').
-extractContent :: FilePath -> [FilePath] -> DecodedEntry -> IO (Either Text ())
-extractContent outDir comps entry =
+extractContent :: FilePath -> UnpackLimits -> [FilePath] -> DecodedEntry -> IO (Either Text UnpackLimits)
+extractContent outDir budget comps entry =
   case TarEntry.entryContent entry of
-    Tar.Directory -> do
-      createDirectoryIfMissing True dest
-      pure (Right ())
-    Tar.NormalFile bytes _size -> do
-      fresh <- freshDestination dest
-      case fresh of
+    Tar.Directory ->
+      case chargeBudget pathText 0 budget of
         Left err -> pure (Left err)
-        Right () -> do
-          createDirectoryIfMissing True (takeDirectory dest)
-          BL.writeFile dest bytes
-          when (executableEntry entry && not isWindowsHost) (markExecutable dest)
-          pure (Right ())
+        Right remaining -> do
+          createDirectoryIfMissing True dest
+          pure (Right remaining)
+    Tar.NormalFile bytes size ->
+      -- The header size is charged before the lazy content is realized,
+      -- so a breach rejects the entry rather than materializing it.
+      case chargeBudget pathText size budget of
+        Left err -> pure (Left err)
+        Right remaining -> do
+          fresh <- freshDestination dest
+          case fresh of
+            Left err -> pure (Left err)
+            Right () -> do
+              createDirectoryIfMissing True (takeDirectory dest)
+              BL.writeFile dest bytes
+              when (executableEntry entry && not isWindowsHost) (markExecutable dest)
+              pure (Right remaining)
     -- A symlink target is relative to the link's own directory.
     Tar.SymbolicLink target ->
       copyLinkTarget "symlink" (resolveLinkTarget parentComps target)
@@ -252,7 +302,7 @@ extractContent outDir comps entry =
     Tar.HardLink target ->
       copyLinkTarget "hardlink" (entryComponents target)
     Tar.OtherEntryType code _ _
-      | code == paxPerFileCode || code == paxGlobalCode -> pure (Right ())
+      | code == paxPerFileCode || code == paxGlobalCode -> pure (Right budget)
       | otherwise ->
           pure (Left ("unsupported tar entry type '" <> T.singleton code <> "': " <> pathText))
     Tar.CharacterDevice _ _ -> unsupportedSpecial "character device"
@@ -277,9 +327,13 @@ extractContent outDir comps entry =
           case fresh of
             Left err -> pure (Left err)
             Right () -> do
-              createDirectoryIfMissing True (takeDirectory dest)
-              copyFile targetPath dest
-              pure (Right ())
+              size <- getFileSize targetPath
+              case chargeBudget pathText (fromIntegral size) budget of
+                Left err -> pure (Left err)
+                Right remaining -> do
+                  createDirectoryIfMissing True (takeDirectory dest)
+                  copyFile targetPath dest
+                  pure (Right remaining)
       | isDir = do
           -- The same collision guard as regular entries: without it a
           -- directory link copy silently merges into content another
@@ -287,9 +341,9 @@ extractContent outDir comps entry =
           fresh <- freshDestination dest
           case fresh of
             Left err -> pure (Left err)
-            Right () -> do
-              copyTree targetPath dest
-              pure (Right ())
+            Right () -> case chargeBudget pathText 0 budget of
+              Left err -> pure (Left err)
+              Right remaining -> copyTree remaining targetPath dest
       | otherwise =
           pure
             ( Left
@@ -386,17 +440,33 @@ markExecutable path = do
   setPermissions path (setOwnerExecutable True perms)
 
 -- | Recursively copy a directory tree (used to materialize directory
--- symlinks, which cannot be store-portable links on Windows).
-copyTree :: FilePath -> FilePath -> IO ()
-copyTree src dest = do
+-- symlinks, which cannot be store-portable links on Windows), charging
+-- every created entry and byte against the budget: each tree copy
+-- duplicates content already extracted and charged once, so uncharged
+-- copies would let K link entries multiply the output roughly 2^K-fold.
+copyTree :: UnpackLimits -> FilePath -> FilePath -> IO (Either Text UnpackLimits)
+copyTree budget0 src dest = do
   createDirectoryIfMissing True dest
   names <- listDirectory src
-  mapM_ copyOne names
+  go budget0 names
   where
-    copyOne name = do
+    go budget [] = pure (Right budget)
+    go budget (name : rest) = do
       let from = src </> name
           to = dest </> name
       isDir <- doesDirectoryExist from
-      if isDir
-        then copyTree from to
-        else copyFile from to
+      copied <-
+        if isDir
+          then case chargeBudget (T.pack to) 0 budget of
+            Left err -> pure (Left err)
+            Right remaining -> copyTree remaining from to
+          else do
+            size <- getFileSize from
+            case chargeBudget (T.pack to) (fromIntegral size) budget of
+              Left err -> pure (Left err)
+              Right remaining -> do
+                copyFile from to
+                pure (Right remaining)
+      case copied of
+        Left err -> pure (Left err)
+        Right remaining -> go remaining rest

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -12,6 +12,7 @@ module Nix.Builtins
 
     -- * NIX_PATH parsing
     parseNixPath,
+    splitNixPath,
   )
 where
 
@@ -150,14 +151,21 @@ parseNixPath raw
 -- drive letters.  A colon followed by @\\@ or @/@ (e.g. @C:\\@) is
 -- part of a path, not a separator.
 splitNixPath :: Text -> [Text]
-splitNixPath = go T.empty
+splitNixPath = go []
   where
-    go acc remaining = case T.uncons remaining of
-      Nothing -> [acc | not (T.null acc)]
-      Just (':', rest)
-        | isDriveSep rest -> go (acc <> ":" <> T.take 1 rest) (T.drop 1 rest)
-        | otherwise -> acc : go T.empty rest
-      Just (c, rest) -> go (T.snoc acc c) rest
+    -- Accumulates reversed chunks and concatenates once per entry, so a
+    -- long entry costs O(n) instead of the O(n^2) of per-character snoc.
+    go !chunks remaining =
+      let (chunk, rest) = T.break (== ':') remaining
+       in case T.uncons rest of
+            Nothing ->
+              let entry = T.concat (reverse (chunk : chunks))
+               in [entry | not (T.null entry)]
+            Just (_, afterColon)
+              | isDriveSep afterColon ->
+                  go (T.take 1 afterColon : ":" : chunk : chunks) (T.drop 1 afterColon)
+              | otherwise ->
+                  T.concat (reverse (chunk : chunks)) : go [] afterColon
     -- After a colon, if the next char is \ or /, it's a drive letter
     isDriveSep t = case T.uncons t of
       Just ('\\', _) -> True

--- a/src/Nix/DependencyGraph.hs
+++ b/src/Nix/DependencyGraph.hs
@@ -180,16 +180,21 @@ decrementDependents dc = foldl' step (dc, [])
 
 -- | All transitive dependencies of a store path (not including itself).
 transitiveDeps :: DepGraph -> StorePath -> Set StorePath
-transitiveDeps (DepGraph graph) root = go Set.empty (Seq.singleton root)
+transitiveDeps (DepGraph graph) root =
+  Set.delete root (go (Set.singleton root) (Seq.singleton root))
   where
-    go visited queue = case Seq.viewl queue of
+    -- visited marks ENQUEUED nodes - the root is seeded, so a
+    -- self-dependent root is expanded once instead of recursing forever.
+    go !visited queue = case Seq.viewl queue of
       Seq.EmptyL -> visited
-      sp Seq.:< rest
-        | Set.member sp visited -> go visited rest
-        | otherwise ->
-            let deps = maybe [] dnDeps (Map.lookup sp graph)
-                visitedWithDep = if sp == root then visited else Set.insert sp visited
-             in go visitedWithDep (foldl' (|>) rest deps)
+      sp Seq.:< rest ->
+        enqueueFresh visited rest (maybe [] dnDeps (Map.lookup sp graph))
+    -- Mark and enqueue each dep not yet seen, then continue the walk.
+    enqueueFresh !visited !queue deps = case deps of
+      [] -> go visited queue
+      (dep : more)
+        | Set.member dep visited -> enqueueFresh visited queue more
+        | otherwise -> enqueueFresh (Set.insert dep visited) (queue |> dep) more
 
 -- | Direct dependencies of a store path.
 directDeps :: DepGraph -> StorePath -> [StorePath]

--- a/src/Nix/Eval.hs
+++ b/src/Nix/Eval.hs
@@ -4272,15 +4272,17 @@ scanTomlLine st0 line = go st0 line 0
 joinLogicalLine :: Text -> [Text] -> (Text, [Text])
 joinLogicalLine firstLine rest0 =
   let (st0, visible0) = scanTomlLine emptyTomlScan firstLine
-   in go st0 visible0 rest0
+   in go st0 [visible0] rest0
   where
-    go st acc remaining
-      | not (tomlNeedsMoreLines st) = (acc, remaining)
+    -- Reversed line chunks, joined once - O(n) in the logical line's
+    -- length instead of the O(n^2) of appending per physical line.
+    go st !chunks remaining
+      | not (tomlNeedsMoreLines st) = (T.intercalate "\n" (reverse chunks), remaining)
       | otherwise = case remaining of
-          [] -> (acc, [])
+          [] -> (T.intercalate "\n" (reverse chunks), [])
           (next : more) ->
             let (advanced, visible) = scanTomlLine st next
-             in go advanced (acc <> "\n" <> visible) more
+             in go advanced (visible : chunks) more
 
 -- | Parse a key = value line.
 parseKVLine :: Text -> Either Text ([Text], TOMLValue)
@@ -4294,23 +4296,27 @@ parseKVLine line =
           Right (parseDottedKey (T.strip keyPart), parsed)
 
 -- | Split a line at the first unquoted '=' sign.
+-- O(n) via bulk spans into a chunk list instead of O(n^2) T.snoc.
 splitAtEquals :: Text -> (Text, Text)
-splitAtEquals = go T.empty
+splitAtEquals = go []
   where
-    go acc t = case T.uncons t of
-      Nothing -> (acc, T.empty)
-      Just ('=', rest) -> (acc, rest)
+    keyPart chunks = T.concat (reverse chunks)
+    go !chunks t = case T.uncons t of
+      Nothing -> (keyPart chunks, T.empty)
+      Just ('=', rest) -> (keyPart chunks, rest)
       Just ('"', rest) ->
         let (quoted, after) = T.break (== '"') rest
          in case T.uncons after of
-              Just ('"', r) -> go (acc <> "\"" <> quoted <> "\"") r
-              _ -> go (acc <> "\"" <> quoted) after
+              Just ('"', r) -> go ("\"" : quoted : "\"" : chunks) r
+              _ -> go (quoted : "\"" : chunks) after
       Just ('\'', rest) ->
         let (quoted, after) = T.break (== '\'') rest
          in case T.uncons after of
-              Just ('\'', r) -> go (acc <> "'" <> quoted <> "'") r
-              _ -> go (acc <> "'" <> quoted) after
-      Just (c, rest) -> go (T.snoc acc c) rest
+              Just ('\'', r) -> go ("'" : quoted : "'" : chunks) r
+              _ -> go (quoted : "'" : chunks) after
+      Just (_, _) ->
+        let (plain, after) = T.break (\c -> c == '=' || c == '"' || c == '\'') t
+         in go (plain : chunks) after
 
 -- | Parse dotted key like @foo.bar."baz qux"@ into @["foo", "bar", "baz qux"]@.
 parseDottedKey :: Text -> [Text]
@@ -4366,22 +4372,29 @@ parseTOMLValue t =
         _ -> parseTOMLNumberOrDatetime cleaned
 
 -- | Strip inline comment from a value (not inside quotes).
+-- O(n) via bulk spans into a chunk list instead of O(n^2)
+-- per-character T.cons (each cons copies the whole tail).
 stripInlineComment :: Text -> Text
-stripInlineComment = go (0 :: Int)
+stripInlineComment = go (0 :: Int) []
   where
-    go _ t | T.null t = T.empty
-    go depth t = case T.uncons t of
-      Nothing -> T.empty
-      Just ('#', _) | depth == (0 :: Int) -> T.empty
+    finish chunks = T.concat (reverse chunks)
+    go depth !chunks t = case T.uncons t of
+      Nothing -> finish chunks
+      Just ('#', _) | depth == 0 -> finish chunks
       Just ('"', rest)
         | depth == 0 ->
             let (str, after) = T.break (== '"') rest
-             in T.cons '"' (str <> T.take 1 after <> go depth (T.drop 1 after))
-      Just ('[', rest) -> T.cons '[' (go (depth + 1) rest)
-      Just ('{', rest) -> T.cons '{' (go (depth + 1) rest)
-      Just (']', rest) -> T.cons ']' (go (max 0 (depth - 1)) rest)
-      Just ('}', rest) -> T.cons '}' (go (max 0 (depth - 1)) rest)
-      Just (c, rest) -> T.cons c (go depth rest)
+             in go depth (T.take 1 after : str : "\"" : chunks) (T.drop 1 after)
+      Just ('[', rest) -> go (depth + 1) ("[" : chunks) rest
+      Just ('{', rest) -> go (depth + 1) ("{" : chunks) rest
+      Just (']', rest) -> go (max 0 (depth - 1)) ("]" : chunks) rest
+      Just ('}', rest) -> go (max 0 (depth - 1)) ("}" : chunks) rest
+      Just (c, rest) ->
+        -- c is plain (or a quote/hash inside brackets, kept as content);
+        -- take it plus the whole plain run after it in one span.
+        let (plain, after) = T.break scanBreak rest
+         in go depth (plain : T.singleton c : chunks) after
+    scanBreak c = c == '#' || c == '"' || c == '[' || c == '{' || c == ']' || c == '}'
 
 -- | Parse a basic (double-quoted) TOML string.
 -- O(n) via chunk list + T.concat instead of O(n^2) T.snoc.

--- a/src/Nix/Hash.hs
+++ b/src/Nix/Hash.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE ExistentialQuantification #-}
+
 -- | Cryptographic hashing for the Nix store.
 --
 -- == How Nix uses hashes
@@ -36,6 +38,10 @@ module Nix.Hash
     byteToHex,
     hexToBytes,
     rawHashWithAlgo,
+    IncrementalHash,
+    hashInitWithAlgo,
+    hashUpdateChunk,
+    hashFinalizeBytes,
     hashAlgoBytes,
     hexHashLen,
     nix32HashLen,
@@ -163,6 +169,30 @@ rawHashWithAlgo algo bytes = case algo of
   "sha1" -> Just (BA.convert (CH.hash bytes :: CH.Digest CH.SHA1))
   "md5" -> Just (BA.convert (CH.hash bytes :: CH.Digest CH.MD5))
   _ -> Nothing
+
+-- | An in-progress digest under a named algorithm - the incremental
+-- form of 'rawHashWithAlgo', for hashing a stream chunk by chunk
+-- without materializing the whole input.
+data IncrementalHash = forall a. (CH.HashAlgorithm a) => IncrementalHash !(CH.Context a)
+
+-- | Start an incremental digest.  'Nothing' for an unknown algorithm
+-- name (same names 'rawHashWithAlgo' accepts).
+hashInitWithAlgo :: Text -> Maybe IncrementalHash
+hashInitWithAlgo algo = case algo of
+  "sha256" -> Just (IncrementalHash (CH.hashInit :: CH.Context CH.SHA256))
+  "sha512" -> Just (IncrementalHash (CH.hashInit :: CH.Context CH.SHA512))
+  "sha1" -> Just (IncrementalHash (CH.hashInit :: CH.Context CH.SHA1))
+  "md5" -> Just (IncrementalHash (CH.hashInit :: CH.Context CH.MD5))
+  _ -> Nothing
+
+-- | Absorb one chunk.
+hashUpdateChunk :: IncrementalHash -> BS.ByteString -> IncrementalHash
+hashUpdateChunk (IncrementalHash ctx) chunk = IncrementalHash (CH.hashUpdate ctx chunk)
+
+-- | Finish, yielding the same raw digest bytes 'rawHashWithAlgo'
+-- produces for the concatenated chunks.
+hashFinalizeBytes :: IncrementalHash -> BS.ByteString
+hashFinalizeBytes (IncrementalHash ctx) = BA.convert (CH.hashFinalize ctx)
 
 -- | Raw digest size in bytes of a supported hash algorithm.  'Nothing' for
 -- an unknown algorithm name.

--- a/src/Nix/Parser/Lexer.hs
+++ b/src/Nix/Parser/Lexer.hs
@@ -577,8 +577,10 @@ lexNumber st acc =
            in lexNormalMode newSt (tok : acc)
         _
           -- C++ Nix rejects out-of-range integer literals rather than
-          -- silently wrapping modulo 2^64.
-          | readInteger digits > toInteger (maxBound :: Int64) ->
+          -- silently wrapping modulo 2^64.  Range is decided by digit
+          -- count first: 'readInteger' is quadratic in the digit count,
+          -- and the guard must not pay that on input it rejects.
+          | not (integerLiteralInRange digits) ->
               Left
                 ParseError
                   { peFile = lsFile st,
@@ -596,6 +598,20 @@ lexNumber st acc =
 readInteger :: Text -> Integer
 readInteger = T.foldl' (\n c -> n * decimalBase + fromIntegral (fromEnum c - zeroOrd)) 0
 
+-- | Digit count of @maxBound :: Int64@ (9223372036854775807).  A literal
+-- with more significant digits is out of range on count alone.
+int64MaxDigits :: Int
+int64MaxDigits = 19
+
+-- | Whether an all-digit literal fits 'Int64', decided by significant
+-- digit count before any bignum is built.
+integerLiteralInRange :: Text -> Bool
+integerLiteralInRange digits =
+  let significant = T.dropWhile (== '0') digits
+      count = T.length significant
+   in count < int64MaxDigits
+        || (count == int64MaxDigits && readInteger significant <= toInteger (maxBound :: Int64))
+
 -- | Read a floating-point literal from its integer, decimal, and exponent
 -- parts.  The digits form one exact 'Rational' scaled by the exponent, and
 -- 'fromRational' rounds once - the correctly-rounded conversion C++ Nix
@@ -603,11 +619,62 @@ readInteger = T.foldl' (\n c -> n * decimalBase + fromIntegral (fromEnum c - zer
 -- and exponent steps separately drifts an ulp from upstream on long
 -- literals and flushes subnormals (e.g. 1.0e-320) to zero.  Total - no
 -- 'read', no exceptions.
+--
+-- The exact path runs only within double's decimal range: @10 ^^ scale@
+-- materializes a bignum of |scale| digits, so the cost must follow the
+-- literal's length, never the exponent's magnitude (@1.0e999999999@
+-- would otherwise build a gigabyte of Rational).  A scale provably past
+-- the overflow bound saturates to Infinity and past the underflow bound
+-- to 0.0 - the values strtod rounds such literals to.  Mantissas keep
+-- 'mantissaDigitBound' significant digits, a dropped nonzero tail
+-- standing in as one sticky digit; past that bound the tail cannot
+-- change the correctly-rounded result.
 readDouble :: Text -> Text -> Integer -> Double
-readDouble intPart decPart expVal =
-  let mantissa = readInteger (intPart <> decPart)
-      scale = expVal - toInteger (T.length decPart)
-   in fromRational (toRational mantissa * fromInteger decimalBase ^^ scale)
+readDouble intPart decPart expVal
+  | T.null significantAll = 0.0
+  | overflows = positiveInfinity
+  | underflows = 0.0
+  | otherwise = fromRational (toRational mantissa * fromInteger decimalBase ^^ scale)
+  where
+    significantAll = T.dropWhile (== '0') (intPart <> decPart)
+    truncated = T.length significantAll > mantissaDigitBound
+    (keptDigits, droppedTail) = T.splitAt mantissaDigitBound significantAll
+    stickyDigit = if T.any (/= '0') droppedTail then "1" else "0"
+    mantissaText = if truncated then keptDigits <> stickyDigit else significantAll
+    mantissa = readInteger mantissaText
+    -- Each dropped tail digit shifts the represented value's scale up by
+    -- one; the appended sticky digit takes the place of the last one.
+    droppedCount = if truncated then T.length droppedTail - 1 else 0
+    scale = expVal - toInteger (T.length decPart) + toInteger droppedCount
+    -- mantissa has exactly digitCount digits (leading digit nonzero), so
+    -- the value lies in [10^(digitCount-1+scale), 10^(digitCount+scale)).
+    digitCount = toInteger (T.length mantissaText)
+    overflows = digitCount - 1 + scale >= doubleOverflowExp10
+    underflows = digitCount + scale <= doubleUnderflowExp10
+
+-- | Significant decimal digits kept of a float mantissa.  Correctly
+-- rounding binary64 never needs more than 767 significant digits (the
+-- longest exactly-representable double and every rounding midpoint fit
+-- in 767), so with one sticky digit for the dropped tail, 768 kept
+-- digits decide every rounding exactly as the full literal would.
+mantissaDigitBound :: Int
+mantissaDigitBound = 768
+
+-- | Any value at or above 10^309 exceeds double's maximum (~1.798e308)
+-- and rounds to Infinity.
+doubleOverflowExp10 :: Integer
+doubleOverflowExp10 = 309
+
+-- | Any value below 10^-324 is under half the smallest denormal
+-- (~4.94e-324) and rounds to 0.0.
+doubleUnderflowExp10 :: Integer
+doubleUnderflowExp10 = -324
+
+-- | IEEE positive infinity, strtod's overflow result.  Float literals
+-- are unsigned at the lexer (minus is an operator), so only the
+-- positive infinity is ever produced.
+positiveInfinity :: Double
+positiveInfinity = 1 / 0
 
 -- | Consume an optional exponent @[eE][+-]?[0-9]+@ after a float's digits.
 -- Returns the signed exponent, the remaining input, and the characters
@@ -625,8 +692,31 @@ lexExponent input =
               (expDigits, afterExp) = T.span isDigit afterSign
            in if T.null expDigits
                 then (0, input, 0)
-                else (sign * readInteger expDigits, afterExp, 1 + signLen + T.length expDigits)
+                else (sign * exponentMagnitude expDigits, afterExp, 1 + signLen + T.length expDigits)
     _ -> (0, input, 0)
+
+-- | The magnitude of an exponent's digit run.  Reading n digits builds
+-- an n-digit bignum quadratically, so runs past 'exponentDigitBound'
+-- saturate to a stand-in already so far outside double's range that
+-- 'readDouble' collapses it to the same Infinity or 0.0 the exact
+-- exponent would round to.
+exponentMagnitude :: Text -> Integer
+exponentMagnitude expDigits =
+  let significant = T.dropWhile (== '0') expDigits
+   in if T.length significant > exponentDigitBound
+        then saturatedExponent
+        else readInteger significant
+
+-- | Exponent digit runs past this bound saturate (see
+-- 'exponentMagnitude').
+exponentDigitBound :: Int
+exponentDigitBound = 18
+
+-- | Stand-in exponent magnitude past 'exponentDigitBound': any exponent
+-- with more significant digits is at least 10^18, and double's whole
+-- decimal range spans only around 10^+-324.
+saturatedExponent :: Integer
+saturatedExponent = 10 ^ (18 :: Int)
 
 -- | Lex a leading-dot float like @.5@ or @.5e3@ (Nix's @0?\\.[0-9]+@ form).
 -- The current input begins with the @.@.

--- a/src/Nix/Store.hs
+++ b/src/Nix/Store.hs
@@ -56,6 +56,9 @@ module Nix.Store
     -- * NAR entry-name safety
     isSafeNarName,
 
+    -- * Link ordering (exposed for testing)
+    orderLinks,
+
     -- * Re-exports
     module Nix.Store.Path,
     module Nix.Store.DB,
@@ -63,9 +66,10 @@ module Nix.Store
 where
 
 import Control.Exception (IOException, SomeException, catch, try)
-import Control.Monad (filterM, unless, when)
+import Control.Monad (unless, when)
 import qualified Data.ByteString as BS
 import Data.Char (isDigit)
+import Data.List (foldl', inits)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
@@ -89,7 +93,7 @@ import System.Directory
     setPermissions,
   )
 import qualified System.Directory as Dir
-import System.FilePath (takeDirectory, (</>))
+import System.FilePath (splitDirectories, takeDirectory, (</>))
 
 -- | An open store with database and configuration.
 data Store = Store
@@ -386,31 +390,82 @@ unpackChildren path ((name, child) : rest)
             Left err -> pure (Left err)
             Right moreLinks -> pure (Right (links <> moreLinks))
 
--- | Second unpack pass: create the recorded symlinks.  Links whose targets
--- already exist are created first - possibly unblocking link-to-link
--- chains - so the Windows link flavor (file vs directory) is read off the
--- real target.  When no pending link's target exists, the remainder are
--- dangling and their kind is unknowable: they default to file links.
+-- | Second unpack pass: create the recorded symlinks in dependency
+-- order - each link is created after every pending link its target
+-- resolves at or through - so the Windows link flavor (file vs
+-- directory) is read off the real target with one probe per link.
+-- (The previous ready-set rounds re-stat'd every remaining link per
+-- round: quadratic filesystem stats on a link chain.)  Links on a
+-- dependency cycle have no knowable kind and default to file links,
+-- exactly as dangling links always have.
 createSymlinks :: [(FilePath, Text)] -> IO (Either Text ())
-createSymlinks [] = pure (Right ())
-createSymlinks pending = do
-  ready <- filterM targetExists pending
-  case ready of
-    [] -> createAll pending
-    _ -> do
-      made <- createAll ready
-      case made of
-        Left err -> pure (Left err)
-        Right () -> createSymlinks (filter (`notElem` ready) pending)
+createSymlinks pending = createAll (orderLinks pending)
   where
-    targetExists (linkPath, target) =
-      Dir.doesPathExist (takeDirectory linkPath </> T.unpack target)
     createAll [] = pure (Right ())
     createAll (link : rest) = do
       made <- uncurry createSymlink link
       case made of
         Left err -> pure (Left err)
         Right () -> createAll rest
+
+-- | Order pending links so each follows every pending link its target
+-- path resolves at or through: the target itself, or a link standing on
+-- one of the target's ancestor directories.  Purely textual over the
+-- same @takeDirectory linkPath \</\> target@ resolution 'createSymlink'
+-- probes - no filesystem access.  Kahn's ordering, deterministic:
+-- ready links leave in input order, and cycle members keep input order
+-- at the end.  Exported for testing (the ordering property is pure).
+orderLinks :: [(FilePath, Text)] -> [(FilePath, Text)]
+orderLinks pending =
+  let indexed = zip [0 :: Int ..] pending
+      linkByIndex = Map.fromList indexed
+      indexByKey =
+        Map.fromList [(normalisedComponents linkPath, i) | (i, (linkPath, _)) <- indexed]
+      -- The pending links this link's resolved target lands on or
+      -- passes through (every nonempty component prefix).
+      depsOf (linkPath, target) =
+        let resolved = normalisedComponents (takeDirectory linkPath </> T.unpack target)
+         in Set.fromList
+              [j | prefix <- drop 1 (inits resolved), Just j <- [Map.lookup prefix indexByKey]]
+      dependsOn = Map.fromList [(i, depsOf link) | (i, link) <- indexed]
+      dependents =
+        Map.fromListWith
+          (flip (++))
+          [(dep, [i]) | (i, deps) <- Map.toList dependsOn, dep <- Set.toList deps]
+      initialCounts = Map.map Set.size dependsOn
+      initialReady = [i | (i, count) <- Map.toList initialCounts, count == 0]
+      -- Kahn's ordering with a two-list queue (amortized O(1) pops).
+      run !emittedRev !counts front back = case front of
+        [] -> case back of
+          [] -> reverse emittedRev
+          _ -> run emittedRev counts (reverse back) []
+        (i : rest) ->
+          let (updatedCounts, readied) = release counts (Map.findWithDefault [] i dependents)
+           in run (i : emittedRev) updatedCounts rest (readied ++ back)
+      release !counts deps = case deps of
+        [] -> (counts, [])
+        (d : more) ->
+          let updated = Map.adjust (subtract 1) d counts
+              (finalCounts, readied) = release updated more
+           in (finalCounts, [d | Map.lookup d updated == Just 0] ++ readied)
+      emittedOrder = run [] initialCounts initialReady []
+      emittedSet = Set.fromList emittedOrder
+      cycleRemainder = [link | (i, link) <- indexed, not (Set.member i emittedSet)]
+   in [link | i <- emittedOrder, Just link <- [Map.lookup i linkByIndex]] ++ cycleRemainder
+
+-- | Path components with @.@ dropped and @..@ collapsed textually - the
+-- spelling-insensitive key that matches a link target against pending
+-- link paths ('splitDirectories' accepts both separator spellings).  A
+-- @..@ with nothing left to pop stays, matching no real path.
+normalisedComponents :: FilePath -> [FilePath]
+normalisedComponents path = reverse (foldl' step [] (splitDirectories path))
+  where
+    step stack comp
+      | comp == "." = stack
+      | comp == ".." = case stack of
+          (top : rest) | top /= ".." -> rest
+          _ -> comp : stack
+      | otherwise = comp : stack
 
 -- | Create one symlink, choosing the Windows flavor from the target's kind.
 -- A creation failure is loud: the old fallback of writing the target text

--- a/src/Nix/Substituter.hs
+++ b/src/Nix/Substituter.hs
@@ -40,6 +40,8 @@ module Nix.Substituter
     defaultCacheConfig,
 
     -- * Pure helpers (exported for testing)
+    maxNarInfoBody,
+    readBodyCapped,
     sortCaches,
     tryCachesWith,
     verifySigs,
@@ -59,8 +61,8 @@ import Control.Applicative ((<|>))
 import Control.Concurrent (threadDelay)
 import Control.Exception (SomeException, try)
 import qualified Data.ByteString as BS
-import qualified Data.ByteString.Lazy as LBS
 import Data.List (sortBy)
+import Data.Maybe (fromMaybe)
 import Data.Ord (comparing)
 import Data.Text (Text)
 import qualified Data.Text as T
@@ -317,25 +319,54 @@ httpOk = 200
 httpNotFound :: Int
 httpNotFound = 404
 
+-- | Cap on a narinfo response body, mirroring nova-cache's server-side
+-- @maxNarInfoBodySize@ - the server bounds what it reads, and the
+-- client bounds what any cache in its list can make it buffer.
+-- Narinfo is small key-value text; 4 MB is far beyond any real one.
+maxNarInfoBody :: Int
+maxNarInfoBody = 4 * 1024 * 1024
+
+-- | Read an HTTP response body in bounded chunks up to a byte cap -
+-- 'Nothing' once the cap is exceeded, so an over-large body aborts
+-- mid-stream instead of buffering without limit.  The client-side
+-- mirror of nova-cache's @readBodyLimited@.
+readBodyCapped :: Int -> HTTP.BodyReader -> IO (Maybe BS.ByteString)
+readBodyCapped cap reader = go [] 0
+  where
+    go chunks !total = do
+      chunk <- HTTP.brRead reader
+      if BS.null chunk
+        then pure (Just (BS.concat (reverse chunks)))
+        else
+          let newTotal = total + BS.length chunk
+           in if newTotal > cap
+                then pure Nothing
+                else go (chunk : chunks) newTotal
+
 -- | Fetch a narinfo from a cache.
 -- Returns @Left SubstNotFound@ on 404, @Left (SubstError msg)@ on other errors.
 fetchNarInfo :: HTTP.Manager -> CacheConfig -> StorePath -> IO (Either SubstResult NarInfo.NarInfo)
 fetchNarInfo mgr cache sp = do
   let url = T.unpack (ccUrl cache) <> "/" <> T.unpack (spHash sp) <> ".narinfo"
   request <- HTTP.parseRequest url
-  response <- HTTP.httpLbs request mgr
-  let code = HTTP.statusCode (HTTP.responseStatus response)
-  -- Lenient decode: the body is cache-controlled bytes, and a stray
-  -- invalid UTF-8 sequence must surface as a narinfo parse error, not an
-  -- impure UnicodeException (the push side decodes the same way).
-  if code == httpOk
-    then case NarInfo.parseNarInfo (TE.decodeUtf8Lenient (LBS.toStrict (HTTP.responseBody response))) of
-      Left err -> pure (Left (SubstError ("narinfo parse error: " <> T.pack err)))
-      Right ni -> pure (Right ni)
-    else
-      if code == httpNotFound
-        then pure (Left SubstNotFound)
-        else pure (Left (SubstError ("narinfo fetch failed: HTTP " <> T.pack (show code))))
+  HTTP.withResponse request mgr $ \response -> do
+    let code = HTTP.statusCode (HTTP.responseStatus response)
+    -- Lenient decode: the body is cache-controlled bytes, and a stray
+    -- invalid UTF-8 sequence must surface as a narinfo parse error, not an
+    -- impure UnicodeException (the push side decodes the same way).
+    if code == httpOk
+      then do
+        body <- readBodyCapped maxNarInfoBody (HTTP.responseBody response)
+        case body of
+          Nothing ->
+            pure (Left (SubstError ("narinfo body exceeds " <> T.pack (show maxNarInfoBody) <> " bytes")))
+          Just bytes -> case NarInfo.parseNarInfo (TE.decodeUtf8Lenient bytes) of
+            Left err -> pure (Left (SubstError ("narinfo parse error: " <> T.pack err)))
+            Right ni -> pure (Right ni)
+      else
+        if code == httpNotFound
+          then pure (Left SubstNotFound)
+          else pure (Left (SubstError ("narinfo fetch failed: HTTP " <> T.pack (show code))))
 
 -- | How many times to attempt a NAR download before giving up and letting the
 -- caller fall back to a local build.  Matches Nix's @download-attempts@ default.
@@ -374,17 +405,30 @@ downloadNarWithRetry mgr cache narInfo = attempt narDownloadAttempts
 -- | Download the NAR file referenced by a narinfo.
 --
 -- The whole NAR is realized in memory (nova-cache's 'NAR.deserialise' consumes
--- a strict 'BS.ByteString'), so a very large path briefly spikes RSS.  Streaming
--- would need a streaming NAR parser that nova-cache does not yet provide.
+-- a strict 'BS.ByteString'), but never more of it than the narinfo declares:
+-- the narinfo was signature-verified before this runs, so its FileSize /
+-- NarSize is the key-trusted bound, and a body that exceeds it aborts
+-- mid-stream instead of buffering without limit - the excess bytes could not
+-- hash-verify anyway.  Streaming the verify itself would need a streaming NAR
+-- parser that nova-cache does not yet provide.
 downloadNar :: HTTP.Manager -> CacheConfig -> NarInfo.NarInfo -> IO (Either Text BS.ByteString)
 downloadNar mgr cache narInfo = do
   let narUrl = T.unpack (ccUrl cache) <> "/" <> T.unpack (NarInfo.niUrl narInfo)
-  request <- HTTP.parseRequest narUrl
-  response <- HTTP.httpLbs request mgr
-  let code = HTTP.statusCode (HTTP.responseStatus response)
-  if code == httpOk
-    then pure (Right (LBS.toStrict (HTTP.responseBody response)))
-    else pure (Left ("NAR download failed: HTTP " <> T.pack (show code)))
+      declared = fromMaybe (NarInfo.niNarSize narInfo) (NarInfo.niFileSize narInfo)
+  if declared < 0 || declared > toInteger (maxBound :: Int)
+    then pure (Left ("narinfo declares an unusable NAR size: " <> T.pack (show declared)))
+    else do
+      request <- HTTP.parseRequest narUrl
+      HTTP.withResponse request mgr $ \response -> do
+        let code = HTTP.statusCode (HTTP.responseStatus response)
+        if code == httpOk
+          then do
+            body <- readBodyCapped (fromInteger declared) (HTTP.responseBody response)
+            case body of
+              Nothing ->
+                pure (Left ("NAR body exceeds the declared size (" <> T.pack (show declared) <> " bytes)"))
+              Just bytes -> pure (Right bytes)
+          else pure (Left ("NAR download failed: HTTP " <> T.pack (show code)))
 
 -- ---------------------------------------------------------------------------
 -- Pure helpers

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -7,12 +7,13 @@ module Main (main) where
 import qualified Codec.Archive.Tar as Tar
 import qualified Codec.Archive.Tar.Entry as TarEntry
 import qualified Codec.Compression.Zstd.Lazy as ZstdL
-import Control.Exception (SomeException, bracket_, try)
+import Control.Exception (SomeException, bracket_, evaluate, try)
 import Control.Monad (filterM, void, when)
 import Data.Bits (shiftR, (.&.))
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BL
 import Data.IORef (atomicModifyIORef', newIORef, readIORef)
+import Data.List (foldl')
 import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe, isJust)
 import qualified Data.Set as Set
@@ -24,8 +25,8 @@ import qualified Data.Text.IO as TIO
 import Foreign.Ptr (castPtr)
 import Foreign.StablePtr (StablePtr, castPtrToStablePtr, castStablePtrToPtr, deRefStablePtr, freeStablePtr, newStablePtr)
 import Nix.Builder (BuildConfig (..), BuildResult (..), buildDerivation, buildWithDeps, defaultBuildConfig, verifyFetchHash)
-import Nix.Builder.Unpack (builtinUnpackBuilder, entryComponents, envSrcs, resolveLinkTarget)
-import Nix.Builtins (builtinEnv, parseNixPath)
+import Nix.Builder.Unpack (UnpackLimits (..), builtinUnpackBuilder, entryComponents, envSrcs, resolveLinkTarget)
+import Nix.Builtins (builtinEnv, parseNixPath, splitNixPath)
 import qualified Nix.DependencyGraph as DepGraph
 import Nix.Derivation (Derivation (..), DerivationOutput (..), Platform (..), currentPlatform, fromATerm, platformToText, toATerm, toATermForHash)
 import Nix.Eval (MonadEval (..), NixValue (..), StringContext (..), StringContextElement (..), Thunk (..), attrSetFromMap, attrSetLookup, attrSetNull, attrSetSize, builtinNames, emptyContext, emptyEnv, eval, force, mkStr, readThunkValue, runPureEval)
@@ -46,7 +47,7 @@ import qualified Nix.Hash as Hash
 import Nix.Parser (parseNix)
 import Nix.Parser.Lexer (Located (..), Token (..), tokenize)
 import Nix.Push (checkRecordedNarHash, computeClosure, loadApiKeyFile, mkNarInfo, narFileName, planMissing, storePathBasename, stripHashPrefix)
-import Nix.Store (Store (..), addToStore, closeStore, copyPathInto, isSafeNarName, isValid, materializeEvalSources, openStore, pathExists, scanReferences, scanTempReferences, setReadOnly, writeDrv)
+import Nix.Store (Store (..), addToStore, closeStore, copyPathInto, isSafeNarName, isValid, materializeEvalSources, openStore, orderLinks, pathExists, scanReferences, scanTempReferences, setReadOnly, writeDrv)
 import Nix.Store.DB (PathInfo (..), PathRegistration (..), closeStoreDB, isValidPath, openStoreDB, queryDeriver, queryPathInfo, queryReferences, registerPath, registerPaths)
 import Nix.Store.Path (StoreDir (..), StorePath (..), defaultStoreDir, parseStorePath, platformStoreDirText, storePathToFilePath, storePathToText, windowsStoreDir)
 import qualified Nix.Substituter as Subst
@@ -875,6 +876,57 @@ testLexer = do
       runTest "subnormal float literal survives" $
         assertRight "lex float-subnormal" (tokenize "<test>" "1.0e-320") $ \toks ->
           assertEqual "tokens" [TokFloat 1.0e-320] (tokenTypes toks),
+      -- Bounded number lexing: a literal's cost must follow its length,
+      -- never its exponent's magnitude, and megadigit literals must
+      -- resolve promptly.  The watchdog turns a cost regression into a
+      -- FAIL instead of a stuck suite; the checks force full values.
+      runTestM "huge positive exponent saturates to Infinity" $ do
+        let saturated = case tokenize "<test>" "1.0e999999999" of
+              Right toks | [TokFloat f] <- tokenTypes toks -> isInfinite f && f > 0
+              _ -> False
+        outcome <- timeout walkWatchdogMicros (evaluate saturated)
+        pure $ case outcome of
+          Just True -> Pass
+          Just False -> Fail "wrong tokens for a huge positive exponent"
+          Nothing -> Fail "lexing did not return promptly",
+      runTestM "huge negative exponent saturates to zero" $ do
+        let flushed = case tokenize "<test>" "1.0e-999999999" of
+              Right toks -> tokenTypes toks == [TokFloat 0.0]
+              Left _ -> False
+        outcome <- timeout walkWatchdogMicros (evaluate flushed)
+        pure $ case outcome of
+          Just True -> Pass
+          Just False -> Fail "wrong tokens for a huge negative exponent"
+          Nothing -> Fail "lexing did not return promptly",
+      runTestM "zero mantissa ignores a huge exponent" $ do
+        let zeroed = case tokenize "<test>" "0.0e999999999" of
+              Right toks -> tokenTypes toks == [TokFloat 0.0]
+              Left _ -> False
+        outcome <- timeout walkWatchdogMicros (evaluate zeroed)
+        pure $ case outcome of
+          Just True -> Pass
+          Just False -> Fail "wrong tokens for a zero mantissa"
+          Nothing -> Fail "lexing did not return promptly",
+      runTestM "megadigit integer literal rejects promptly" $ do
+        let rejected = case tokenize "<test>" (T.replicate 1000000 "9") of
+              Left _ -> True
+              Right _ -> False
+        outcome <- timeout walkWatchdogMicros (evaluate rejected)
+        pure $ case outcome of
+          Just True -> Pass
+          Just False -> Fail "megadigit literal was not rejected"
+          Nothing -> Fail "range rejection did not return promptly",
+      runTestM "megadigit mantissa still rounds correctly" $ do
+        -- 1.999...9e5 sits within half an ulp of 200000.0; the kept-768
+        -- digits plus the sticky digit must round it there.
+        let rounded = case tokenize "<test>" ("1." <> T.replicate 1000000 "9" <> "e5") of
+              Right toks -> tokenTypes toks == [TokFloat 200000.0]
+              Left _ -> False
+        outcome <- timeout walkWatchdogMicros (evaluate rounded)
+        pure $ case outcome of
+          Just True -> Pass
+          Just False -> Fail "wrong rounding for a megadigit mantissa"
+          Nothing -> Fail "lexing did not return promptly",
       runTest "true" $
         assertRight "lex true" (tokenize "<test>" "true") $ \toks ->
           assertEqual "tokens" [TokTrue] (tokenTypes toks),
@@ -2744,6 +2796,11 @@ testDepGraph = do
         | sp == spB = Right drvBCycle
         | sp == spA = Right drvACycle
         | otherwise = Left ("unknown drv: " <> spName sp)
+      -- Self-loop: A depends on itself
+      drvSelf = baseDrv {drvInputDrvs = Map.singleton spA ["out"]}
+      readSelf sp
+        | sp == spA = Right drvSelf
+        | otherwise = Left ("unknown drv: " <> spName sp)
   sequence
     [ -- Single node
       runTest "single node graph" $ case DepGraph.buildDepGraph readSingle drvA spA of
@@ -2802,12 +2859,47 @@ testDepGraph = do
           DepGraph.TopoSorted order ->
             Fail ("cyclic graph topo-sorted as " <> T.pack (show (length order)) <> " nodes")
         -- A loud rejection at graph-build time also counts as detection.
-        Left _ -> Pass
+        Left _ -> Pass,
+      -- A root that depends on itself: the walk marks the root visited
+      -- on enqueue, so it terminates - and per contract the result
+      -- excludes the root, leaving nothing.
+      runTestM "transitiveDeps terminates on a self-loop" $ do
+        outcome <-
+          timeout walkWatchdogMicros $
+            evaluate $ case DepGraph.buildDepGraph readSelf drvSelf spA of
+              Left _ -> Nothing
+              Right graph -> Just $! DepGraph.transitiveDeps graph spA
+        pure $ case outcome of
+          Nothing -> Fail "did not terminate on a self-loop"
+          Just Nothing -> Fail "graph build failed"
+          Just (Just deps) -> assertEqual "self-loop deps" Set.empty deps,
+      -- A two-node cycle already terminated; pin that the root stays
+      -- excluded from its own transitive closure.
+      runTestM "transitiveDeps two-node cycle excludes the root" $ do
+        outcome <-
+          timeout walkWatchdogMicros $
+            evaluate $ case DepGraph.buildDepGraph readCycle drvACycle spA of
+              Left _ -> Nothing
+              Right graph -> Just $! DepGraph.transitiveDeps graph spA
+        pure $ case outcome of
+          Nothing -> Fail "did not terminate on a cycle"
+          Just Nothing -> Fail "graph build failed"
+          Just (Just deps) -> assertEqual "cycle deps" (Set.singleton spB) deps
     ]
 
 -- ---------------------------------------------------------------------------
 -- Tests: Substituter (Phase 3, Batch 6)
 -- ---------------------------------------------------------------------------
+
+-- | A fake HTTP body reader: yields the given chunks, then empty
+-- forever (an HTTP BodyReader is just an IO ByteString).
+chunkReader :: [BS.ByteString] -> IO (IO BS.ByteString)
+chunkReader chunks = do
+  ref <- newIORef chunks
+  pure $
+    atomicModifyIORef' ref $ \case
+      [] -> ([], BS.empty)
+      (c : cs) -> (cs, c)
 
 testSubstituter :: IO [Bool]
 testSubstituter = do
@@ -2828,6 +2920,21 @@ testSubstituter = do
       -- sortCaches: empty list
       runTest "sortCaches empty" $
         assertEqual "empty-sort" [] (Subst.sortCaches []),
+      -- readBodyCapped: the client-side body cap (mirror of the server's
+      -- readBodyLimited).  A body reader is just IO ByteString yielding
+      -- chunks then empty.
+      runTestM "readBodyCapped concatenates under the cap" $ do
+        reader <- chunkReader ["abc", "def", "g"]
+        body <- Subst.readBodyCapped 10 reader
+        pure (assertEqual "under cap" (Just "abcdefg") body),
+      runTestM "readBodyCapped allows exactly the cap" $ do
+        reader <- chunkReader ["abcde", "fghij"]
+        body <- Subst.readBodyCapped 10 reader
+        pure (assertEqual "at cap" (Just "abcdefghij") body),
+      runTestM "readBodyCapped aborts past the cap" $ do
+        reader <- chunkReader ["abcdef", "ghijkl"]
+        body <- Subst.readBodyCapped 10 reader
+        pure (assertEqual "over cap" Nothing body),
       -- decompressorFor decides support from the narinfo value alone,
       -- so unsupported compression rejects before any NAR download.
       runTest "decompressorFor rejects xz up front" $
@@ -3827,6 +3934,9 @@ testUnpackBuildIO = do
           archiveDirLinkBase = workDir </> "pkg-dirlink-base.tar.zst"
           archiveDirLinkCollide = workDir </> "pkg-dirlink-collide.tar.zst"
           archiveHardLinkCollide = workDir </> "pkg-hardlink-collide.tar.zst"
+          archiveManyEntries = workDir </> "pkg-many-entries.tar.zst"
+          archiveBigFile = workDir </> "pkg-big-file.tar.zst"
+          archiveAmplify = workDir </> "pkg-amplify.tar.zst"
       BL.writeFile archiveTools $
         compressArchive
           [ tarDir "pkg",
@@ -3885,6 +3995,20 @@ testUnpackBuildIO = do
             tarFile "smuggle/extra.txt" "smuggled",
             tarHardLink "pkg" "smuggle"
           ]
+      -- Budget probes, built against tiny caps injected via BuildConfig.
+      BL.writeFile archiveManyEntries $
+        compressArchive [tarFile ("e" <> show i <> ".txt") "x" | i <- [1 :: Int .. 6]]
+      BL.writeFile archiveBigFile $
+        compressArchive [tarFile "big.bin" (BL.replicate 100 55)]
+      -- Two directory symlinks each re-copy the 40-byte payload: the
+      -- copies must charge the budget like first-class content.
+      BL.writeFile archiveAmplify $
+        compressArchive
+          [ tarDir "base",
+            tarFile "base/blob.bin" (BL.replicate 40 55),
+            tarSymLink "dup1" "base",
+            tarSymLink "dup2" "base"
+          ]
       let mkUnpackDrv outP srcFiles =
             Derivation
               { drvOutputs =
@@ -3913,6 +4037,9 @@ testUnpackBuildIO = do
           dirLinkOut = StorePath (T.replicate 31 "0" <> "8") "unpack-dirlink"
           dirLinkCollideOut = StorePath (T.replicate 31 "0" <> "9") "unpack-dirlink-collide"
           hardLinkCollideOut = StorePath (T.replicate 30 "0" <> "10") "unpack-hardlink-collide"
+          manyEntriesOut = StorePath (T.replicate 30 "0" <> "11") "unpack-entry-budget"
+          bigFileOut = StorePath (T.replicate 30 "0" <> "12") "unpack-size-budget"
+          amplifyOut = StorePath (T.replicate 30 "0" <> "13") "unpack-amplify-budget"
       buildTmp <- (</> "nova-nix-test-unpack-build-tmp") <$> getTemporaryDirectory
       forceRemoveIfExists buildTmp
       createDirectoryIfMissing True buildTmp
@@ -3926,6 +4053,11 @@ testUnpackBuildIO = do
       dirLinkResult <- buildDerivation config store (mkUnpackDrv dirLinkOut [archiveDirLink])
       dirLinkCollideResult <- buildDerivation config store (mkUnpackDrv dirLinkCollideOut [archiveDirLinkBase, archiveDirLinkCollide])
       hardLinkCollideResult <- buildDerivation config store (mkUnpackDrv hardLinkCollideOut [archiveDirLinkBase, archiveHardLinkCollide])
+      let tinyBudget bytes entries =
+            config {bcUnpackLimits = UnpackLimits {ulMaxBytes = bytes, ulMaxEntries = entries}}
+      manyEntriesResult <- buildDerivation (tinyBudget 1000000 4) store (mkUnpackDrv manyEntriesOut [archiveManyEntries])
+      bigFileResult <- buildDerivation (tinyBudget 64 1000) store (mkUnpackDrv bigFileOut [archiveBigFile])
+      amplifyResult <- buildDerivation (tinyBudget 100 1000) store (mkUnpackDrv amplifyOut [archiveAmplify])
       forceRemoveIfExists buildTmp
       forceRemoveIfExists workDir
       seedChecks <- case seedResult of
@@ -4038,6 +4170,15 @@ testUnpackBuildIO = do
             runTest "unpack: directory hardlink onto existing content fails loudly" $
               rejectedWith "file collision" hardLinkCollideResult
           ]
+      budgetChecks <-
+        sequence
+          [ runTest "unpack: entry budget breach fails loudly" $
+              rejectedWith "entry budget" manyEntriesResult,
+            runTest "unpack: size budget breach fails loudly" $
+              rejectedWith "size budget" bigFileResult,
+            runTest "unpack: directory link copies charge the budget" $
+              rejectedWith "size budget" amplifyResult
+          ]
       -- Unit: the rooted (drive-relative) case is the Blocker-4 Windows vuln.
       -- tar's toLinkTarget refuses an absolute payload on POSIX, so exercise the
       -- guard predicate directly - portable and exact on every host.
@@ -4050,7 +4191,7 @@ testUnpackBuildIO = do
             runTest "unpack guard: rooted hardlink target rejected" $
               assertLeft "rooted hardlink" (entryComponents "/planted-hardlink-target.txt")
           ]
-      pure (seedChecks ++ collideChecks ++ escapeChecks ++ maliciousChecks ++ dirLinkChecks ++ collisionGuardChecks ++ guardChecks)
+      pure (seedChecks ++ collideChecks ++ escapeChecks ++ maliciousChecks ++ dirLinkChecks ++ collisionGuardChecks ++ budgetChecks ++ guardChecks)
 
 -- | Step 2 of the ladder: a dependency-aware build end-to-end.  A root
 -- derivation depends on a leaf; both @.drv@ files are pre-written to the store
@@ -4464,7 +4605,22 @@ testHashHelpers :: IO [Bool]
 testHashHelpers = do
   putStrLn "hash/decode-helpers"
   sequence
-    [ runTest "hexToBytes empty" $ assertEqual "empty" (Just BS.empty) (Hash.hexToBytes ""),
+    [ -- The incremental digest is the streaming twin of the one-shot:
+      -- chunked input must produce identical bytes for every algorithm.
+      runTest "incremental digest matches one-shot across algorithms" $
+        let chunks = ["nova", "-", "nix", " streams", BS.replicate 1000 55]
+            agrees algo = case (Hash.hashInitWithAlgo algo, Hash.rawHashWithAlgo algo (BS.concat chunks)) of
+              (Just ctx0, Just expected) ->
+                Hash.hashFinalizeBytes (foldl' Hash.hashUpdateChunk ctx0 chunks) == expected
+              _ -> False
+         in if all agrees ["sha256", "sha512", "sha1", "md5"]
+              then Pass
+              else Fail "incremental and one-shot digests disagree",
+      runTest "incremental digest rejects an unknown algorithm" $
+        case Hash.hashInitWithAlgo "blake3" of
+          Nothing -> Pass
+          Just _ -> Fail "unknown algorithm accepted",
+      runTest "hexToBytes empty" $ assertEqual "empty" (Just BS.empty) (Hash.hexToBytes ""),
       runTest "hexToBytes deadbeef" $
         assertEqual "deadbeef" (Just (BS.pack [0xde, 0xad, 0xbe, 0xef])) (Hash.hexToBytes "deadbeef"),
       runTest "hexToBytes uppercase" $
@@ -4633,7 +4789,34 @@ testFromTOML :: IO [Bool]
 testFromTOML = do
   putStrLn "eval/fromTOML"
   sequence
-    [ runTest "multi-line array" $
+    [ -- Key splitting and logical-line joining accumulate in chunks, so
+      -- cost is linear in the input (per-character/per-line append was
+      -- quadratic).  The watchdog turns a cost regression into a FAIL
+      -- rather than a stuck suite.
+      runTestM "fromTOML long key parses in linear time" $ do
+        let source =
+              "builtins.length (builtins.attrNames (builtins.fromTOML \""
+                <> T.replicate 200000 "k"
+                <> " = 1\"))"
+            counted = evalNix source == Right (VInt 1)
+        outcome <- timeout walkWatchdogMicros (evaluate counted)
+        pure $ case outcome of
+          Just True -> Pass
+          Just False -> Fail "wrong parse for a long key"
+          Nothing -> Fail "long key did not parse promptly",
+      runTestM "fromTOML many continued lines join in linear time" $ do
+        -- 4000 physical lines of 50 elements each: one ~400KB logical
+        -- line, one 200000-element array.
+        let line = T.intercalate " " (replicate 50 "1,")
+            body = "x = [\n" <> T.intercalate "\n" (replicate 4000 line) <> "\n]"
+            source = "builtins.length (builtins.fromTOML \"" <> body <> "\").x"
+            counted = evalNix source == Right (VInt 200000)
+        outcome <- timeout walkWatchdogMicros (evaluate counted)
+        pure $ case outcome of
+          Just True -> Pass
+          Just False -> Fail "wrong parse for continued lines"
+          Nothing -> Fail "continued lines did not join promptly",
+      runTest "multi-line array" $
         assertEval
           "toml-ml-array"
           "builtins.concatStringsSep \",\" (builtins.fromTOML \"deps = [\\n \\\"bar\\\",\\n \\\"baz\\\",\\n]\\n\").deps"
@@ -5055,6 +5238,65 @@ testSymlinkWalksIO = do
                         <> T.pack (show relTarget)
                     )
         ]
+
+-- | Pure ordering for the store's symlink second pass: each link
+-- follows the pending links its target resolves at or through, and
+-- cycle members fall out at the end in input order.
+testLinkOrdering :: IO [Bool]
+testLinkOrdering = do
+  putStrLn "store/link-ordering"
+  let root = "out"
+  sequence
+    [ runTest "chain orders targets first" $
+        let pending = [(root </> "l1", "l2"), (root </> "l2", "l3"), (root </> "l3", "real")]
+         in assertEqual
+              "chain"
+              [root </> "l3", root </> "l2", root </> "l1"]
+              (map fst (orderLinks pending)),
+      runTest "already-ordered chain is stable" $
+        let pending = [(root </> "l3", "real"), (root </> "l2", "l3"), (root </> "l1", "l2")]
+         in assertEqual
+              "stable"
+              [root </> "l3", root </> "l2", root </> "l1"]
+              (map fst (orderLinks pending)),
+      runTest "link through a linked directory follows it" $
+        let pending = [(root </> "a", "dirlink/x"), (root </> "dirlink", "realdir")]
+         in assertEqual
+              "through-dir"
+              [root </> "dirlink", root </> "a"]
+              (map fst (orderLinks pending)),
+      runTest "parent-relative target orders after its link" $
+        let pending = [(root </> "sub" </> "l", "../other"), (root </> "other", "real")]
+         in assertEqual
+              "dotdot"
+              [root </> "other", root </> "sub" </> "l"]
+              (map fst (orderLinks pending)),
+      runTest "cycle members keep input order at the end" $
+        let pending = [(root </> "a", "b"), (root </> "b", "a"), (root </> "c", "real")]
+         in assertEqual
+              "cycle"
+              [root </> "c", root </> "a", root </> "b"]
+              (map fst (orderLinks pending)),
+      runTest "self-target link survives to the fallback" $
+        assertEqual
+          "self"
+          [root </> "x"]
+          (map fst (orderLinks [(root </> "x", "x")])),
+      runTestM "long chain orders in linear time" $ do
+        -- 20000 links each targeting the next: the ready-set rounds
+        -- this replaced were quadratic here.
+        let chain =
+              [ (root </> ("l" <> show i), T.pack ("l" <> show (i + 1)))
+              | i <- [1 :: Int .. 20000]
+              ]
+                ++ [(root </> "l20001", "real")]
+            complete = length (orderLinks chain) == length chain
+        outcome <- timeout walkWatchdogMicros (evaluate complete)
+        pure $ case outcome of
+          Just True -> Pass
+          Just False -> Fail "ordering dropped links"
+          Nothing -> Fail "ordering did not return promptly"
+    ]
 
 -- ---------------------------------------------------------------------------
 -- Tests: fromATerm + Derivation Output Population (Phase 2, Batch 3)
@@ -5672,6 +5914,23 @@ testPhase4 = do
               _ -> Fail ("expected one entry, got " <> T.pack (show (length result))),
       runTest "parseNixPath multiple" $
         assertEqual "count" 2 (length (parseNixPath "nixpkgs=/nix:custom=/opt")),
+      runTest "splitNixPath drive letters and separators" $
+        assertEqual
+          "split"
+          ["nixpkgs=C:\\nixpkgs", "custom=/opt/custom", "C:/x"]
+          (splitNixPath "nixpkgs=C:\\nixpkgs:custom=/opt/custom:C:/x"),
+      runTest "splitNixPath keeps interior empty entries" $
+        assertEqual "split-empty" ["a", "", "b"] (splitNixPath "a::b"),
+      runTest "splitNixPath drops a trailing empty entry" $
+        assertEqual "split-trail" ["a"] (splitNixPath "a:"),
+      runTestM "splitNixPath long entry splits in linear time" $ do
+        let entry = T.replicate 2000000 "p"
+            split = splitNixPath ("first:" <> entry) == ["first", entry]
+        outcome <- timeout walkWatchdogMicros (evaluate split)
+        pure $ case outcome of
+          Just True -> Pass
+          Just False -> Fail "wrong split for a long entry"
+          Nothing -> Fail "split did not return promptly",
       runTest "parseNixPath plain path" $
         let result = parseNixPath "/some/path"
          in case result of
@@ -7374,6 +7633,7 @@ main = bracket_ arenaInit arenaDestroy $ do
           testParseStorePath,
           testStoreOps,
           testSymlinkWalksIO,
+          testLinkOrdering,
           testFromATerm,
           testBuilder,
           testE2E,


### PR DESCRIPTION
Closes #41.

Number lexing paid costs set by a literal's value, not its length: a
float exponent was applied as exact-Rational 10 ^^ scale, so
1.0e999999999 built a bignum of the exponent's magnitude before
rounding, and the integer range guard built the full bignum of a
literal it then rejected (H1, L1).  The TOML parser accumulated per
character and per line (splitAtEquals, joinLogicalLine), quadratic in
key and logical-line length - a roughly 1MB fromTOML key cost on the
order of an hour of CPU (N4, N5) - and splitNixPath shared the same
per-character append (N6).  builtin:unpack extracted with no output
bound, so a small archive could expand without limit, and an uncharged
directory-link copy let K link entries multiply the output roughly
2^K-fold (M7).  The substituter buffered whole narinfo and NAR bodies
before any verify step, so any cache in the configured list could
drive unbounded buffering (M8), and builtin:fetchurl buffered whole
downloads before hashing (L6).  transitiveDeps never marked the root
visited, recursing forever on a self-dependent root (L5), and
createSymlinks re-stat'd every pending link per ready round, quadratic
on a link chain (N12).

- The lexer saturates: exponent digit runs past 18 stand in for a
  value already far outside double's range; readDouble proves
  overflow/underflow bounds with integer comparisons and returns the
  Infinity or 0.0 strtod rounds such literals to, entering the
  exact-Rational path only inside double's decimal range; mantissas
  keep 768 significant digits with a sticky digit for the dropped tail
  (767 digits decide every binary64 rounding); integer literals
  range-check on significant digit count before any bignum.
  Subnormal parity (1.0e-320) and single-rounding parity are
  unchanged.
- fromTOML's splitAtEquals, joinLogicalLine, and stripInlineComment
  (a third quadratic site the new watchdog tests exposed:
  per-character T.cons, each cons copying the whole tail) and
  splitNixPath all accumulate chunks and concatenate once, O(n).
- builtin:unpack charges every created entry and byte - including
  link-materialization copies - against an UnpackLimits budget carried
  in BuildConfig (default 4 GiB and one million entries, matching the
  largest NAR nova-cache's server accepts).
- The substituter reads bodies in bounded chunks (readBodyCapped, the
  client mirror of the server's readBodyLimited): narinfo bodies are
  capped at the server's same 4 MB, the NAR at the
  signature-verified narinfo's declared FileSize/NarSize.
- builtin:fetchurl streams to the output file through an incremental
  digest (new Nix.Hash API over crypton contexts), holding one chunk
  in memory regardless of download size.
- transitiveDeps marks nodes visited on enqueue, so a self-loop
  terminates and the result stays root-exclusive.
- createSymlinks orders pending links with one pure topological pass
  (orderLinks): each link follows the pending links its target
  resolves at or through, one flavor probe per link, cycle members
  falling back to file links in input order as danglers always did.
- M6 (quadratic .drv string accumulation) was already fixed on main:
  pStringContent scans with bulk BC.break spans.

Tests: watchdogged lexer bounds (saturation, megadigit literals,
sticky-digit rounding), TOML and NIX_PATH linearity, unpack budget
breaches (entry, size, and directory-link amplification) via tiny
budgets injected through BuildConfig, readBodyCapped units,
incremental-vs-one-shot digest equivalence across algorithms,
dependency-graph self-loop termination, and pure orderLinks ordering
(chains, links through linked directories, parent-relative targets,
cycles).
