### PR TITLE
Audit class H: folding-name collision guard and on-disk hash recheck

### DIFF
--- a/src/Nix/Store.hs
+++ b/src/Nix/Store.hs
@@ -69,7 +69,7 @@ where
 import Control.Exception (IOException, SomeException, catch, throwIO, try)
 import Control.Monad (unless, when)
 import qualified Data.ByteString as BS
-import Data.Char (isDigit)
+import Data.Char (isDigit, toUpper)
 import Data.List (foldl', inits)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
@@ -96,6 +96,7 @@ import System.Directory
   )
 import qualified System.Directory as Dir
 import System.FilePath (splitDirectories, takeDirectory, (</>))
+import qualified System.Info
 
 -- | An open store with database and configuration.
 data Store = Store
@@ -420,22 +421,70 @@ unpackTree path entry = case entry of
     createDirectoryIfMissing True path
     unpackChildren path entries
 
+-- | The on-disk identity a NAR entry name occupies on this platform's
+-- store filesystem.  Windows (NTFS\/Win32) compares names
+-- case-insensitively and strips trailing dots and spaces; the default
+-- macOS APFS volume folds case; Linux preserves names byte-for-byte.
+-- Two sibling entries sharing a key land on ONE file, the second
+-- silently overwriting the first.  The fold is per-character uppercase:
+-- a corruption backstop for the collisions real trees carry
+-- (@Makefile@\/@makefile@), not a full model of filesystem Unicode
+-- folding.
+onDiskNameKey :: Text -> Text
+onDiskNameKey = case System.Info.os of
+  "mingw32" -> T.map toUpper . T.dropWhileEnd (\c -> c == '.' || c == ' ')
+  "darwin" -> T.map toUpper
+  _ -> id
+
+-- | The first pair of sibling names folding to the same on-disk file,
+-- if any: (earlier entry, colliding later entry).
+firstNameCollision :: [Text] -> Maybe (Text, Text)
+firstNameCollision = go Map.empty
+  where
+    go !_ [] = Nothing
+    go !seen (name : rest) =
+      let key = onDiskNameKey name
+       in case Map.lookup key seen of
+            Just earlier -> Just (earlier, name)
+            Nothing -> go (Map.insert key name seen) rest
+
 -- | Unpack directory children, short-circuiting with a typed failure on the
 -- first unsafe entry name rather than crashing on untrusted input.
+--
+-- The sibling list is checked for on-disk name collisions BEFORE any
+-- child is written: a folding filesystem lands two distinct NAR names
+-- on one file, and the silent merge would materialize a tree that no
+-- longer matches the NAR hash it is about to be registered under.
+-- (Upstream works around such trees with its case-hack name mangling;
+-- until that lands here, the collision is a loud failure, never a
+-- corrupt store path.)
 unpackChildren :: FilePath -> [(Text, NAR.NarEntry)] -> IO (Either Text [(FilePath, Text)])
-unpackChildren _ [] = pure (Right [])
-unpackChildren path ((name, child) : rest)
-  | not (isSafeNarName name) =
-      pure (Left ("unsafe NAR directory entry name: " <> name))
-  | otherwise = do
-      result <- unpackTree (path </> T.unpack name) child
-      case result of
-        Left err -> pure (Left err)
-        Right links -> do
-          restResult <- unpackChildren path rest
-          case restResult of
+unpackChildren path entries = case firstNameCollision (map fst entries) of
+  Just (earlier, later) ->
+    pure
+      ( Left
+          ( "NAR sibling entries '"
+              <> earlier
+              <> "' and '"
+              <> later
+              <> "' fold to the same on-disk name on this filesystem"
+          )
+      )
+  Nothing -> go entries
+  where
+    go [] = pure (Right [])
+    go ((name, child) : rest)
+      | not (isSafeNarName name) =
+          pure (Left ("unsafe NAR directory entry name: " <> name))
+      | otherwise = do
+          result <- unpackTree (path </> T.unpack name) child
+          case result of
             Left err -> pure (Left err)
-            Right moreLinks -> pure (Right (links <> moreLinks))
+            Right links -> do
+              restResult <- go rest
+              case restResult of
+                Left err -> pure (Left err)
+                Right moreLinks -> pure (Right (links <> moreLinks))
 
 -- | Second unpack pass: create the recorded symlinks in dependency
 -- order - each link is created after every pending link its target

--- a/src/Nix/Store.hs
+++ b/src/Nix/Store.hs
@@ -454,10 +454,10 @@ firstNameCollision = go Map.empty
 -- The sibling list is checked for on-disk name collisions BEFORE any
 -- child is written: a folding filesystem lands two distinct NAR names
 -- on one file, and the silent merge would materialize a tree that no
