### PR TITLE
Audit class E: canonical identity versus platform store paths

### DIFF
--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -16,6 +16,7 @@ module Nix.Builtins
   )
 where
 
+import Data.Char (isAsciiLower, isAsciiUpper)
 import Data.Int (Int64)
 import qualified Data.Map.Strict as Map
 import Data.Text (Text)
@@ -23,7 +24,7 @@ import qualified Data.Text as T
 import Foreign.Ptr (nullPtr)
 import Nix.Eval (Env (..), NixValue (..), Thunk (..), attrSetFromMap, builtinNames, currentSystemStr, evaluated)
 import Nix.Eval.Types (clistFromThunks, mkStr, newCEnv, thunkToCPtr)
-import Nix.Store.Path (platformStoreDirText)
+import Nix.Store.Path (defaultStoreDirText)
 
 -- | The initial environment containing all builtins.
 --
@@ -107,7 +108,10 @@ standardEntries timestamp searchPaths =
     [ ("true", evaluated (VBool True)),
       ("false", evaluated (VBool False)),
       ("null", evaluated VNull),
-      ("storeDir", evaluated (mkStr platformStoreDirText)),
+      -- Canonical, not platform: eval-visible store paths carry the
+      -- /nix/store spelling on every platform, and storeDir must agree
+      -- with them (upstream returns the store dir its paths are under).
+      ("storeDir", evaluated (mkStr defaultStoreDirText)),
       ("nixVersion", evaluated (mkStr "2.24.0")),
       ("langVersion", evaluated (VInt 6)),
       ("nixPath", evaluated (VList (clistFromThunks (map thunkToCPtr searchPaths)))),
@@ -147,9 +151,19 @@ parseNixPath raw
                 )
             )
 
--- | Split a NIX_PATH string on colon separators, respecting Windows
--- drive letters.  A colon followed by @\\@ or @/@ (e.g. @C:\\@) is
--- part of a path, not a separator.
+-- | Split a NIX_PATH string on colon separators.  A colon stays part of
+-- its entry, rather than separating, in exactly two shapes:
+--
+-- * a URL colon - followed by @//@ - so an entry like
+--   @nixpkgs=https://example.com/nixpkgs.tar.gz@ stays whole (upstream's
+--   NIX_PATH parser keeps pseudo-URL entries whole);
+-- * a Windows drive colon - preceded by a single ASCII letter that opens
+--   the entry or follows @=@, and followed by @\\@ or @/@ - so @C:\\x@,
+--   @C:/x@, and @nixpkgs=C:\\x@ stay whole.
+--
+-- Every other colon separates, so a Unix-style list of absolute paths
+-- (@/foo:/bar@) splits at each colon: @/foo@ does not end in a drive
+-- letter, and a lone @/@ after the colon is not a URL.
 splitNixPath :: Text -> [Text]
 splitNixPath = go []
   where
@@ -162,12 +176,23 @@ splitNixPath = go []
               let entry = T.concat (reverse (chunk : chunks))
                in [entry | not (T.null entry)]
             Just (_, afterColon)
-              | isDriveSep afterColon ->
+              | keepsColon (null chunks) chunk afterColon ->
                   go (T.take 1 afterColon : ":" : chunk : chunks) (T.drop 1 afterColon)
               | otherwise ->
                   T.concat (reverse (chunk : chunks)) : go [] afterColon
-    -- After a colon, if the next char is \ or /, it's a drive letter
-    isDriveSep t = case T.uncons t of
-      Just ('\\', _) -> True
-      Just ('/', _) -> True
-      _ -> False
+    -- Whether the colon between chunk and afterColon is a URL or drive
+    -- colon (the two shapes above).  atEntryStart says chunk opens its
+    -- entry (nothing absorbed before it), so a lone letter can only be a
+    -- drive letter there.
+    keepsColon atEntryStart chunk afterColon
+      | T.isPrefixOf "//" afterColon = True
+      | startsWithPathSep afterColon = endsInDriveLetter atEntryStart chunk
+      | otherwise = False
+    startsWithPathSep t = case T.uncons t of
+      Just (c, _) -> c == '/' || c == '\\'
+      Nothing -> False
+    endsInDriveLetter atEntryStart chunk = case T.unsnoc chunk of
+      Just (beforeLetter, letter) ->
+        (isAsciiUpper letter || isAsciiLower letter)
+          && (T.isSuffixOf "=" beforeLetter || (atEntryStart && T.null beforeLetter))
+      Nothing -> False

