### PR TITLE
CI: bump run-ormolu to v19

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,11 @@ jobs:
       - uses: actions/checkout@v6
       - uses: haskell-actions/run-ormolu@v19
         with:
+          # Pinned to the version the repo is formatted with: formatting
+          # is not stable across ormolu releases, and a floating version
+          # would fail CI on untouched code when upstream ships one.
+          # Upgrades bump this and the local binary together.
+          version: "0.7.7.0"
           pattern: |
             src/**/*.hs
             app/**/*.hs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: haskell-actions/run-ormolu@v17
+      - uses: haskell-actions/run-ormolu@v19
         with:
           pattern: |
             src/**/*.hs


### PR DESCRIPTION
Closes #58: the v17 wrapper declares the deprecated node20 runtime, so every run warns about the forced node24 migration; v19 declares node24.

Also pins the ormolu binary itself to 0.7.7.0 (the version the tree is formatted with): formatting is not stable across ormolu releases, so the previous floating default failed CI on untouched code whenever upstream shipped one. Upgrades bump the pin and the local binary together.

The hlint actions carry the same warning but have no node24 release yet - tracked in #60.