--- longer matches the NAR hash it is about to be registered under.
--- (Upstream works around such trees with its case-hack name mangling;
--- until that lands here, the collision is a loud failure, never a
--- corrupt store path.)
+-- longer matches the NAR hash it is about to be registered under.  A
+-- tree this filesystem cannot represent is refused outright - the store
+-- never holds an approximation of a tree (no name-mangling schemes),
+-- so a registered path always reproduces its NAR byte-for-byte.
 unpackChildren :: FilePath -> [(Text, NAR.NarEntry)] -> IO (Either Text [(FilePath, Text)])
 unpackChildren path entries = case firstNameCollision (map fst entries) of
   Just (earlier, later) ->

--- a/src/Nix/Store.hs
+++ b/src/Nix/Store.hs
@@ -454,10 +454,12 @@ firstNameCollision = go Map.empty
 -- The sibling list is checked for on-disk name collisions BEFORE any
 -- child is written: a folding filesystem lands two distinct NAR names
 -- on one file, and the silent merge would materialize a tree that no
--- longer matches the NAR hash it is about to be registered under.  A
--- tree this filesystem cannot represent is refused outright - the store
--- never holds an approximation of a tree (no name-mangling schemes),
--- so a registered path always reproduces its NAR byte-for-byte.
+-- longer matches the NAR hash it is about to be registered under.
+-- Refusal is the fail-closed backstop; upstream materializes such
+-- trees with its reversible case-hack suffix (applied at unpack,
+-- stripped at serialise), which follows here once the serialiser side
+-- ships in nova-cache - a registered path must always reproduce its
+-- NAR byte-for-byte, whichever branch handles the collision.
 unpackChildren :: FilePath -> [(Text, NAR.NarEntry)] -> IO (Either Text [(FilePath, Text)])
 unpackChildren path entries = case firstNameCollision (map fst entries) of
   Just (earlier, later) ->

--- a/src/Nix/Substituter.hs
+++ b/src/Nix/Substituter.hs
@@ -51,6 +51,7 @@ module Nix.Substituter
     decompressorFor,
     decompressNar,
     unpackNarEntry,
+    unpackAndVerify,
     clearStaleDestination,
     parseReferences,
     parseDeriver,
@@ -238,18 +239,36 @@ unpackAndVerify store sp narInfo rawNar =
           Right (Left err) -> pure (SubstError ("unpack failed: " <> err))
           Right (Right ()) -> do
             setReadOnly destPath
-            pure $
-              SubstSuccess
-                PathRegistration
-                  { prPath = sp,
-                    prNarHash = NarInfo.niNarHash narInfo,
-                    -- The verified actual byte count (equal to the declared
-                    -- NarSize per 'verifyNarSize') - no Integer conversion
-                    -- that could wrap.
-                    prNarSize = BS.length rawNar,
-                    prDeriver = deriver,
-                    prReferences = refs
-                  }
+            -- A path registered valid must match its recorded hash ON
+            -- DISK, not merely in the downloaded bytes: any divergence
+            -- the filesystem introduced between the NAR and the
+            -- materialized tree (name folding, link replication) must
+            -- surface here, before the row exists.  A mismatching tree
+            -- is removed - left in place it would be adopted by
+            -- existence checks at this path.
+            onDisk <- NAR.serialiseFromPath destPath
+            case verifyNarHash narInfo (NAR.serialise onDisk) of
+              Left _ -> do
+                Dir.removePathForcibly destPath
+                pure
+                  ( SubstError
+                      ( "unpacked tree does not reproduce the declared NAR hash at "
+                          <> T.pack destPath
+                      )
+                  )
+              Right () ->
+                pure $
+                  SubstSuccess
+                    PathRegistration
+                      { prPath = sp,
+                        prNarHash = NarInfo.niNarHash narInfo,
+                        -- The verified actual byte count (equal to the declared
+                        -- NarSize per 'verifyNarSize') - no Integer conversion
+                        -- that could wrap.
+                        prNarSize = BS.length rawNar,
+                        prDeriver = deriver,
+                        prReferences = refs
+                      }
   where
     registrationMeta = do
       refs <- parseReferences (NarInfo.niReferences narInfo)

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -3191,7 +3191,74 @@ testSubstituter = do
             throughLink <- doesDirectoryExist (dest </> "alink")
             pure (if throughLink then Pass else Fail "dir symlink not traversable (wrong flavor)")
         Subst.clearStaleDestination dest