--- a/src/Nix/Eval/IO.hs
+++ b/src/Nix/Eval/IO.hs
@@ -250,7 +250,7 @@ instance MonadEval EvalIO where
   -- values keep arbitrary bytes).  Any failure - absent file, malformed ATerm
   -- - is 'Nothing', which the caller turns into a loud modulo-hash error.
   readStoreDerivation sp = EvalIO $ do
-    let filePath = SP.storePathToFilePath SP.defaultStoreDir sp
+    let filePath = platformFilePath sp
     result <- liftIO (try (BS.readFile filePath) :: IO (Either SomeException BS.ByteString))
     pure $ case result of
       Left _ -> Nothing
@@ -285,7 +285,7 @@ instance MonadEval EvalIO where
         entry <- wrapIO (NAR.serialiseFromPath (T.unpack rawPath))
         let narDigest = sha256Digest (NAR.serialise entry)
         sp <- storePathOrThrow copyContext (makeFixedOutputPath name "sha256" "recursive" narDigest)
-        let spText = SP.storePathToText SP.defaultStoreDir sp
+        let spText = canonicalStorePathText sp
         EvalIO (liftIO (modifyIORef' ref (Map.insert rawPath spText)))
         pure spText
 
@@ -301,8 +301,8 @@ instance MonadEval EvalIO where
     -- (which would CRLF-translate on Windows and store bytes that no
     -- longer match the hash that named the path).
     sp <- storePathOrThrow "builtins.toFile" (makeTextPath name (sha256Digest contents) refs)
-    let filePath = SP.storePathToFilePath SP.defaultStoreDir sp
-        storePath = SP.storePathToText SP.defaultStoreDir sp
+    let filePath = platformFilePath sp
+        storePath = canonicalStorePathText sp
     wrapIO $ do
       Dir.createDirectoryIfMissing True (takeDirectory filePath)
       BS.writeFile filePath contents
@@ -379,8 +379,8 @@ instance MonadEval EvalIO where
               )
       _ -> pure ()
     sp <- storePathOrThrow copyContext (makeFixedOutputPath name "sha256" "recursive" narDigest)
-    let destFilePath = SP.storePathToFilePath SP.defaultStoreDir sp
-        destPath = SP.storePathToText SP.defaultStoreDir sp
+    let destFilePath = platformFilePath sp
+        destPath = canonicalStorePathText sp
     wrapIO (copyToStoreIfMissing (T.unpack srcPath) destFilePath (takeDirectory destFilePath))
     pure destPath
 
@@ -396,8 +396,8 @@ instance MonadEval EvalIO where
       Left err -> throwEvalError ("builtins.path: internal NAR round-trip error: " <> T.pack err)
       Right entry -> do
         sp <- storePathOrThrow "builtins.path" (makeFixedOutputPath name "sha256" "recursive" (sha256Digest narBytes))
-        let destFilePath = SP.storePathToFilePath SP.defaultStoreDir sp
-            destPath = SP.storePathToText SP.defaultStoreDir sp
+        let destFilePath = platformFilePath sp
+            destPath = canonicalStorePathText sp
         wrapIO $ do
           alreadyThere <- Dir.doesPathExist destFilePath
           unless alreadyThere $ do
@@ -410,8 +410,8 @@ instance MonadEval EvalIO where
     -- Canonical fixed-output path: a sha256-pinned fetch must land at the same
     -- store path C++ Nix computes, so it stays reproducible and cache-compatible.
     sp <- storePathOrThrow "builtins.fetchurl" (makeFixedOutputPath name "sha256" "flat" (sha256Digest bytes))
-    let filePath = SP.storePathToFilePath SP.defaultStoreDir sp
-        storePath = SP.storePathToText SP.defaultStoreDir sp
+    let filePath = platformFilePath sp
+        storePath = canonicalStorePathText sp
     wrapIO $ do
       Dir.createDirectoryIfMissing True (takeDirectory filePath)
       BS.writeFile filePath bytes
@@ -550,6 +550,19 @@ importCacheMaxAttrs = 1000
 -- ---------------------------------------------------------------------------
 -- Helpers
 -- ---------------------------------------------------------------------------
+
+-- | Where a store path lives on this machine: the platform store dir
+-- mapped to a filesystem path.  Every eval-time read and write of a
+-- store object resolves through this, landing in the same store the
+-- builder and CLI operate on.
+platformFilePath :: SP.StorePath -> FilePath
+platformFilePath = SP.storePathToFilePath SP.platformStoreDir
+
+-- | A store path's identity: the canonical @/nix/store@ spelling every
+-- platform shares.  Hashes and eval-visible strings carry this form; it
+-- never names a location on disk.
+canonicalStorePathText :: SP.StorePath -> Text
+canonicalStorePathText = SP.storePathToText SP.defaultStoreDir
 
 -- | Classify a filesystem path as @"regular"@, @"directory"@, @"symlink"@,
 -- or @"unknown"@ - matching Nix's @builtins.readDir@ / @readFileType@.

--- a/src/Nix/Eval/IO.hs
+++ b/src/Nix/Eval/IO.hs
@@ -174,10 +174,10 @@ instance MonadEval EvalIO where
       Left err@(NixEvalError ErrorUncatchable _) -> liftIO (throwIO err)
       Right val -> pure (Right val)
 
-  doesPathExist path = wrapIO (Dir.doesPathExist (T.unpack path))
+  doesPathExist path = wrapIO (Dir.doesPathExist (SP.storeTextToFilePath path))
 
   listDirectory path = wrapIO $ do
-    let dir = T.unpack path
+    let dir = SP.storeTextToFilePath path
     entries <- Dir.listDirectory dir
     mapM (classifyEntry dir) entries
 
@@ -185,20 +185,14 @@ instance MonadEval EvalIO where
     baseDir <- EvalIO (asks esBaseDir)
     timestamp <- EvalIO (asks esTimestamp)
     searchPaths <- EvalIO (asks esSearchPaths)
-    let raw = T.unpack rawPath
-        resolved = if isRelative raw then baseDir </> raw else raw
-    canonical <- wrapIO (Dir.canonicalizePath resolved)
-    -- Directory import: append /default.nix if target is a directory
-    target <- wrapIO $ do
-      isDir <- Dir.doesDirectoryExist canonical
-      pure (if isDir then canonical </> "default.nix" else canonical)
+    (target, ioTarget) <- resolveImportTarget baseDir rawPath
     -- Check import cache (readIORef cannot throw, no wrapIO needed)
     cacheRef <- EvalIO (asks esImportCache)
     cache <- EvalIO (liftIO (readIORef cacheRef))
     case Map.lookup target cache of
       Just cached -> pure cached
       Nothing -> do
-        source <- wrapIO (readFileAutoEncoding target)
+        source <- wrapIO (readFileAutoEncoding ioTarget)
         case parseNix (T.pack target) source of
           Left err ->
             throwEvalError
@@ -282,7 +276,7 @@ instance MonadEval EvalIO where
         case SP.checkStorePathName name of
           Left err -> throwEvalError (copyContext <> ": " <> SP.storePathNameErrorText err)
           Right () -> pure ()
-        entry <- wrapIO (NAR.serialiseFromPath (T.unpack rawPath))
+        entry <- wrapIO (NAR.serialiseFromPath (SP.storeTextToFilePath rawPath))
         let narDigest = sha256Digest (NAR.serialise entry)
         sp <- storePathOrThrow copyContext (makeFixedOutputPath name "sha256" "recursive" narDigest)
         let spText = canonicalStorePathText sp
@@ -312,14 +306,8 @@ instance MonadEval EvalIO where
     baseDir <- EvalIO (asks esBaseDir)
     timestamp <- EvalIO (asks esTimestamp)
     searchPaths <- EvalIO (asks esSearchPaths)
-    let raw = T.unpack rawPath
-        resolved = if isRelative raw then baseDir </> raw else raw
-    canonical <- wrapIO (Dir.canonicalizePath resolved)
-    -- Directory import: append /default.nix if target is a directory
-    target <- wrapIO $ do
-      isDir <- Dir.doesDirectoryExist canonical
-      pure (if isDir then canonical </> "default.nix" else canonical)
-    source <- wrapIO (readFileAutoEncoding target)
+    (target, ioTarget) <- resolveImportTarget baseDir rawPath
+    source <- wrapIO (readFileAutoEncoding ioTarget)
     case parseNix (T.pack target) source of
       Left err ->
         throwEvalError
@@ -335,9 +323,9 @@ instance MonadEval EvalIO where
               (unEvalIO (eval scopedEnv expr))
           )
 
