### PR TITLE
Store: true-name NAR materialization on folding filesystems

### DIFF
--- a/cbits/nn_winfs.c
+++ b/cbits/nn_winfs.c
@@ -1,0 +1,67 @@
+#include "nn_winfs.h"
+
+#ifdef _WIN32
+
+#include <windows.h>
+#include <winternl.h>
+
+/* FileCaseSensitiveInformation and its flag are absent from older SDK and
+ * MinGW headers; both values are fixed ABI, defined locally. */
+enum { NN_FILE_CASE_SENSITIVE_INFORMATION = 71 };
+
+#ifndef FILE_CS_FLAG_CASE_SENSITIVE_DIR
+#define FILE_CS_FLAG_CASE_SENSITIVE_DIR 0x00000001
+#endif
+
+typedef struct nn_file_case_sensitive_info {
+  ULONG flags;
+} nn_file_case_sensitive_info;
+
+typedef NTSTATUS(NTAPI *nn_nt_set_information_file)(HANDLE, PIO_STATUS_BLOCK,
+                                                    PVOID, ULONG, ULONG);
+
+int nn_dir_set_case_sensitive(const wchar_t *path) {
+  HMODULE ntdll;
+  nn_nt_set_information_file set_information_file;
+  HANDLE dir;
+  nn_file_case_sensitive_info info;
+  IO_STATUS_BLOCK iosb;
+  NTSTATUS status;
+
+  /* NtSetInformationFile is the documented route to the per-directory
+   * flag (fsutil and WSL use it); resolved dynamically because it lives
+   * in ntdll, which is always loaded but not in the link line. */
+  ntdll = GetModuleHandleW(L"ntdll.dll");
+  if (ntdll == NULL) {
+    return 0;
+  }
+  set_information_file =
+      (nn_nt_set_information_file)GetProcAddress(ntdll, "NtSetInformationFile");
+  if (set_information_file == NULL) {
+    return 0;
+  }
+
+  dir = CreateFileW(path, FILE_WRITE_ATTRIBUTES,
+                    FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                    NULL, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, NULL);
+  if (dir == INVALID_HANDLE_VALUE) {
+    return 0;
+  }
+
+  info.flags = FILE_CS_FLAG_CASE_SENSITIVE_DIR;
+  status = set_information_file(dir, &iosb, &info, sizeof info,
+                                NN_FILE_CASE_SENSITIVE_INFORMATION);
+  CloseHandle(dir);
+  return status >= 0 ? 1 : 0;
+}
+
+#else /* !_WIN32 */
+
+/* Per-directory case sensitivity is an NTFS feature; APFS decides at
+ * volume creation and Linux filesystems are case-sensitive by nature. */
+int nn_dir_set_case_sensitive(const wchar_t *path) {
+  (void)path;
+  return 0;
+}
+
+#endif

--- a/cbits/nn_winfs.h
+++ b/cbits/nn_winfs.h
@@ -1,0 +1,18 @@
+/* Platform filesystem capabilities the store layer probes at runtime.
+ * Windows-only functionality; other platforms compile the constant-failure
+ * stubs so callers fall back without conditional compilation. */
+#ifndef NN_WINFS_H
+#define NN_WINFS_H
+
+#include <wchar.h>
+
+/* Make an EMPTY directory's namespace case-sensitive (the NTFS
+ * per-directory flag, the same mechanism WSL uses to host Linux trees).
+ * Returns 1 on success, 0 when refused or unsupported - a non-NTFS
+ * volume, policy, a non-empty directory, or a non-Windows build - and
+ * the caller falls back to the case-hack.  The check guards external
+ * input (NAR trees choose which directories need it), so the failure
+ * path is a live branch, never an assert. */
+int nn_dir_set_case_sensitive(const wchar_t *path);
+
+#endif

--- a/nova-nix.cabal
+++ b/nova-nix.cabal
@@ -77,6 +77,7 @@ library
     Nix.Store
     Nix.Store.Path
     Nix.Store.DB
+    Nix.Store.CaseSensitive
     Nix.DependencyGraph
     Nix.Derivation
     Nix.Builder
@@ -99,7 +100,7 @@ library
     , http-types          >= 0.12 && < 0.13
     , ram                 >= 0.20 && < 1
     , mtl                 >= 2.2 && < 2.4
