### PR TITLE
Audit class F: parser and name-validator upstream parity

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -38,7 +38,7 @@ import Nix.Eval.IO (EvalState (..), newEvalState, runEvalIO)
 import Nix.Eval.Types (bytesToTextLossy, clistFromThunks, clistThunks, thunkToCPtr)
 import Nix.Parser (parseNix, readFileAutoEncoding)
 import Nix.Push (PushConfig (..), PushSummary (..), loadApiKeyFile, pushPaths)
-import Nix.Store (Store (..), closeStore, materializeEvalSources, openStore, queryAllValidPaths, writeDrv, writeDrvAterm)
+import Nix.Store (Store (..), closeStore, materializeEvalSources, openStore, queryAllValidPaths, writeDrv, writeDrvClosure)
 import Nix.Store.Path (StoreDir (..), StorePath (..), defaultStoreDir, parseStorePath, platformStoreDir, storePathHashLen, storePathToFilePath)
 import Nix.Substituter (CacheConfig (..))
 import Paths_nova_nix (getDataDir)
@@ -498,17 +498,6 @@ failWith :: T.Text -> IO a
 failWith msg = do
   TIO.hPutStrLn stderr msg
   exitFailure
-
--- | Write every recorded @.drv@ ATerm (keyed by its store-path text) to the
--- store.  Keys come from evaluation via 'storePathToText' so they always parse;
--- an unparseable key is skipped defensively.
-writeDrvClosure :: Store -> Map.Map T.Text BS.ByteString -> IO ()
-writeDrvClosure store = mapM_ writeOne . Map.toList
-  where
-    writeOne (pathText, aterm) =
-      case parseStorePath defaultStoreDir pathText of
-        Just sp -> writeDrvAterm store sp aterm
-        Nothing -> pure ()
 
 -- ---------------------------------------------------------------------------
 -- Output formatting

--- a/src/Nix/Derivation.hs
+++ b/src/Nix/Derivation.hs
@@ -421,7 +421,9 @@ pStringContent = Parser $ \input -> go input []
               Just ('n', rest2) -> go rest2 ("\n" : plain : acc)
               Just ('r', rest2) -> go rest2 ("\r" : plain : acc)
               Just ('t', rest2) -> go rest2 ("\t" : plain : acc)
-              Just (c, rest2) -> go rest2 (BC.pack ['\\', c] : plain : acc)
+              -- A non-standard escape keeps the byte and drops the
+              -- backslash, as upstream's .drv string parser does.
+              Just (c, rest2) -> go rest2 (BC.singleton c : plain : acc)
             -- Unreachable: BC.break stops only at '"' or '\\'.
             Just (c, _) -> Left ("pStringContent: impossible break byte '" <> T.singleton c <> "'")
 