-  readFileBytes path = wrapIO (BS.readFile (T.unpack path))
+  readFileBytes path = wrapIO (BS.readFile (SP.storeTextToFilePath path))
 
-  getFileType path = wrapIO (classifyPath (T.unpack path))
+  getFileType path = wrapIO (classifyPath (SP.storeTextToFilePath path))
 
   runProcess cmd cmdArgs stdinText = wrapIO $ do
     let cp =
@@ -365,7 +353,7 @@ instance MonadEval EvalIO where
     -- existence check in copyToStoreIfMissing is sound - changed source
     -- content can never serve stale bytes from an earlier copy (the old
     -- scheme hashed the path STRING, so it did exactly that).
-    entry <- wrapIO (NAR.serialiseFromPath (T.unpack srcPath))
+    entry <- wrapIO (NAR.serialiseFromPath (SP.storeTextToFilePath srcPath))
     let narDigest = sha256Digest (NAR.serialise entry)
     case expectedSha256 of
       Just (subject, expected)
@@ -381,12 +369,12 @@ instance MonadEval EvalIO where
     sp <- storePathOrThrow copyContext (makeFixedOutputPath name "sha256" "recursive" narDigest)
     let destFilePath = platformFilePath sp
         destPath = canonicalStorePathText sp
-    wrapIO (copyToStoreIfMissing (T.unpack srcPath) destFilePath (takeDirectory destFilePath))
+    wrapIO (copyToStoreIfMissing (SP.storeTextToFilePath srcPath) destFilePath (takeDirectory destFilePath))
     pure destPath
 
