### PR TITLE
Audit class G: store DB foreign keys enforced

### DIFF
--- a/src/Nix/Store/DB.hs
+++ b/src/Nix/Store/DB.hs
@@ -139,7 +139,8 @@ createRefsSQL =
 
 -- | Open (or create) the store database.
 -- Creates the store directory, metadata subdirectory, and database
--- tables if they don't exist.  Enables WAL mode for concurrency.
+-- tables if they don't exist.  Enables WAL mode for concurrency and
+-- foreign-key enforcement for referential integrity.
 openStoreDB :: StoreDir -> IO StoreDB
 openStoreDB dir = do
   let storeRoot = unStoreDir dir
@@ -148,6 +149,11 @@ openStoreDB dir = do
   createDirectoryIfMissing True metaDir
   conn <- open dbPath
   execute_ conn "PRAGMA journal_mode=WAL"
+  -- SQLite leaves foreign keys OFF per connection; without this the Refs
+  -- REFERENCES clauses are inert, and deleting a ValidPaths row (path
+  -- deletion, garbage collection) would leave dangling Refs edges that
+  -- closure JOINs silently under-report.
+  execute_ conn "PRAGMA foreign_keys=ON"
   execute_ conn (fromString createValidPathsSQL)
   execute_ conn (fromString createRefsSQL)
   pure StoreDB {sdbDir = dir, sdbConn = conn}


### PR DESCRIPTION
Closes #44.

N14: the schema declares REFERENCES ValidPaths(id) on both Refs columns, but SQLite leaves foreign-key enforcement off per connection, so the declared integrity was inert - a future ValidPaths delete (path deletion #23, garbage collection #24) would silently leave dangling Refs edges that closure JOINs under-report. openStoreDB now sets PRAGMA foreign_keys=ON alongside the WAL pragma, with the constraint stated at the site.

The other register item, N16 (key types deriving Show and Eq), lives in nova-cache as Novavero-AI/nova-cache#21; the nova-nix PushConfig angle is covered by that fix.

On testing: enforcement is per-connection state, and no current public API can produce a violating statement - registerPaths id-checks every referent before inserting an edge, updates never touch ids, and no delete exists yet - so the enforcement itself becomes exercisable (and will get its test) with #23's delete primitive. What the suite does prove is the other direction: the full DB battery (registration, re-registration, batch edges, closure queries) runs with enforcement on and passes unchanged.

cabal test passes, -Werror build clean, ormolu and hlint clean.