-        pure outcome
+        pure outcome,
+      -- Case-variant siblings fold onto ONE file on Windows and macOS;
+      -- the unpack rejects them loudly there instead of silently merging.
+      -- Linux preserves both names and must keep accepting them.
+      runTestM "unpackNarEntry rejects folding sibling names on a folding filesystem" $ do
+        tmpBase <- getTemporaryDirectory
+        let dest = tmpBase </> "nova-nix-test-unpack-fold"
+            tree =
+              NAR.NarDirectory
+                [ ("Foo", NAR.NarRegular False "upper"),
+                  ("foo", NAR.NarRegular False "lower")
+                ]
+        Subst.clearStaleDestination dest
+        result <- Subst.unpackNarEntry dest tree
+        outcome <-
+          if SI.os == "mingw32" || SI.os == "darwin"
+            then case result of
+              Left _ -> pure Pass
+              Right () -> pure (Fail "folding sibling names were silently merged")
+            else case result of
+              Right () -> do
+                upper <- BS.readFile (dest </> "Foo")
+                lower <- BS.readFile (dest </> "foo")
+                pure (assertEqual "distinct files" ("upper", "lower") (upper, lower))
+              Left err -> pure (Fail ("non-folding platform rejected: " <> err))
+        Subst.clearStaleDestination dest
+        pure outcome,
+      -- unpackAndVerify re-serialises the materialized tree and checks it
+      -- against the declared hash before returning a registration: a
+      -- faithful round-trip passes, and the registration carries the
+      -- declared hash.
+      runTestM "unpackAndVerify accepts a tree that reproduces its hash" $ do
+        tmpBase <- getTemporaryDirectory
+        let tmpStore = tmpBase </> "nova-nix-test-unpack-verify"
+        forceRemoveIfExists tmpStore
+        store <- openStore (StoreDir tmpStore)
+        let sp = StorePath (T.replicate 32 "b") "roundtrip"
+            tree =
+              NAR.NarDirectory
+                [ ("data.txt", NAR.NarRegular False "verified bytes"),
+                  ("sub", NAR.NarDirectory [("inner", NAR.NarRegular False "nested")])
+                ]
+            rawNar = NAR.serialise tree
+            narHash = CHash.formatNixHash (CHash.hashBytes rawNar)
+            info =
+              NarInfo.NarInfo
+                { NarInfo.niStorePath = storePathToText defaultStoreDir sp,
+                  NarInfo.niUrl = "nar/roundtrip.nar",
+                  NarInfo.niCompression = "none",
+                  NarInfo.niFileHash = Nothing,
+                  NarInfo.niFileSize = Nothing,
+                  NarInfo.niNarHash = narHash,
+                  NarInfo.niNarSize = fromIntegral (BS.length rawNar),
+                  NarInfo.niReferences = [],
+                  NarInfo.niDeriver = Nothing,
+                  NarInfo.niSigs = [],
+                  NarInfo.niCA = Nothing
+                }
+        result <- Subst.unpackAndVerify store sp info rawNar
+        onDisk <- BS.readFile (storePathToFilePath (stDir store) sp </> "data.txt")
+        closeStore store
+        forceRemoveIfExists tmpStore
+        pure $ case result of
+          Subst.SubstSuccess reg ->
+            if prNarHash reg == narHash && onDisk == "verified bytes"
+              then Pass
+              else Fail "registration or on-disk bytes diverge from the declared hash"
+          other -> Fail ("unpackAndVerify failed: " <> T.pack (show other))
     ]
   where
     chainCache url = Subst.CacheConfig url "unused-key" 10


### PR DESCRIPTION
Closes #45 (P3-H1), the integrity half. The substitutability half - upstream's case-hack - is split out below; this PR closes the corruption hole under both designs.

**The collision guard.** unpackChildren now checks every sibling list against the platform's on-disk name identity before writing anything: Windows folds case and strips trailing dots and spaces (NTFS/Win32), the default macOS APFS volume folds case, Linux preserves names. Two siblings sharing a key previously landed on ONE file with the second silently overwriting the first; they are now a loud typed failure naming both entries. Linux behavior is unchanged (identity key), so upstream-valid case-variant trees still unpack there. Trailing-dot and trailing-space names were already rejected outright by isSafeNarName on every platform (class B); the key keeps the strip as defense in depth.

**The on-disk recheck.** unpackAndVerify verified the downloaded bytes and then registered the path with the declared hash without ever looking at what actually materialized. It now re-serialises the unpacked tree and checks it against the declared NAR hash before returning a registration, so isValid implies the on-disk tree matches its recorded hash - any divergence the filesystem introduces (folding, link replication) surfaces before the row exists. A mismatching tree is removed rather than left to be adopted by existence checks at that path. This matches the build path, which already registers from an on-disk re-serialisation (registrationFor).

**The decision this leaves open - case-hack.** Real nixpkgs paths carry case-variant siblings (Makefile/makefile, Perl/ICU/tz data), and with this guard those paths now fail substitution loudly on Windows and macOS instead of corrupting. Upstream makes them materializable on folding filesystems with its case-hack (a reversible name-mangling suffix applied at unpack, stripped at serialise). That needs the strip in nova-cache's NAR serialiser plus the mangling here, so it is a cross-repo follow-up rather than part of this PR; filed as a linked issue. Merging this PR chooses loud-refusal-until-case-hack, which I recommend over shipping silent corruption another day.

Tests: folding siblings rejected on Windows/macOS and still accepted with distinct contents on Linux; a faithful round-trip passes unpackAndVerify (exported for the test) and registers the declared hash.

cabal test passes (1061), -Werror build clean, ormolu and hlint clean.