-    , nova-cache          >= 0.5 && < 0.6
+    , nova-cache          >= 0.6 && < 0.7
     , process             >= 1.6 && < 1.7
     , regex-tdfa          >= 1.3 && < 1.4
     , sqlite-simple       >= 0.4 && < 0.5
@@ -118,6 +119,7 @@ library
     cbits/nn_arena.c
     cbits/nn_bytecode.c
     cbits/nn_lambda.c
+    cbits/nn_winfs.c
   include-dirs:     cbits
   -- -Werror deliberately NOT baked in: a future gcc/clang adding a new
   -- -Wall diagnostic must not retroactively break installing published
@@ -174,7 +176,7 @@ test-suite nova-nix-test
     , containers          >= 0.6 && < 0.9
     , directory           >= 1.3 && < 1.4
     , filepath            >= 1.4 && < 1.6
-    , nova-cache          >= 0.5 && < 0.6
+    , nova-cache          >= 0.6 && < 0.7
     , nova-nix
     , process             >= 1.6 && < 1.7
     , tar                 >= 0.7.1 && < 0.8

--- a/src/Nix/Store.hs
+++ b/src/Nix/Store.hs
@@ -60,6 +60,9 @@ module Nix.Store
     -- * Link ordering (exposed for testing)
     orderLinks,
 
+    -- * Case-hack naming (exposed for testing)
+    caseHackDiskNames,
+
     -- * Re-exports
     module Nix.Store.Path,
     module Nix.Store.DB,
@@ -80,6 +83,7 @@ import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import Nix.Derivation (Derivation (..), fromATerm, toATerm)
 import Nix.Hash (makeFixedOutputPath, sha256Digest)
+import Nix.Store.CaseSensitive (trySetCaseSensitiveDir)
 import Nix.Store.DB
 import Nix.Store.Path
 import qualified NovaCache.Hash as Hash
@@ -448,42 +452,70 @@ firstNameCollision = go Map.empty
             Just earlier -> Just (earlier, name)
             Nothing -> go (Map.insert key name seen) rest
 
+-- | Whether this platform's NAR serialiser strips the case-hack suffix
+-- ('NAR.defaultCaseHack').  Where it does, an INCOMING entry name
+-- carrying the suffix must be rejected: materialized verbatim it would
+-- re-serialise under a different name and fail its own hash recheck.
+-- Upstream rejects such names whenever its case-hack is active.
+platformStripsCaseHack :: Bool
+platformStripsCaseHack = NAR.defaultCaseHack == NAR.CaseHackEnabled
+
+-- | Disk names for a sibling list on a folding filesystem WITHOUT
+-- per-directory case sensitivity: upstream's case-hack.  The first
+-- occurrence of each folded name keeps its spelling; every later
+-- variant gains the reversible suffix and a per-name counter, which
+-- the platform serialiser strips on the way back out.  Order is
+-- preserved; result pairs are (NAR name, on-disk name).
+caseHackDiskNames :: [Text] -> [(Text, Text)]
+caseHackDiskNames = reverse . snd . foldl' step (Map.empty, [])
+  where
+    step (!seen, !acc) name =
+      let key = onDiskNameKey name
+       in case Map.lookup key seen of
+            Nothing -> (Map.insert key (0 :: Int) seen, (name, name) : acc)
+            Just occurrences ->
+              let next = occurrences + 1
+                  disk = name <> NAR.caseHackSuffix <> T.pack (show next)
+               in (Map.insert key next seen, (name, disk) : acc)
+
 -- | Unpack directory children, short-circuiting with a typed failure on the
 -- first unsafe entry name rather than crashing on untrusted input.
 --
--- The sibling list is checked for on-disk name collisions BEFORE any
--- child is written: a folding filesystem lands two distinct NAR names
--- on one file, and the silent merge would materialize a tree that no
--- longer matches the NAR hash it is about to be registered under.
--- Refusal is the fail-closed backstop; upstream materializes such
--- trees with its reversible case-hack suffix (applied at unpack,
--- stripped at serialise), which follows here once the serialiser side
--- ships in nova-cache - a registered path must always reproduce its
--- NAR byte-for-byte, whichever branch handles the collision.
+-- Sibling names folding to one on-disk name (NTFS, default APFS) take
+-- the TRUE-NAME path when the platform provides one: the just-created
+-- empty directory gains NTFS per-directory case sensitivity and the
+-- tree materializes under its real names.  Where the flag is
+-- unavailable (a non-NTFS store volume, macOS) the collision falls
+-- back to upstream's case-hack renaming, which the platform serialiser
+-- reverses.  Either way a registered path re-serialises to its NAR
+-- byte-for-byte - the substituter's on-disk recheck verifies it.
 unpackChildren :: FilePath -> [(Text, NAR.NarEntry)] -> IO (Either Text [(FilePath, Text)])
