### PR TITLE
Thunk: remove the pre-bytecode StablePtr constructor

### DIFF
--- a/cbits/nn_thunk.c
+++ b/cbits/nn_thunk.c
@@ -126,19 +126,6 @@ nn_thunk_destroy(void)
 /* --- Allocation --- */
 
 nn_thunk_t *
-nn_thunk_new(void *pending_data)
-{
-    nn_thunk_t *t = arena_alloc(g_arena);
-    if (!t) return NULL;
-    t->state = NN_THUNK_PENDING;
-    t->val_tag = 0;
-    t->_pad = 0;
-    t->bc_idx = 0;  /* legacy StablePtr thunk marker */
-    t->payload = pending_data;
-    return t;
-}
-
-nn_thunk_t *
 nn_thunk_new_bc(uint32_t bc_idx, void *env_ptr)
 {
     nn_thunk_t *t = arena_alloc(g_arena);

--- a/cbits/nn_thunk.h
+++ b/cbits/nn_thunk.h
@@ -81,7 +81,8 @@ typedef char nn_thunk_ptr_size_check_[(sizeof(void *) >= sizeof(int64_t)) ? 1 : 
 
 /* Initialize the global thunk arena.  initial_capacity is the number
  * of thunks to pre-allocate per block (0 uses default: 65536 = 1 MB).
- * Must be called once before any nn_thunk_new() calls. */
+ * Must be called once before any thunk allocation (nn_thunk_new_bc or
+ * the computed-value constructors). */
 void nn_thunk_init(uint32_t initial_capacity);
 
 /* Destroy the global thunk arena, freeing all block memory.
@@ -92,13 +93,8 @@ void nn_thunk_destroy(void);
 
 /* --- Allocation --- */
 
-/* Allocate a new PENDING thunk from the arena (legacy StablePtr path).
- * pending_data is an opaque pointer (StablePtr to Haskell value).
- * Sets bc_idx = 0 to distinguish from bytecode thunks.
- * Returns a pointer into arena memory, valid until nn_thunk_destroy(). */
-nn_thunk_t *nn_thunk_new(void *pending_data);
-
 /* Allocate a new PENDING thunk with a bytecode index + env payload.
+ * Returns a pointer into arena memory, valid until nn_thunk_destroy().
  * bc_idx is the root instruction index in the bytecode store.
  * env_ptr is a StablePtr Env from Haskell (required for knot-tying;
  * raw Ptr would force the env at allocation time, breaking laziness). */

--- a/src/Nix/Eval/CThunk.hs
+++ b/src/Nix/Eval/CThunk.hs
@@ -29,7 +29,6 @@ module Nix.Eval.CThunk
     cthunkDestroy,
 
     -- * Allocation
-    cthunkNew,
     cthunkNewBc,
     cthunkNewComputed,
     cthunkNewComputedInt,
@@ -100,9 +99,6 @@ foreign import ccall unsafe "nn_thunk_init"
 
 foreign import ccall unsafe "nn_thunk_destroy"
   c_nn_thunk_destroy :: IO ()
-
-foreign import ccall unsafe "nn_thunk_new"
-  c_nn_thunk_new :: Ptr () -> IO CThunkPtr
 
 foreign import ccall unsafe "nn_thunk_new_bc"
   c_nn_thunk_new_bc :: Word32 -> Ptr () -> IO CThunkPtr
@@ -245,11 +241,6 @@ cthunkDestroy = c_nn_thunk_destroy
 -- ---------------------------------------------------------------------------
 -- Allocation
 -- ---------------------------------------------------------------------------
-
--- | Allocate a new PENDING thunk from the arena (legacy StablePtr path).
--- The payload is an opaque pointer (StablePtr cast to Ptr ()).
-cthunkNew :: Ptr () -> IO CThunkPtr
-cthunkNew = c_nn_thunk_new
 
 -- | Allocate a new PENDING thunk with a bytecode index + C env pointer.
 -- No Haskell heap references - zero GC pressure for pending thunks.

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -33,7 +33,7 @@ import Nix.Eval (MonadEval (..), NixValue (..), StringContext (..), StringContex
 import Nix.Eval.Arena (arenaDestroy, arenaInit)
 import Nix.Eval.CAttrSet (cattrsetFreeze, cattrsetInsert, cattrsetKeys, cattrsetLookup, cattrsetNew, cattrsetSize, cattrsetUnion)
 import Nix.Eval.CBytecode (binaryAdd, captureSlots, captureWithScopes, cbcArg1, cbcArg2, cbcArg3, cbcData, cbcFlags, cbcOpCount, cbcOpcode, cbcShortArg, formalName, formalNamedSet, formalSet, strpartInterp, strpartLit, unaryNegate, pattern OpApp, pattern OpAssert, pattern OpAttrs, pattern OpBinary, pattern OpHasAttr, pattern OpIf, pattern OpIndStr, pattern OpLambda, pattern OpLet, pattern OpList, pattern OpLitBool, pattern OpLitFloat, pattern OpLitInt, pattern OpLitNull, pattern OpLitPath, pattern OpLitUri, pattern OpResolvedVar, pattern OpSelect, pattern OpStr, pattern OpUnary, pattern OpVar, pattern OpWith, pattern OpWithVar)
-import Nix.Eval.CThunk (CThunkPtr, cthunkCount, cthunkGet, cthunkGetBcIdx, cthunkMarkBlackhole, cthunkNew, cthunkNewComputed, cthunkPayload, cthunkSetComputed, cthunkState)
+import Nix.Eval.CThunk (CThunkPtr, cthunkCount, cthunkGet, cthunkGetBcIdx, cthunkMarkBlackhole, cthunkNewBc, cthunkNewComputed, cthunkPayload, cthunkSetComputed, cthunkState)
 import Nix.Eval.CanonPath (canonPath)
 import Nix.Eval.Compile (compileExpr)
 import qualified Nix.Eval.Context as Context
@@ -6506,7 +6506,7 @@ testCThunk = do
   sequence
     [ runTestM "new pending + state" $ do
         sp <- newStablePtr ("pending" :: Text)
-        ptr <- cthunkNew (castStablePtrToPtr sp)
+        ptr <- cthunkNewBc 0 (castStablePtrToPtr sp)
         state <- cthunkState ptr
         pure (assertEqual "state" 0 state),
       runTestM "new computed + state" $ do
@@ -6516,7 +6516,7 @@ testCThunk = do
         pure (assertEqual "state" 1 state),
       runTestM "payload round-trips (pending)" $ do
         sp <- newStablePtr ("hello" :: Text)
-        ptr <- cthunkNew (castStablePtrToPtr sp)
+        ptr <- cthunkNewBc 0 (castStablePtrToPtr sp)
         payload <- cthunkPayload ptr
         val <- deRefStablePtr (castPtrToStablePtr payload) :: IO Text
         pure (assertEqual "payload" "hello" val),
@@ -6528,7 +6528,7 @@ testCThunk = do
         pure (assertEqual "payload" 42 val),
       runTestM "mark_blackhole succeeds on pending" $ do
         sp <- newStablePtr ("x" :: Text)
-        ptr <- cthunkNew (castStablePtrToPtr sp)
+        ptr <- cthunkNewBc 0 (castStablePtrToPtr sp)
         ok <- cthunkMarkBlackhole ptr
         state <- cthunkState ptr
         pure
@@ -6543,13 +6543,13 @@ testCThunk = do
         pure (if not ok then Pass else Fail "should have failed"),
       runTestM "mark_blackhole fails on blackhole" $ do
         sp <- newStablePtr ("x" :: Text)
-        ptr <- cthunkNew (castStablePtrToPtr sp)
+        ptr <- cthunkNewBc 0 (castStablePtrToPtr sp)
         _ <- cthunkMarkBlackhole ptr
         ok <- cthunkMarkBlackhole ptr
         pure (if not ok then Pass else Fail "should have failed"),
       runTestM "set_computed returns old payload" $ do
         pendingSp <- newStablePtr ("old" :: Text)
-        ptr <- cthunkNew (castStablePtrToPtr pendingSp)
+        ptr <- cthunkNewBc 0 (castStablePtrToPtr pendingSp)
         _ <- cthunkMarkBlackhole ptr
         computedSp <- newStablePtr ("new" :: Text)
         oldPayload <- cthunkSetComputed ptr (castStablePtrToPtr computedSp)
@@ -6573,7 +6573,7 @@ testCThunk = do
           ),
       runTestM "set_computed on pending returns old payload" $ do
         sp <- newStablePtr ("x" :: Text)
-        ptr <- cthunkNew (castStablePtrToPtr sp)
+        ptr <- cthunkNewBc 0 (castStablePtrToPtr sp)
         valSp <- newStablePtr ("v" :: Text)
         oldPayload <- cthunkSetComputed ptr (castStablePtrToPtr valSp)
         -- set_computed accepts PENDING (direct memoization, no blackhole step)
@@ -6583,8 +6583,8 @@ testCThunk = do
       runTestM "count tracks allocations" $ do
         countBefore <- cthunkCount
         sp <- newStablePtr (0 :: Int)
-        _ <- cthunkNew (castStablePtrToPtr sp)
-        _ <- cthunkNew (castStablePtrToPtr sp)
+        _ <- cthunkNewBc 0 (castStablePtrToPtr sp)
+        _ <- cthunkNewBc 0 (castStablePtrToPtr sp)
         _ <- cthunkNewComputed (castStablePtrToPtr sp)
         countAfter <- cthunkCount
         let delta = countAfter - countBefore
@@ -6592,7 +6592,7 @@ testCThunk = do
       runTestM "get retrieves by index" $ do
         countBefore <- cthunkCount
         sp <- newStablePtr ("indexed" :: Text)
-        ptr <- cthunkNew (castStablePtrToPtr sp)
+        ptr <- cthunkNewBc 0 (castStablePtrToPtr sp)
         retrieved <- cthunkGet countBefore
         stateOrig <- cthunkState ptr
         stateRetrieved <- cthunkState retrieved
@@ -6604,7 +6604,7 @@ testCThunk = do
       runTestM "stress: 100k thunks" $ do
         countBefore <- cthunkCount
         sp <- newStablePtr (0 :: Int)
-        mapM_ (\_ -> cthunkNew (castStablePtrToPtr sp)) [(1 :: Int) .. 100000]
+        mapM_ (\_ -> cthunkNewBc 0 (castStablePtrToPtr sp)) [(1 :: Int) .. 100000]
         countAfter <- cthunkCount
         let delta = countAfter - countBefore
         -- Spot-check: retrieve one from the middle


### PR DESCRIPTION
The dead-code half of #71 (the sanitizer CI job stays tracked there).

nn_thunk_new was the pre-bytecode thunk constructor: a pending thunk's payload was a StablePtr to a Haskell closure, and bc_idx = 0 marked the non-bytecode kind. The bytecode migration replaced that path with nn_thunk_new_bc (real bytecode index + env payload) and the computed-value constructors; the evaluator has not referenced it since, and nothing anywhere tests bc_idx == 0 as a discriminator. It survived because its exported Haskell binding (cthunkNew) never triggered an unused warning.

One correction to the review note that spawned this: the constructor was evaluator-dead but not test-dead - the C-layer unit tests used it as their handle on the thunk state machine. Those tests exercise states, the blackhole protocol, payload swapping, and allocation counting, all constructor-agnostic, so they now drive the same coverage through cthunkNewBc (the payload argument is opaque either way, and these thunks are never forced). Coverage is unchanged; the suite passes identically.

Comments now state the live constraint instead of the dead lineage: nn_thunk_init's doc names the real constructors, and the arena-validity line moved onto nn_thunk_new_bc.

cabal test passes (1064), -Werror build clean, nn_thunk.c strict-C99-verified with the GHC toolchain compiler, ormolu and hlint clean.