-  isExecutableFile path = wrapIO (Dir.executable <$> Dir.getPermissions (T.unpack path))
+  isExecutableFile path = wrapIO (Dir.executable <$> Dir.getPermissions (SP.storeTextToFilePath path))
 
-  readSymlinkTarget path = wrapIO (T.pack <$> Dir.getSymbolicLinkTarget (T.unpack path))
+  readSymlinkTarget path = wrapIO (T.pack <$> Dir.getSymbolicLinkTarget (SP.storeTextToFilePath path))
 
   addSourceNar name narBytes =
     case NAR.deserialise narBytes of
@@ -563,6 +551,34 @@ platformFilePath = SP.storePathToFilePath SP.platformStoreDir
 -- never names a location on disk.
 canonicalStorePathText :: SP.StorePath -> Text
 canonicalStorePathText = SP.storePathToText SP.defaultStoreDir
+
+-- | Resolve an import's raw path to the value-domain target (the import
+-- cache key, the parse name, and the base dir the file's relative path
+-- literals resolve against) and the filesystem location to read.
+--
+-- Store text stays canonical in the value domain: 'Dir.canonicalizePath'
+-- would attach the working drive to the rooted @/nix@ prefix on Windows,
+-- so store text gets lexical canonicalization ('canonPath') only, and
+-- its reads resolve through 'SP.storeTextToFilePath'.  Every other path
+-- resolves and canonicalizes as a platform path, where the two returned
+-- forms coincide.
+resolveImportTarget :: FilePath -> Text -> EvalIO (FilePath, FilePath)
+resolveImportTarget baseDir rawPath
+  | SP.isCanonicalStoreText rawPath = do
+      let valueBase = T.unpack (canonPath rawPath)
+      isDir <- wrapIO (Dir.doesDirectoryExist (SP.storeTextToFilePath (T.pack valueBase)))
+      -- The value-domain join stays "/" so the canonical spelling survives.
+      let valueTarget = if isDir then valueBase <> "/default.nix" else valueBase
+      pure (valueTarget, SP.storeTextToFilePath (T.pack valueTarget))
+  | otherwise = do
+      let raw = T.unpack rawPath
+          resolved = if isRelative raw then baseDir </> raw else raw
+      canonical <- wrapIO (Dir.canonicalizePath resolved)
+      -- Directory import: append /default.nix if target is a directory
+      target <- wrapIO $ do
+        isDir <- Dir.doesDirectoryExist canonical
+        pure (if isDir then canonical </> "default.nix" else canonical)
+      pure (target, target)
 
 -- | Classify a filesystem path as @"regular"@, @"directory"@, @"symlink"@,
 -- or @"unknown"@ - matching Nix's @builtins.readDir@ / @readFileType@.