-unpackChildren path entries = case firstNameCollision (map fst entries) of
-  Just (earlier, later) ->
-    pure
-      ( Left
-          ( "NAR sibling entries '"
-              <> earlier
-              <> "' and '"
-              <> later
-              <> "' fold to the same on-disk name on this filesystem"
-          )
-      )
-  Nothing -> go entries
+unpackChildren path entries = do
+  diskNames <- resolveDiskNames
+  walkChildren (zip diskNames entries)
   where
-    go [] = pure (Right [])
-    go ((name, child) : rest)
+    names = map fst entries
+    resolveDiskNames = case firstNameCollision names of
+      Nothing -> pure names
+      Just _ -> do
+        trueNames <- trySetCaseSensitiveDir path
+        pure
+          ( if trueNames
+              then names
+              else map snd (caseHackDiskNames names)
+          )
+    walkChildren [] = pure (Right [])
+    walkChildren ((diskName, (name, child)) : rest)
       | not (isSafeNarName name) =
           pure (Left ("unsafe NAR directory entry name: " <> name))
+      | platformStripsCaseHack && NAR.caseHackSuffix `T.isInfixOf` name =
+          pure (Left ("NAR entry name contains the case-hack suffix: " <> name))
       | otherwise = do
-          result <- unpackTree (path </> T.unpack name) child
+          result <- unpackTree (path </> T.unpack diskName) child
           case result of
             Left err -> pure (Left err)
             Right links -> do
-              restResult <- go rest
+              restResult <- walkChildren rest
               case restResult of
                 Left err -> pure (Left err)
                 Right moreLinks -> pure (Right (links <> moreLinks))

--- a/src/Nix/Store/CaseSensitive.hs
+++ b/src/Nix/Store/CaseSensitive.hs
@@ -1,0 +1,37 @@
+{-# LANGUAGE CPP #-}
+
+-- | Per-directory case sensitivity: the capability probe behind
+-- true-name NAR materialization on a folding filesystem.
+--
+-- Windows NTFS exposes case sensitivity as a per-directory flag (the
+-- mechanism WSL uses to host Linux trees), so an unpacker can hold
+-- case-variant siblings under their REAL names instead of mangling
+-- them.  Other platforms report unsupported - APFS fixes sensitivity
+-- per volume at creation, Linux needs nothing - and the caller falls
+-- back to the case-hack.
+module Nix.Store.CaseSensitive (trySetCaseSensitiveDir) where
+
+#ifdef mingw32_HOST_OS
+
+import Foreign.C.String (CWString, withCWString)
+import Foreign.C.Types (CInt (..))
+
+foreign import ccall unsafe "nn_winfs.h nn_dir_set_case_sensitive"
+  c_nn_dir_set_case_sensitive :: CWString -> IO CInt
+
+-- | Enable case-sensitive naming on an EMPTY directory the caller just
+-- created.  True means the directory now holds case-variant sibling
+-- names as distinct files; False (non-NTFS volume, policy) means fall
+-- back to the case-hack.
+trySetCaseSensitiveDir :: FilePath -> IO Bool
+trySetCaseSensitiveDir path =
+  withCWString path (fmap (/= 0) . c_nn_dir_set_case_sensitive)
+
+#else
+
+-- | Unsupported off Windows: sensitivity is a volume-level property on
+-- macOS (chosen at store-volume creation) and inherent on Linux.
+trySetCaseSensitiveDir :: FilePath -> IO Bool
+trySetCaseSensitiveDir _ = pure False
+
+#endif

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -47,7 +47,8 @@ import qualified Nix.Hash as Hash
 import Nix.Parser (parseNix)
 import Nix.Parser.Lexer (Located (..), Token (..), tokenize)
 import Nix.Push (checkRecordedNarHash, computeClosure, loadApiKeyFile, mkNarInfo, narFileName, planMissing, storePathBasename, stripHashPrefix)
-import Nix.Store (Store (..), addToStore, closeStore, copyPathInto, isSafeNarName, isValid, materializeEvalSources, openStore, orderLinks, pathExists, scanReferences, scanTempReferences, setReadOnly, writeDrv, writeDrvClosure)
+import Nix.Store (Store (..), addToStore, caseHackDiskNames, closeStore, copyPathInto, isSafeNarName, isValid, materializeEvalSources, openStore, orderLinks, pathExists, scanReferences, scanTempReferences, setReadOnly, writeDrv, writeDrvClosure)
+import Nix.Store.CaseSensitive (trySetCaseSensitiveDir)
 import Nix.Store.DB (PathInfo (..), PathRegistration (..), closeStoreDB, isValidPath, openStoreDB, queryDeriver, queryPathInfo, queryReferences, registerPath, registerPaths)
 import Nix.Store.Path (StoreDir (..), StorePath (..), defaultStoreDir, defaultStoreDirText, isCanonicalStoreText, parseStorePath, platformStoreDir, platformStoreDirText, storePathToFilePath, storePathToText, storeTextToFilePath, windowsStoreDir)
 import qualified Nix.Substituter as Subst
@@ -3192,10 +3193,12 @@ testSubstituter = do
             pure (if throughLink then Pass else Fail "dir symlink not traversable (wrong flavor)")
         Subst.clearStaleDestination dest
         pure outcome,
-      -- Case-variant siblings fold onto ONE file on Windows and macOS;
-      -- the unpack rejects them loudly there instead of silently merging.
-      -- Linux preserves both names and must keep accepting them.
-      runTestM "unpackNarEntry rejects folding sibling names on a folding filesystem" $ do
+      -- Folding sibling names MATERIALIZE on every platform: true names
+      -- via the NTFS per-directory flag on Windows, upstream's case-hack
+      -- renaming on macOS, plain files on Linux.  The platform serialiser
+      -- reverses whichever branch ran, so the tree re-serialises to its
+      -- original NAR on all three.
+      runTestM "folding sibling names materialize and round-trip" $ do
         tmpBase <- getTemporaryDirectory
         let dest = tmpBase </> "nova-nix-test-unpack-fold"
             tree =
@@ -3205,19 +3208,71 @@ testSubstituter = do
                 ]
         Subst.clearStaleDestination dest
         result <- Subst.unpackNarEntry dest tree
