### PR TITLE
Audit class J: Windows build PATH and environment casing

### DIFF
--- a/src/Nix/Builder.hs
+++ b/src/Nix/Builder.hs
@@ -41,6 +41,8 @@ module Nix.Builder
     defaultBuildConfig,
 
     -- * Pure pieces (exported for tests)
+    buildPath,
+    unionEnvs,
     verifyFetchHash,
   )
 where
@@ -48,7 +50,7 @@ where
 import Control.Exception (IOException, SomeException, displayException, finally, try)
 import Control.Monad (filterM, when)
 import qualified Data.ByteString as BS
-import Data.Char (toLower)
+import Data.Char (toLower, toUpper)
 import Data.Either (fromRight)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
@@ -375,19 +377,45 @@ buildEnvironment config decodedEnv builderPath buildDir outputDirs =
             (envSourceDateEpoch, sourceDateEpochValue)
           ]
    in -- Priority: output paths > derivation env > standard env
-      Map.unions [outputEnv, baseEnv, standardEnv]
+      unionEnvs [outputEnv, baseEnv, standardEnv]
+
+-- | Union environment maps left to right (an earlier map's variable wins).
+-- On Windows environment names are one case-insensitive namespace, so
+-- displacement folds names by per-character uppercase - matching the
+-- kernel's env-name comparison - and the winner keeps its own spelling:
+-- a build's @PATH@ must displace an inherited @Path@, or both would land
+-- in the child's environment block and which one the child sees would be
+-- runtime-dependent.  On Unix names are distinct by case and this is
+-- 'Map.unions'.
+unionEnvs :: [Map Text Text] -> Map Text Text
+unionEnvs envs
+  | isWindows =
+      let foldName = T.map toUpper
+          folded =
+            [ Map.fromList [(foldName name, (name, val)) | (name, val) <- Map.toList env]
+            | env <- envs
+            ]
+       in Map.fromList (Map.elems (Map.unions folded))
+  | otherwise = Map.unions envs
 
 -- | Construct the build PATH from the builder's location.
 -- Includes the builder's directory, its sibling @usr\/bin@ (for MSYS2
 -- coreutils bundled with Git for Windows), and system directories.
 -- On a bootstrapped store, the builder's dir IS a store path, so this
 -- naturally becomes a store-only PATH.
+--
+-- A bare-name or dot-relative builder has no directory to derive: @.@
+-- here would put the BUILD WORKING DIRECTORY first on PATH, so a file
+-- dropped into the build dir would resolve ahead of every tool.  Such
+-- builders get the system directories only.
 buildPath :: FilePath -> Text
 buildPath builderPath =
   let builderDir = takeDirectory builderPath
       parentDir = takeDirectory builderDir
       -- Builder's own dir + coreutils sibling (MSYS2 layout)
-      builderDirs = [builderDir, parentDir </> "usr" </> "bin"]
+      builderDirs
+        | builderDir == "." = []
+        | otherwise = [builderDir, parentDir </> "usr" </> "bin"]
       systemDirs =
         if System.Info.os == "mingw32"
           then ["C:\\Windows\\System32", "C:\\Windows"]
@@ -422,8 +450,8 @@ runBuilder ::
 runBuilder builderPath builderArgs buildEnv workDir = do
   systemEnv <- System.Environment.getEnvironment
   let systemMap = Map.fromList [(T.pack k, T.pack v) | (k, v) <- systemEnv]