--- a/src/Nix/Eval.hs
+++ b/src/Nix/Eval.hs
@@ -80,7 +80,7 @@ import Data.Int (Int64)
 import Data.List (find, foldl', partition, sort)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import Data.Maybe (catMaybes, fromMaybe, isJust, isNothing)
+import Data.Maybe (catMaybes, fromMaybe, isJust, isNothing, listToMaybe)
 import Data.Sequence (Seq (..))
 import qualified Data.Sequence as Seq
 import qualified Data.Set as Set
@@ -583,8 +583,7 @@ evalBcHasAttr env bcIdx0 = do
       (pathLen, pathOff) =
         unsafePerformIO (cbcCountedPayload bcIdx0 =<< cbcArg2 bcIdx0)
   targetVal <- evalBytecode env targetIdx
-  result <- walkBcAttrPath env pathLen pathOff targetVal
-  pure (VBool (isJust result))
+  VBool <$> hasBcAttrPath env pathLen pathOff targetVal
 
 -- | Collect static attribute path names for error reporting.
 collectBcAttrPathNames :: Int -> Word32 -> Text
@@ -597,32 +596,56 @@ collectBcAttrPathNames pathLen pathOff = T.intercalate "." (go pathLen pathOff)
           name = if isExpr /= 0 then "<expr>" else symbolText (Symbol keyVal)
        in name : go (n - 1) (off + 2)
 
+-- | Resolve one attr-path element (two words at @off@) to its key text.
+-- A dynamic key must produce a string - null included, as upstream's
+-- select and has-attr key coercion rejects null with a type error.
+resolveBcAttrKey :: (MonadEval m) => Env -> Word32 -> m Text
+resolveBcAttrKey env off = do
+  let isExpr = unsafePerformIO (cbcData off)
+      keyVal = unsafePerformIO (cbcData (off + 1))
+  if isExpr /= 0
+    then do
+      keyResult <- evalBytecode env keyVal
+      case keyResult of
+        VStr s _ -> decodedText "dynamic attribute key" s
+        _ -> throwEvalError ("dynamic attribute key must be a string, got " <> typeName keyResult)
+    else pure (symbolText (Symbol keyVal))
+
 -- | Walk an attribute path stored in the bytecode data buffer.
--- Each element is two words: (is_expr, key_or_bc_idx).
+-- Each element is two words: (is_expr, key_or_bc_idx).  Every matched
+-- element is forced - select needs the terminal value, and the walk
+-- needs each intermediate to be a set.
 walkBcAttrPath :: (MonadEval m) => Env -> Int -> Word32 -> NixValue -> m (Maybe NixValue)
 walkBcAttrPath _ 0 _ val = pure (Just val)
 walkBcAttrPath env n off val = case val of
   VAttrs attrs -> do
-    let isExpr = unsafePerformIO (cbcData off)
-        keyVal = unsafePerformIO (cbcData (off + 1))
-    resolved <-
-      if isExpr /= 0
-        then do
-          keyResult <- evalBytecode env keyVal
-          case keyResult of
-            VStr s _ -> Just <$> decodedText "dynamic attribute key" s
-            VNull -> pure Nothing
-            _ -> throwEvalError ("dynamic attribute key must be a string, got " <> typeName keyResult)
-        else pure (Just (symbolText (Symbol keyVal)))
-    case resolved >>= (`attrSetLookup` attrs) of
+    key <- resolveBcAttrKey env off
+    case attrSetLookup key attrs of
       Just thunk -> do
         inner <- force thunk
         walkBcAttrPath env (n - 1) (off + 2) inner
       Nothing -> pure Nothing
   -- Non-attrset: attribute path cannot continue.  Return Nothing so
-  -- that callers with a default (``a.b or def'') or hasAttr (``a ? b'')
-  -- can handle it gracefully, matching C++ Nix behaviour.
+  -- that callers with a default (``a.b or def'') can handle it
+  -- gracefully, matching C++ Nix behaviour.
   _ -> pure Nothing
+
+-- | Presence walk for has-attr: intermediates force (the walk must reach
+-- a set), but the terminal element is a membership check only - upstream
+-- ``a ? b.c`` never evaluates the final attribute's value.
+hasBcAttrPath :: (MonadEval m) => Env -> Int -> Word32 -> NixValue -> m Bool
+hasBcAttrPath _ 0 _ _ = pure True
+hasBcAttrPath env n off val = case val of
+  VAttrs attrs -> do
+    key <- resolveBcAttrKey env off
+    case attrSetLookup key attrs of
+      Just thunk
+        | n == 1 -> pure True
+        | otherwise -> do
+            inner <- force thunk
+            hasBcAttrPath env (n - 1) (off + 2) inner
+      Nothing -> pure False
+  _ -> pure False
 
 -- | Evaluate attribute set from bytecode.
 evalBcAttrs :: (MonadEval m) => Env -> Word32 -> m NixValue
@@ -2453,18 +2476,49 @@ builtinReplaceStrings ::
 builtinReplaceStrings (VList fromCl) (VList toCl) (VStr input inputCtx) = do
   let fromThunks = map Thunk (clistThunks fromCl)
       toThunks = map Thunk (clistThunks toCl)
-  froms <- mapM forceStr fromThunks
-  toStrs <- mapM forceStr toThunks
-  when (length froms /= length toStrs) $
+  when (length fromThunks /= length toThunks) $
     throwEvalError "builtins.replaceStrings: 'from' and 'to' must have the same length"
-  let fromTexts = map fst froms
-      toTexts = map fst toStrs
-      -- Nix semantics: input context + 'to' string contexts (not 'from').
-      -- Ideally only 'to' contexts for patterns that matched, but including
-      -- all 'to' contexts is the common implementation.
-      mergedCtx = inputCtx <> mconcat (map snd toStrs)
-      pairs = zip fromTexts toTexts
-  pure (VStr (replaceAll pairs input) mergedCtx)
+  froms <- mapM forceStr fromThunks
+  -- Match-gated replacement forcing, as upstream: a 'to' element is
+  -- forced - and its context joins the result - only the first time its
+  -- pattern matches, memoized per index.  An unmatched replacement is
+  -- never evaluated, so it may throw or diverge harmlessly.
+  --
+  -- Matching and stepping are byte-level, as upstream: an empty @from@
+  -- element inserts between BYTES, so a 2-byte character gets a
+  -- replacement inside it.  Chunks accumulate reversed, one BS.concat
+  -- at the end.
+  let rules = zip3 [0 :: Int ..] (map fst froms) toThunks
+      findRule txt =
+        listToMaybe [r | r@(_, from, _) <- rules, BS.null from || from `BS.isPrefixOf` txt]
+      forcedTo memo (i, _, toThunk) = case Map.lookup i memo of
+        Just hit -> pure (hit, memo)
+        Nothing -> do
+          forced <- forceStr toThunk
+          pure (forced, Map.insert i forced memo)
+      step remaining acc memo
+        | BS.null remaining = case findRule remaining of
+            -- At end of string, still check for an empty-from match.
+            Just rule -> do
+              ((to, _), advanced) <- forcedTo memo rule
+              pure (to : acc, advanced)
+            Nothing -> pure (acc, memo)
+        | otherwise = case findRule remaining of
+            Just rule@(_, from, _) -> do
+              ((to, _), advanced) <- forcedTo memo rule
+              if BS.null from
+                then case BS.uncons remaining of
+                  -- empty-from: insert replacement then advance ONE BYTE
+                  Just (byte, after) -> step after (BS.singleton byte : to : acc) advanced
+                  -- Unreachable: the null string is handled by the guard above.
+                  Nothing -> pure (to : acc, advanced)
+                else step (BS.drop (BS.length from) remaining) (to : acc) advanced
+            Nothing -> case BS.uncons remaining of
+              Just (byte, after) -> step after (BS.singleton byte : acc) memo
+              Nothing -> pure (acc, memo)
+  (revChunks, forcedTos) <- step input [] Map.empty
+  let mergedCtx = inputCtx <> mconcat (map snd (Map.elems forcedTos))
+  pure (VStr (BS.concat (reverse revChunks)) mergedCtx)
   where
     forceStr thunk = do
       val <- force thunk
@@ -2475,36 +2529,6 @@ builtinReplaceStrings _ _ (VStr _ _) =
   throwEvalError "builtins.replaceStrings: first two arguments must be lists"
 builtinReplaceStrings _ _ other =
   throwEvalError ("builtins.replaceStrings: expected a string, got " <> typeName other)
-
--- | Replace all occurrences, O(n) via chunk list + BS.concat.
--- Matching and stepping are byte-level, as upstream: an empty @from@
--- element inserts between BYTES, so a 2-byte character gets a
--- replacement inside it.
-replaceAll :: [(BS.ByteString, BS.ByteString)] -> BS.ByteString -> BS.ByteString
-replaceAll pairs input = BS.concat (go input)
-  where
-    go remaining
-      | BS.null remaining =
-          -- At end of string, still check for empty-from match
-          case findMatch pairs remaining of
-            Just (replacement, _, _) -> [replacement]
-            Nothing -> []
-      | otherwise = case findMatch pairs remaining of
-          Just (replacement, rest, matched) ->
-            if BS.null matched
-              then case BS.uncons remaining of
-                -- empty-from: insert replacement then advance ONE BYTE
-                Just (byte, after) -> replacement : BS.singleton byte : go after
-                Nothing -> [replacement]
-              else replacement : go rest
-          Nothing -> case BS.uncons remaining of
-            Just (byte, after) -> BS.singleton byte : go after
-            Nothing -> []
-    findMatch [] _ = Nothing
-    findMatch ((from, to) : rest) txt
-      | BS.null from = Just (to, txt, from)
-      | Just suffix <- BS.stripPrefix from txt = Just (to, suffix, from)
-      | otherwise = findMatch rest txt
 
 -- ---------------------------------------------------------------------------
 -- Builtin implementations - regex (POSIX ERE via regex-tdfa)

--- a/src/Nix/Eval/Operator.hs
+++ b/src/Nix/Eval/Operator.hs
@@ -194,9 +194,12 @@ nixCompare _ left right =
         <> typeName right
     )
 