--- a/src/Nix/Store/Path.hs
+++ b/src/Nix/Store/Path.hs
@@ -41,6 +41,8 @@ module Nix.Store.Path
     StorePath (..),
     storePathToFilePath,
     storePathToText,
+    isCanonicalStoreText,
+    storeTextToFilePath,
     parseStorePath,
     parseStorePathBaseName,
 
@@ -114,6 +116,29 @@ storePathToFilePath (StoreDir dir) sp =
 storePathToText :: StoreDir -> StorePath -> Text
 storePathToText (StoreDir dir) sp =
   T.pack dir <> "/" <> spHash sp <> "-" <> spName sp
+
+-- | Whether path text lies under the canonical store dir: exactly
+-- @\/nix\/store@, or @\/nix\/store@ followed by a separator of either
+-- spelling.  This is the spelling writers put into eval-visible values.
+isCanonicalStoreText :: Text -> Bool
+isCanonicalStoreText txt = case T.stripPrefix defaultStoreDirText txt of
+  Just rest -> case T.uncons rest of
+    Nothing -> True
+    Just (c, _) -> c == '/' || c == '\\'
+  Nothing -> False
+
+-- | Resolve path-value text to the filesystem location it names: text
+-- under the canonical store dir resolves into the platform store dir,
+-- and every other path is taken as written.  Writers emit the canonical
+-- spelling into eval values, so every reader that performs IO on a path
+-- value must resolve through this - on Windows the rooted @\/nix@ prefix
+-- would otherwise resolve against the working drive.  On Unix the two
+-- dirs coincide and this is 'T.unpack'.
+storeTextToFilePath :: Text -> FilePath
+storeTextToFilePath txt
+  | isCanonicalStoreText txt =
+      unStoreDir platformStoreDir <> T.unpack (T.drop (T.length defaultStoreDirText) txt)
+  | otherwise = T.unpack txt
 
 -- | Length of the Nix base-32 hash component in store paths (32 chars).
 storePathHashLen :: Int

--- a/src/Nix/Store/Path.hs
+++ b/src/Nix/Store/Path.hs
@@ -77,8 +77,9 @@ defaultStoreDirText = T.pack (unStoreDir defaultStoreDir)
 
 -- | Platform-appropriate store directory.
 -- Returns @C:\\nix\\store@ on Windows, @\/nix\/store@ on Unix.
--- Use this for filesystem operations and user-facing output.
--- Use 'defaultStoreDir' only for Nix-internal canonical paths (ATerm hashing).
+-- Use this for filesystem operations and operator-facing output.
+-- Use 'defaultStoreDir' for identity - hashing, ATerm text, and every
+-- eval-visible store-path string (including @builtins.storeDir@).
 platformStoreDir :: StoreDir
 platformStoreDir = case System.Info.os of
   "mingw32" -> windowsStoreDir
@@ -86,7 +87,6 @@ platformStoreDir = case System.Info.os of
 
 -- | Platform-appropriate store directory as 'Text'.
 -- Returns @C:\\nix\\store@ on Windows, @\/nix\/store@ on Unix.
--- Used for user-facing values like @builtins.storeDir@.
 platformStoreDirText :: Text
 platformStoreDirText = T.pack (unStoreDir platformStoreDir)
 

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -49,7 +49,7 @@ import Nix.Parser.Lexer (Located (..), Token (..), tokenize)
 import Nix.Push (checkRecordedNarHash, computeClosure, loadApiKeyFile, mkNarInfo, narFileName, planMissing, storePathBasename, stripHashPrefix)
 import Nix.Store (Store (..), addToStore, closeStore, copyPathInto, isSafeNarName, isValid, materializeEvalSources, openStore, orderLinks, pathExists, scanReferences, scanTempReferences, setReadOnly, writeDrv)
 import Nix.Store.DB (PathInfo (..), PathRegistration (..), closeStoreDB, isValidPath, openStoreDB, queryDeriver, queryPathInfo, queryReferences, registerPath, registerPaths)