+        outcome <- case result of
+          Left err -> pure (Fail ("unpack failed: " <> err))
+          Right () -> do
+            onDisk <- NAR.serialiseFromPath dest
+            if onDisk /= tree
+              then pure (Fail "materialized tree does not re-serialise to its NAR")
+              else
+                if SI.os == "mingw32"
+                  then do
+                    -- The flag path, not the hack: both TRUE names hold
+                    -- distinct contents inside the case-sensitive dir.
+                    upper <- BS.readFile (dest </> "Foo")
+                    lower <- BS.readFile (dest </> "foo")
+                    pure (assertEqual "true names on NTFS" ("upper", "lower") (upper, lower))
+                  else pure Pass
+        Subst.clearStaleDestination dest
+        pure outcome,
+      -- The pure case-hack naming: later case variants gain the
+      -- reversible suffix with a per-name counter.  The fold key is
+      -- platform-derived, so Linux (no folding) keeps every name.
+      runTest "caseHackDiskNames renames later case variants" $
+        let resolved = caseHackDiskNames ["Foo", "foo", "fOO", "bar"]
+         in if SI.os == "mingw32" || SI.os == "darwin"
+              then
+                assertEqual
+                  "hack naming"
+                  [("Foo", "Foo"), ("foo", "foo~nix~case~hack~1"), ("fOO", "fOO~nix~case~hack~2"), ("bar", "bar")]
+                  resolved
+              else
+                assertEqual
+                  "identity naming"
+                  [("Foo", "Foo"), ("foo", "foo"), ("fOO", "fOO"), ("bar", "bar")]
+                  resolved,
+      -- Where the platform serialiser strips the suffix, an incoming
+      -- name carrying it must reject (it could not round-trip); on
+      -- Linux such a name is legitimate and materializes verbatim.
+      runTestM "incoming case-hack suffix names reject where the serialiser strips" $ do
+        tmpBase <- getTemporaryDirectory
+        let dest = tmpBase </> "nova-nix-test-unpack-suffix"
+            tree = NAR.NarDirectory [("x~nix~case~hack~1", NAR.NarRegular False "v")]
+        Subst.clearStaleDestination dest
+        result <- Subst.unpackNarEntry dest tree
         outcome <-
           if SI.os == "mingw32" || SI.os == "darwin"
             then case result of
               Left _ -> pure Pass