--- | Lexicographic comparison of two thunk lists for the @<@ operator: the
--- first differing element decides; a proper prefix is less than the longer
--- list.  Mirrors 'listEqual'.
+-- | Lexicographic comparison of two thunk lists for the @<@ operator:
+-- the first NON-EQUAL element pair decides via @<@ on that pair, as
+-- upstream does (eqValues, then CompareValues on the first difference).
+-- An unequal pair where @<@ holds in neither direction (NaN) therefore
+-- decides False rather than being skipped as equal.  A proper prefix is
+-- less than the longer list.  Mirrors 'listEqual'.
 listCompare :: (MonadEval m) => Force m -> [Thunk] -> [Thunk] -> m Bool
 listCompare _ [] [] = pure False
 listCompare _ [] (_ : _) = pure True
@@ -206,12 +209,10 @@ listCompare forceFn (a : as) (b : bs)
   | otherwise = do
       va <- forceFn a
       vb <- forceFn b
-      ltAB <- nixCompare forceFn va vb
-      if ltAB
-        then pure True
-        else do
-          ltBA <- nixCompare forceFn vb va
-          if ltBA then pure False else listCompare forceFn as bs
+      equal <- nixEqual forceFn va vb
+      if equal
+        then listCompare forceFn as bs
+        else nixCompare forceFn va vb
 
 -- | Deep structural equality.  Forces thunks inside lists and
 -- attribute sets as needed.