-import Nix.Store.Path (StoreDir (..), StorePath (..), defaultStoreDir, parseStorePath, platformStoreDirText, storePathToFilePath, storePathToText, windowsStoreDir)
+import Nix.Store.Path (StoreDir (..), StorePath (..), defaultStoreDir, defaultStoreDirText, parseStorePath, platformStoreDirText, storePathToFilePath, storePathToText, windowsStoreDir)
 import qualified Nix.Substituter as Subst
 import qualified NovaCache.Base64 as B64
 import qualified NovaCache.Hash as CHash
@@ -1477,7 +1477,7 @@ testBatch1 = do
         assertEval "lt-str" "builtins.lessThan \"a\" \"b\"" (VBool True),
       -- Constants
       runTest "storeDir" $
-        assertEval "storeDir" "builtins.storeDir" (mkStr platformStoreDirText),
+        assertEval "storeDir" "builtins.storeDir" (mkStr defaultStoreDirText),
       runTest "nixVersion" $
         assertEval "nixVersion" "builtins.nixVersion" (mkStr "2.24.0"),
       runTest "langVersion" $
@@ -5919,6 +5919,15 @@ testPhase4 = do
           "split"
           ["nixpkgs=C:\\nixpkgs", "custom=/opt/custom", "C:/x"]
           (splitNixPath "nixpkgs=C:\\nixpkgs:custom=/opt/custom:C:/x"),
+      runTest "splitNixPath splits a Unix-style absolute path list" $
+        assertEqual "split-unix" ["/foo", "/bar"] (splitNixPath "/foo:/bar"),
+      runTest "splitNixPath splits a Unix entry after a drive entry" $
+        assertEqual "split-mixed" ["C:\\a", "/foo"] (splitNixPath "C:\\a:/foo"),
+      runTest "splitNixPath keeps a URL entry whole" $
+        assertEqual
+          "split-url"
+          ["nixpkgs=https://example.com/nixpkgs.tar.gz", "custom=/opt"]
+          (splitNixPath "nixpkgs=https://example.com/nixpkgs.tar.gz:custom=/opt"),
       runTest "splitNixPath keeps interior empty entries" $
         assertEqual "split-empty" ["a", "", "b"] (splitNixPath "a::b"),
       runTest "splitNixPath drops a trailing empty entry" $

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -49,7 +49,7 @@ import Nix.Parser.Lexer (Located (..), Token (..), tokenize)
 import Nix.Push (checkRecordedNarHash, computeClosure, loadApiKeyFile, mkNarInfo, narFileName, planMissing, storePathBasename, stripHashPrefix)
 import Nix.Store (Store (..), addToStore, closeStore, copyPathInto, isSafeNarName, isValid, materializeEvalSources, openStore, orderLinks, pathExists, scanReferences, scanTempReferences, setReadOnly, writeDrv)
 import Nix.Store.DB (PathInfo (..), PathRegistration (..), closeStoreDB, isValidPath, openStoreDB, queryDeriver, queryPathInfo, queryReferences, registerPath, registerPaths)
-import Nix.Store.Path (StoreDir (..), StorePath (..), defaultStoreDir, defaultStoreDirText, parseStorePath, platformStoreDirText, storePathToFilePath, storePathToText, windowsStoreDir)
+import Nix.Store.Path (StoreDir (..), StorePath (..), defaultStoreDir, defaultStoreDirText, isCanonicalStoreText, parseStorePath, platformStoreDir, platformStoreDirText, storePathToFilePath, storePathToText, storeTextToFilePath, windowsStoreDir)
 import qualified Nix.Substituter as Subst
 import qualified NovaCache.Base64 as B64
 import qualified NovaCache.Hash as CHash
@@ -250,7 +250,33 @@ testStorePaths = do
           (T.unpack (storePathToText defaultStoreDir sp)),
       runTest "store path ordering" $
         let sp2 = StorePath {spHash = "zzz", spName = "later"}