-              Right () -> pure (Fail "folding sibling names were silently merged")
+              Right () -> pure (Fail "suffix-bearing name accepted where the serialiser strips")
             else case result of
               Right () -> do
-                upper <- BS.readFile (dest </> "Foo")
-                lower <- BS.readFile (dest </> "foo")
-                pure (assertEqual "distinct files" ("upper", "lower") (upper, lower))
-              Left err -> pure (Fail ("non-folding platform rejected: " <> err))
+                kept <- BS.readFile (dest </> "x~nix~case~hack~1")
+                pure (assertEqual "verbatim on Linux" "v" kept)
+              Left err -> pure (Fail ("Linux rejected a legitimate name: " <> err))
         Subst.clearStaleDestination dest
         pure outcome,
+      -- The capability probe itself: NTFS grants the per-directory flag
+      -- (CI runners and the dev box run NTFS temp dirs); other
+      -- platforms report unsupported.
+      runTestM "trySetCaseSensitiveDir reflects platform support" $ do
+        tmpBase <- getTemporaryDirectory
+        let dir = tmpBase </> "nova-nix-test-csdir"
+        Subst.clearStaleDestination dir
+        createDirectoryIfMissing True dir
+        flagged <- trySetCaseSensitiveDir dir
+        Subst.clearStaleDestination dir
+        pure (assertEqual "flag support" (SI.os == "mingw32") flagged),
       -- unpackAndVerify re-serialises the materialized tree and checks it
       -- against the declared hash before returning a registration: a
       -- faithful round-trip passes, and the registration carries the


### PR DESCRIPTION
Closes #67. The finale of the folding-filesystem class (#45): a NAR tree with case-variant siblings now MATERIALIZES on every platform, with true names wherever the platform can hold them.

**Windows: true names via NTFS per-directory case sensitivity.** New cbits/nn_winfs.c probes the flag (FILE_CASE_SENSITIVE_INFORMATION via NtSetInformationFile - the mechanism WSL uses to host Linux trees on NTFS), bound in the new Nix.Store.CaseSensitive module. When a directory's sibling list carries a fold-collision, the unpacker sets the flag on the just-created empty directory and writes the REAL names: Makefile and makefile coexist as distinct files, readdir tells running programs the truth, and serialisation needs no un-mangling. Zero extra syscalls for directories without collisions. Upstream's Windows port never did this - it inherited the macOS-era case-hack - so this is a capability upstream does not have.

**Fallback and macOS: upstream's case-hack.** Where the flag is unavailable (a non-NTFS store volume, and macOS, where sensitivity is per-volume at creation - see #68), the collision falls back to upstream's reversible ~nix~case~hack~N renaming, which nova-cache 0.6.0.0's platform serialiser strips on the way back out (the bound bumps to >= 0.6 && < 0.7). Wherever the platform serialiser strips, an INCOMING entry name already carrying the suffix is rejected - materialized verbatim it would re-serialise under a different name and fail its own hash - matching upstream, which rejects such names whenever its case-hack is active. On Linux such names remain legitimate and materialize verbatim.

**Verification stays universal.** The on-disk hash recheck from #66 verifies every branch: a registered path re-serialises to its NAR byte-for-byte whether it took the flag path, the hack path, or the plain path.

The C shim is C99-strict-verified with GHC's own toolchain compiler (clang) under -Wall -Wextra -pedantic -Werror, Windows body included; non-Windows builds compile a constant-failure stub, and the Haskell side is CPP-split per the platform rules. The capability check guards external input (archives choose which directories are probed), so the failure path is a live branch, never an assert.

Tests: the folding-siblings test now asserts materialization + byte-identical re-serialisation on all three platforms, plus Windows-only proof that both TRUE names hold distinct contents (the flag path, not the hack); the pure case-hack naming (ordering, per-name counters) is pinned per platform; suffix-bearing incoming names reject on Windows/macOS and materialize verbatim on Linux; and the capability probe itself is asserted per platform (NTFS temp dirs grant it; others report unsupported).

cabal test passes (1064, native flag round-trip included), -Werror build against Hackage nova-cache-0.6.0.0 clean, ormolu and hlint clean.