--- a/src/Nix/Parser/Expr.hs
+++ b/src/Nix/Parser/Expr.hs
@@ -22,7 +22,7 @@ module Nix.Parser.Expr
   )
 where
 
-import Control.Monad (foldM)
+import Control.Monad (foldM, when)
 import Data.List (foldl')
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
@@ -133,6 +133,9 @@ parseFormalsBody = do
 parseFormalsList :: [Formal] -> Parser ([Formal], Bool)
 parseFormalsList acc = do
   name <- expectIdent
+  -- Upstream rejects a repeated formal name at parse time.
+  when (any ((== name) . fName) acc) $
+    parseError ("duplicate formal function argument '" <> name <> "'")
   -- Check for default value
   hasDefault <- match TokQuestion
   defVal <-

--- a/src/Nix/Store.hs
+++ b/src/Nix/Store.hs
@@ -52,6 +52,7 @@ module Nix.Store
     unpackNarEntry,
     writeDrv,
     writeDrvAterm,
+    writeDrvClosure,
 
     -- * NAR entry-name safety
     isSafeNarName,
@@ -65,18 +66,19 @@ module Nix.Store
   )
 where
 
-import Control.Exception (IOException, SomeException, catch, try)
+import Control.Exception (IOException, SomeException, catch, throwIO, try)
 import Control.Monad (unless, when)
 import qualified Data.ByteString as BS
 import Data.Char (isDigit)
 import Data.List (foldl', inits)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
+import Data.Maybe (catMaybes)
 import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
-import Nix.Derivation (Derivation, toATerm)
+import Nix.Derivation (Derivation (..), fromATerm, toATerm)
 import Nix.Hash (makeFixedOutputPath, sha256Digest)
 import Nix.Store.DB
 import Nix.Store.Path
@@ -333,9 +335,54 @@ writeDrvAterm store sp aterm = do
   -- bytes that no longer match their content address.
   BS.writeFile destPath aterm
 
--- | Serialize a derivation to ATerm and write it to the store at the given path.
+-- | Serialize a derivation to ATerm, write it to the store, and register
+-- it: a @.drv@ is a store object like any other, so it gets a ValidPaths
+-- row with its NAR hash and its references.  Reference scans may name a
+-- @.drv@ (an output that embeds an input drv hash), and an unregistered
+-- referent fails the whole registration batch.
 writeDrv :: Store -> Derivation -> StorePath -> IO ()
-writeDrv store drv sp = writeDrvAterm store sp (toATerm drv)
+writeDrv store drv sp = do
+  writeDrvAterm store sp (toATerm drv)
+  reg <- registrationFor store sp Nothing (drvReferences drv)
+  registerPath (stDB store) reg
+
+-- | A @.drv@'s references: its input sources and input @.drv@ paths -
+-- the same set upstream records when writing a derivation to the store.
+drvReferences :: Derivation -> [StorePath]
+drvReferences drv = drvInputSrcs drv ++ Map.keys (drvInputDrvs drv)
+
+-- | Write every recorded @.drv@ ATerm (keyed by its store-path text) to
+-- the store and register the whole closure in one batch: rows all land
+-- before edges ('registerPaths'), so references between the closure's
+-- own @.drv@ files resolve regardless of map order.  Input SOURCES must
+-- already be registered - the build driver runs 'materializeEvalSources'
+-- first.
+--
+-- Keys come from evaluation via 'storePathToText' so they always parse;
+-- an unparseable key is skipped defensively.  The ATerm bytes were
+-- rendered by evaluation, so a re-parse failure is an invariant break
+-- and throws rather than registering a recipe with dropped references.
+writeDrvClosure :: Store -> Map Text BS.ByteString -> IO ()
+writeDrvClosure store closure = do
+  regs <- mapM writeOne (Map.toList closure)
+  registerPaths (stDB store) (catMaybes regs)
+  where
+    writeOne (pathText, aterm) =
+      case parseStorePath defaultStoreDir pathText of
+        Nothing -> pure Nothing
+        Just sp -> do
+          writeDrvAterm store sp aterm
+          case fromATerm aterm of
+            Right drv -> Just <$> registrationFor store sp Nothing (drvReferences drv)
+            Left err ->
+              throwIO
+                ( userError
+                    ( "writeDrvClosure: recorded ATerm for "
+                        <> T.unpack pathText
+                        <> " does not re-parse: "
+                        <> T.unpack err
+                    )
+                )
 
 -- ---------------------------------------------------------------------------
 -- NAR unpacking

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -13,7 +13,7 @@ import Data.Bits (shiftR, (.&.))
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BL
 import Data.IORef (atomicModifyIORef', newIORef, readIORef)
-import Data.List (foldl')
+import Data.List (foldl', sort)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe, isJust, listToMaybe)
 import qualified Data.Set as Set
@@ -47,7 +47,7 @@ import qualified Nix.Hash as Hash
 import Nix.Parser (parseNix)
 import Nix.Parser.Lexer (Located (..), Token (..), tokenize)
 import Nix.Push (checkRecordedNarHash, computeClosure, loadApiKeyFile, mkNarInfo, narFileName, planMissing, storePathBasename, stripHashPrefix)
-import Nix.Store (Store (..), addToStore, closeStore, copyPathInto, isSafeNarName, isValid, materializeEvalSources, openStore, orderLinks, pathExists, scanReferences, scanTempReferences, setReadOnly, writeDrv)
+import Nix.Store (Store (..), addToStore, closeStore, copyPathInto, isSafeNarName, isValid, materializeEvalSources, openStore, orderLinks, pathExists, scanReferences, scanTempReferences, setReadOnly, writeDrv, writeDrvClosure)
 import Nix.Store.DB (PathInfo (..), PathRegistration (..), closeStoreDB, isValidPath, openStoreDB, queryDeriver, queryPathInfo, queryReferences, registerPath, registerPaths)
 import Nix.Store.Path (StoreDir (..), StorePath (..), defaultStoreDir, defaultStoreDirText, isCanonicalStoreText, parseStorePath, platformStoreDir, platformStoreDirText, storePathToFilePath, storePathToText, storeTextToFilePath, windowsStoreDir)
 import qualified Nix.Substituter as Subst
@@ -1501,6 +1501,15 @@ testBatch1 = do
         assertEval "lt-f" "builtins.lessThan 2 1" (VBool False),
       runTest "lessThan strings" $
         assertEval "lt-str" "builtins.lessThan \"a\" \"b\"" (VBool True),
+      -- List < decides at the first UNEQUAL pair, as upstream: a pair
+      -- where < holds in neither direction (NaN) decides False rather
+      -- than being skipped as equal.
+      -- Distinct NaN values: a shared binding would be skipped as equal
+      -- via reference identity, which upstream's eqValues also does.
+      runTest "list compare decides at the first unequal pair" $
+        assertEval "lt-list-nan" "let inf = 1.0e308 * 10; in [ (inf - inf) 1 ] < [ (inf - inf) 2 ]" (VBool False),
+      runTest "list compare skips equal prefixes" $
+        assertEval "lt-list-prefix" "[ 1 2 ] < [ 1 3 ]" (VBool True),
       -- Constants
       runTest "storeDir" $
         assertEval "storeDir" "builtins.storeDir" (mkStr defaultStoreDirText),
@@ -1628,6 +1637,9 @@ testBatch4 = do
         assertEval "replace-empty" "builtins.replaceStrings [ \"\" ] [ \"x\" ] \"ab\"" (mkStr "xaxbx"),
       runTest "replaceStrings no match" $
         assertEval "replace-nomatch" "builtins.replaceStrings [ \"z\" ] [ \"Z\" ] \"abc\"" (mkStr "abc"),
+      -- Match-gated forcing: an unmatched replacement is never evaluated.
+      runTest "replaceStrings never forces an unmatched replacement" $
+        assertEval "replace-lazy" "builtins.replaceStrings [ \"z\" ] [ (builtins.throw \"unused\") ] \"abc\"" (mkStr "abc"),
       -- compareVersions
       runTest "compareVersions equal" $
         assertEval "cmpVer-eq" "builtins.compareVersions \"1.2.3\" \"1.2.3\"" (VInt 0),
@@ -4552,6 +4564,10 @@ testEvalFidelity = do
         assertEval "merge-add" "{ a = { b = 1; }; a.c = 2; }.a.c" (VInt 2),
       runTest "duplicate plain key is a parse error" $
         assertParseFail "dup-key" "{ a = 1; a = 2; }",
+      runTest "duplicate formal is rejected" $
+        assertParseFail "dup-formal" "{ a, a }: a",
+      runTest "duplicate formal with defaults is rejected" $
+        assertParseFail "dup-formal-default" "{ a ? 1, a ? 2 }: a",
       runTest "duplicate inner key on merge is an error" $
         assertParseFail "dup-inner" "{ a.b = 1; a = { b = 2; }; }",
       runTest "inherit conflicting with a definition is an error" $
@@ -5472,6 +5488,12 @@ testFromATerm = do
                   drvEnv = Map.fromList [("msg", "line1\nline2\ttab\\slash")]
                 }
          in assertEqual "escape round-trip" (Right escapeDrv) (fromATerm (toATerm escapeDrv)),
+      -- A non-standard escape keeps the byte and drops the backslash,
+      -- matching upstream's .drv string parser.
+      runTest "fromATerm drops the backslash on a non-standard escape" $
+        let aterm = "Derive([(\"out\",\"/nix/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-x\",\"\",\"\")],[],[],\"x86_64-linux\",\"/bin/sh\",[],[(\"k\",\"a\\xb\")])"
+         in assertRight "nonstandard escape" (fromATerm aterm) $ \drv ->
+              assertEqual "escape dropped" (Just "axb") (Map.lookup "k" (drvEnv drv)),
       -- writeDrv writes correct ATerm
       runTestM "writeDrv writes correct ATerm" $ do
         tmpBase <- getTemporaryDirectory
@@ -5485,6 +5507,51 @@ testFromATerm = do
         closeStore store
         removeIfExists tmpStore
         pure (assertEqual "writeDrv content" (toATerm simpleTestDrv) contents),
+      -- The .drv closure registers as store objects: a row for every
+      -- recipe plus edges to its input sources and input .drvs, so an
+      -- output reference scan that names an input .drv resolves instead
+      -- of failing the registration batch.
+      runTestM "writeDrvClosure registers recipes with their references" $ do
+        tmpBase <- getTemporaryDirectory
+        let tmpStore = tmpBase </> "nova-nix-test-drv-closure"
+            sd = StoreDir tmpStore
+        removeIfExists tmpStore
+        store <- openStore sd
+        let srcSp = StorePath "gggggggggggggggggggggggggggggggg" "source.tar.gz"
+            drvASp = StorePath "cccccccccccccccccccccccccccccccc" "dep1.drv"
+            drvBSp = StorePath "dddddddddddddddddddddddddddddddd" "top.drv"
+            drvB =
+              simpleTestDrv
+                { drvInputDrvs = Map.fromList [(drvASp, ["out"])],
+                  drvInputSrcs = [srcSp]
+                }
+        -- The source row registers first, as in the build driver, where
+        -- materializeEvalSources precedes the closure write.
+        registerPath (stDB store) (PathRegistration srcSp "sha256:0" 0 Nothing [])
+        writeDrvClosure
+          store
+          ( Map.fromList
+              [ (storePathToText defaultStoreDir drvASp, toATerm simpleTestDrv),
+                (storePathToText defaultStoreDir drvBSp, toATerm drvB)
+              ]
+          )
+        validA <- isValid store drvASp
+        validB <- isValid store drvBSp
+        refsB <- queryReferences (stDB store) drvBSp
+        closeStore store
+        removeIfExists tmpStore
+        let expectedRefs =
+              sort
+                [ T.pack (storePathToFilePath sd drvASp),
+                  T.pack (storePathToFilePath sd srcSp)
+                ]
+        pure $
+          if not validA
+            then Fail "input .drv not registered"
+            else
+              if not validB
+                then Fail "root .drv not registered"
+                else assertEqual "drv references" expectedRefs (sort refsB),
       -- builtinDerivation populates drvOutputs
       runTest "builtinDerivation populates drvOutputs"
         $ assertRight
@@ -6016,6 +6083,22 @@ testPhase4 = do
         assertEval "dynamic key hasAttr" "let s = { x = 10; }; in s ? ${\"x\"}" (VBool True),
       runTest "dynamic key hasAttr missing" $
         assertEval "dynamic key hasAttr missing" "let s = { x = 10; }; in s ? ${\"y\"}" (VBool False),
+      -- has-attr checks presence of the terminal attribute without
+      -- forcing its value, matching upstream laziness.
+      runTest "hasAttr does not force the final attribute" $
+        assertEval "hasattr-lazy" "{ a = builtins.throw \"boom\"; } ? a" (VBool True),
+      runTest "hasAttr path does not force the terminal attribute" $
+        assertEval "hasattr-path-lazy" "{ a = { b = builtins.throw \"boom\"; }; } ? a.b" (VBool True),
+      -- A null dynamic key in select or has-attr is a type error, as
+      -- upstream; it is not treated as an absent attribute.
+      runTest "null dynamic select key is a type error" $
+        assertEvalFail "sel-null-key" "({ x = 1; }).${null}",
+      runTest "null dynamic hasAttr key is a type error" $
+        assertEvalFail "has-null-key" "{ x = 1; } ? ${null}",
+      -- inherit inside a rec set with a dynamic key resolves against the
+      -- enclosing scope, never the rec set's own binding.
+      runTest "inherit in a dynamic-keyed rec set resolves outward" $
+        assertEval "dyn-rec-inherit" "let v = 42; in (rec { ${\"d\"} = 1; inherit v; }).v" (VInt 42),
       -- Dynamic attr inside string interpolation (the ${name} must not
       -- prematurely close the outer interpolation)
       runTest "dynamic key in string interp" $


### PR DESCRIPTION
Closes #43. All eight live register items, plus M1 verified already-resolved and pinned.

**M1 - inherit in a dynamic-keyed rec set.** The defect (inherit resolving against the rec set's own binding) is no longer present: both the positional and the NameBarrier paths resolve a plain inherit against the enclosing scope with a level shift. Verified and pinned with a regression test; no code change.

**M2 - duplicate formals accepted.** parseFormalsList now rejects a repeated formal name at parse time ("duplicate formal function argument 'a'"), as upstream. Tests cover the plain and defaulted forms.

**N13 - input .drv paths were never registered.** writeDrvClosure moves from the app driver into Nix.Store and registers what it writes: every recipe gets a ValidPaths row with its real NAR hash plus reference edges to its input sources and input .drvs (the same reference set upstream records), batched through registerPaths so intra-closure edges resolve in any order. writeDrv gets the same treatment for the root/fallback path. A reference scan that names an input .drv now resolves instead of failing the whole registration batch - the successful-build-reported-as-failure defect. A re-parse failure of recorded ATerm bytes throws rather than registering a recipe with dropped references.

**P3-F1 - has-attr forced the terminal attribute.** The walk is split: select keeps forcing (it needs the value), has-attr forces intermediates only and checks the terminal by membership - `{ a = throw "boom"; } ? a` is now true, matching upstream laziness. The builtins.hasAttr function form was already membership-only.

**L2 - a null dynamic key selected as absent.** The shared key resolver now rejects any non-string dynamic key in select and has-attr with a type error, null included, as upstream. (Null keys in attr-set construction are untouched.)

**P3-F2 - replaceStrings forced every replacement.** Forcing is now match-gated and memoized per index: a 'to' element is forced - and its context joins the result - only the first time its pattern matches. The length check moved before any forcing (upstream checks list sizes first). Byte-level matching and the empty-from stepping are unchanged and stay pinned by the existing byte-semantics tests.

**P3-F4 - list < skipped incomparable pairs as equal.** listCompare now decides at the first NON-EQUAL pair via < on that pair (upstream's eqValues-then-CompareValues shape), so `[ nan 1 ] < [ nan 2 ]` with distinct NaNs is False rather than continuing to later elements. The reference-identity shortcut stays - upstream's eqValues has the same pointer short-circuit.

**P3-F5 - ATerm kept the backslash on non-standard escapes.** The fallback now emits the byte alone, as upstream's .drv string parser does.

cabal test passes (1059, including nine new pins), -Werror build clean, ormolu and hlint clean.