-         in assertEqual "Ord" True (sp < sp2)
+         in assertEqual "Ord" True (sp < sp2),
+      -- The reader-side mapping: canonical store text resolves into the
+      -- platform store dir; everything else is the path as written.
+      runTest "store text maps into the platform store dir" $
+        assertEqual
+          "mapped"
+          (unStoreDir platformStoreDir <> "/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-x/sub/f")
+          (storeTextToFilePath "/nix/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-x/sub/f"),
+      runTest "bare store dir text maps to the platform store root" $
+        assertEqual "mapped-root" (unStoreDir platformStoreDir) (storeTextToFilePath "/nix/store"),
+      runTest "store text with a backslash subpath maps" $
+        assertEqual
+          "mapped-backslash"
+          (unStoreDir platformStoreDir <> "\\bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-y")
+          (storeTextToFilePath "/nix/store\\bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-y"),
+      runTest "non-store text is the path as written" $
+        assertEqual "unmapped" "/etc/hosts" (storeTextToFilePath "/etc/hosts"),
+      runTest "a store-prefix-like name does not map" $
+        assertEqual "unmapped-like" "/nix/storefoo" (storeTextToFilePath "/nix/storefoo"),
+      runTest "isCanonicalStoreText accepts both separators and rejects lookalikes" $
+        assertEqual
+          "predicate"
+          [True, True, True, False, False]
+          ( map
+              isCanonicalStoreText
+              ["/nix/store", "/nix/store/x", "/nix/store\\x", "/nix/storefoo", "C:\\nix\\store\\x"]
+          )
     ]
 
 -- ---------------------------------------------------------------------------
@@ -1993,8 +2019,8 @@ testPathSymlinkBody = do
   results <- case (spFor "path-symlink-src" linkEntry, spFor "path-symlink-cycle" cycleEntry) of
     (Right linkSp, Right cycleSp) -> do
       -- The same mapping the evaluator's copy uses for its destination.
-      let linkDest = storePathToFilePath defaultStoreDir linkSp
-          cycleDest = storePathToFilePath defaultStoreDir cycleSp
+      let linkDest = storePathToFilePath platformStoreDir linkSp
+          cycleDest = storePathToFilePath platformStoreDir cycleSp
       -- A leftover materialization from an earlier (possibly pre-fix) run
       -- would short-circuit the copy under test.
       Dir.removePathForcibly linkDest


### PR DESCRIPTION
Closes #42.

The class root: the canonical store dir (/nix/store) is for identity - hashing, ATerm text, eval-visible strings - and the platform store dir (C:\nix\store on Windows) is for filesystem IO. All three findings fixed.

**M3 - builtins.storeDir returned the platform spelling.** Eval-visible store paths carry the canonical spelling on every platform, and storeDir now agrees with them (defaultStoreDirText, matching upstream, where storeDir is the dir its paths are under). The test that pinned the platform spelling is flipped.

**N11 - eval-time store IO resolved through the canonical dir.** writeToStore (toFile), copyPathToStore, addSourceNar (builtins.path), addFixedOutputFile (fetchurl), and the read side readStoreDerivation computed their on-disk path with storePathToFilePath defaultStoreDir, which lands on the wrong drive whenever the working directory is off the store drive. Two named helpers in Nix.Eval.IO now make the boundary structural: platformFilePath (every filesystem read/write) and canonicalStorePathText (every identity string). defaultStoreDir appears in the module only inside the identity helper, so the invariant is greppable. The issue named the four write sinks; readStoreDerivation is the same boundary miss on the read side and is included.

**L3 - splitNixPath merged Unix-style entries.** The old rule treated any colon followed by / or \ as a drive colon, so a NIX_PATH of /foo:/bar parsed as one entry. The new rule keeps a colon inside its entry in exactly two shapes: a URL colon (followed by //, keeping nixpkgs=https://... whole, as upstream's NIX_PATH parsing does) and a drive colon (a single ASCII letter opening the entry or following =, then \ or /). New tests pin the Unix list split, a mixed drive-then-Unix list, and URL wholeness; the existing drive-letter, empty-entry, and linear-time pins are unchanged.

Notes:
- N11 is observable only with a working directory off the store drive, which CI cannot exercise; the named helpers make the invariant structural instead.
- Out of scope, unchanged behavior: upstream's pseudo-URL scheme allowlist and channel: entries (our URL rule is the shape test ://). Filing as a follow-up parity note.

cabal test passes, -Werror build clean, ormolu and hlint clean on the changed files.