-      -- Build env wins over system env
-      mergedEnv = Map.union buildEnv systemMap
+      -- Build env wins over system env, displacing case variants on Windows
+      mergedEnv = unionEnvs [buildEnv, systemMap]
       envList = [(T.unpack k, T.unpack v) | (k, v) <- Map.toList mergedEnv]
       cp =
         (mkBuilderProcess builderPath builderArgs)

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -15,7 +15,7 @@ import qualified Data.ByteString.Lazy as BL
 import Data.IORef (atomicModifyIORef', newIORef, readIORef)
 import Data.List (foldl')
 import qualified Data.Map.Strict as Map
-import Data.Maybe (fromMaybe, isJust)
+import Data.Maybe (fromMaybe, isJust, listToMaybe)
 import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as T
@@ -24,7 +24,7 @@ import Data.Text.Encoding.Error (lenientDecode)
 import qualified Data.Text.IO as TIO
 import Foreign.Ptr (castPtr)
 import Foreign.StablePtr (StablePtr, castPtrToStablePtr, castStablePtrToPtr, deRefStablePtr, freeStablePtr, newStablePtr)
-import Nix.Builder (BuildConfig (..), BuildResult (..), buildDerivation, buildWithDeps, defaultBuildConfig, verifyFetchHash)
+import Nix.Builder (BuildConfig (..), BuildResult (..), buildDerivation, buildPath, buildWithDeps, defaultBuildConfig, unionEnvs, verifyFetchHash)
 import Nix.Builder.Unpack (UnpackLimits (..), builtinUnpackBuilder, entryComponents, envSrcs, resolveLinkTarget)
 import Nix.Builtins (builtinEnv, parseNixPath, splitNixPath)
 import qualified Nix.DependencyGraph as DepGraph
@@ -3213,6 +3213,29 @@ testBuildOrchestrator = do
     [ -- BuildConfig has caches field
       runTest "defaultBuildConfig has empty caches" $
         assertEqual "empty-caches" [] (bcCaches (defaultBuildConfig defaultStoreDir)),
+      -- The build PATH must never open with the build working directory:
+      -- a bare-name builder has no directory to derive.
+      runTest "bare-name builder derives no PATH entry" $
+        let entries = T.splitOn (if SI.os == "mingw32" then ";" else ":") (buildPath "bash")
+         in assertEqual "no-dot" False (any (\e -> e == "." || T.isPrefixOf "./" e || T.isPrefixOf ".\\" e) entries),
+      runTest "dot-relative builder derives no PATH entry" $
+        let entries = T.splitOn (if SI.os == "mingw32" then ";" else ":") (buildPath "./bash")
+         in assertEqual "no-dot-rel" False (any (\e -> e == "." || T.isPrefixOf "./" e || T.isPrefixOf ".\\" e) entries),
+      runTest "absolute builder opens PATH with its own directory" $
+        let path = buildPath ("/store/aaa-bootstrap/bin" </> "bash")
+         in assertEqual "builder-dir-first" (Just "/store/aaa-bootstrap/bin") (listToMaybe (T.splitOn (if SI.os == "mingw32" then ";" else ":") path)),
+      -- unionEnvs: earlier maps win; on Windows displacement is
+      -- case-insensitive and keeps the winner's spelling.
+      runTest "unionEnvs left map wins" $
+        assertEqual
+          "left-bias"
+          (Just "build")
+          (Map.lookup "A" (unionEnvs [Map.fromList [("A", "build")], Map.fromList [("A", "host")]])),
+      runTest "unionEnvs displaces a case variant on Windows" $
+        let merged = unionEnvs [Map.fromList [("PATH", "build")], Map.fromList [("Path", "host")]]
+         in if SI.os == "mingw32"
+              then assertEqual "displaced" (Map.fromList [("PATH", "build")]) merged
+              else assertEqual "distinct" (Map.fromList [("PATH", "build"), ("Path", "host")]) merged,
       -- BuildConfig with caches
       runTest "BuildConfig accepts caches" $
         let cache = Subst.CacheConfig "https://cache.example.com" "key" 10


### PR DESCRIPTION
Closes #46.

**P3-J1 - the build environment merged case-sensitively.** Windows environment names are one case-insensitive namespace, but both assembly points used case-sensitive Map unions: runBuilder's build-over-system overlay (where the inherited variable is typically spelled Path), and buildEnvironment's output > derivation > standard priority stack. A build's PATH therefore did not displace the inherited Path - both landed in the child's environment block, and which one the child saw was runtime-dependent. Both points now merge through unionEnvs: on Windows, names fold by per-character uppercase (matching the kernel's env-name comparison) so an earlier map's variable displaces any case variant and keeps its own spelling; on Unix it is Map.unions unchanged.

**P3-J2 - a bare-name builder opened the build PATH with the build directory.** takeDirectory on a bare name (bash, the Windows default config) is ., so the constructed PATH began with the build working directory and its ./usr/bin sibling - a file dropped into the build dir resolved ahead of every tool. buildPath now derives no directories when the builder has none (. covers bare and dot-relative spellings); such builders get the system directories only. Resolution hardening of the builder executable itself belongs to the sandbox work (#25).

buildPath and unionEnvs are exported for tests: PATH never opens with the build dir for bare and dot-relative builders (pinned on both platforms - the assertions catch the pre-fix . and ./usr/bin shapes), the absolute-builder PATH is unchanged, union left-bias holds, and the case-variant displacement asserts per platform (folded on Windows, distinct on Unix).

cabal test passes, -Werror build clean, ormolu and hlint clean.