### PR TITLE
Class K: fixed-output hash recheck, fetchGit transport allowlist, isolated fetcher scratch dirs

### DIFF
--- a/profiling/bench.sh
+++ b/profiling/bench.sh
@@ -4,6 +4,10 @@
 # Usage:
 #   ./profiling/bench.sh <label> [rts-flags...] [--build] [--full]
 #
+# Requires NIXPKGS_PATH in the environment: the nixpkgs checkout that
+# <nixpkgs> in the eval expression resolves to, in the path spelling the
+# platform's executable expects.
+#
 # Examples:
 #   ./profiling/bench.sh baseline                        # Just -s stats, -M4G
 #   ./profiling/bench.sh iter6-trim -hT                  # Type-based heap profile
@@ -36,7 +40,7 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-NIXPKGS_PATH="C:\\Users\\devon\\nixpkgs-nixos-24.11"
+NIXPKGS_PATH="${NIXPKGS_PATH:?set NIXPKGS_PATH to a nixpkgs checkout}"
 EVAL_EXPR='builtins.length (builtins.attrNames (import <nixpkgs> {}))'
 DEFAULT_HEAP_CAP="-M4G"
 HEAP_CAP="$DEFAULT_HEAP_CAP"

--- a/src/Nix/Builder.hs
+++ b/src/Nix/Builder.hs
@@ -71,6 +71,7 @@ import Nix.Hash (IncrementalHash, bytesToHexText, hashFinalizeBytes, hashInitWit
 import Nix.Store (PathRegistration, Store (..), isValid, placeInStore, registerPaths, scanReferences, scanTempReferences)
 import Nix.Store.Path (StoreDir (..), StorePath (..), storePathToFilePath)
 import Nix.Substituter (CacheConfig, SubstResult (..), trySubstitute)
+import qualified NovaCache.NAR as NAR
 import System.Directory (createDirectoryIfMissing, doesDirectoryExist, doesPathExist, removeDirectoryRecursive, removePathForcibly)
 import qualified System.Environment
 import System.Exit (ExitCode (..))
@@ -706,7 +707,76 @@ prepareOutput config store candidates tempPairs drvPathText (output, (_outName, 
           selfRefs <- scanTempReferences tempPairs outDir
           let refs = dedupStorePaths (inputRefs ++ selfRefs)
           reg <- placeInStore store outDir targetSP drvPathText refs
-          pure (Right (Just reg))
+          fixedCheck <- verifyFixedOutput output targetPath
+          case fixedCheck of
+            Left err -> do
+              -- Wrong bytes for a declared content address: remove the
+              -- placed tree so a later run cannot meet it on disk.
+              removePathForcibly targetPath
+              pure (Left err)
+            Right () -> pure (Right (Just reg))
+
+-- | Re-check a placed fixed-output output against its declared hash.
+-- A fixed-output derivation declares both its store path and, via the
+-- output spec (@doHashAlgo@ + @doHash@), the exact content the path
+-- must carry - but the builder process writes the actual bytes, so the
+-- placed result must reproduce the declared digest before it may
+-- register as valid (upstream: the fixed-output check in its
+-- registerOutputs).  Flat mode hashes the output file's bytes;
+-- recursive (@r:@) mode hashes the canonical NAR of the placed tree.
+-- Non-fixed outputs (empty @doHashAlgo@) pass unchecked.
+verifyFixedOutput :: DerivationOutput -> FilePath -> IO (Either Text ())
+verifyFixedOutput out placedPath
+  | T.null (doHashAlgo out) = pure (Right ())
+  | recursive = do
+      -- Re-serialises the placed tree: the registration's NAR hash is
+      -- always sha256, while the declared algorithm may be any.
+      entry <- NAR.serialiseFromPath placedPath
+      pure (finish (rawHashWithAlgo algo (NAR.serialise entry)))
+  | otherwise = do
+      isDir <- doesDirectoryExist placedPath
+      if isDir
+        then pure (Left (subject <> ": flat outputHashMode, but the output is a directory"))
+        else finish <$> hashFileWithAlgo algo placedPath
+  where
+    (recursive, algo) = splitHashMode (doHashAlgo out)
+    subject = "fixed-output '" <> spName (doPath out) <> "'"
+    finish Nothing =
+      Left (subject <> ": unsupported hash algorithm '" <> algo <> "'")
+    finish (Just got) = case hexToBytes (doHash out) of
+      Nothing -> Left (subject <> ": malformed expected hash")
+      Just expected
+        | expected == got -> Right ()
+        | otherwise ->
+            Left
+              ( subject
+                  <> ": hash mismatch\n  expected: "
+                  <> doHashAlgo out
+                  <> ":"
+                  <> doHash out
+                  <> "\n  got:      "
+                  <> doHashAlgo out
+                  <> ":"
+                  <> bytesToHexText got
+              )
+
+-- | Stream a file through the incremental hash without materializing it
+-- (a fixed-output file is input-sized).  'Nothing' for an unsupported
+-- algorithm.
+hashFileWithAlgo :: Text -> FilePath -> IO (Maybe BS.ByteString)
+hashFileWithAlgo algo path = case hashInitWithAlgo algo of
+  Nothing -> pure Nothing
+  Just initialCtx -> System.IO.withBinaryFile path System.IO.ReadMode $ \handle ->
+    let consume !ctx = do
+          chunk <- BS.hGet handle fixedOutputHashChunk
+          if BS.null chunk
+            then pure (Just (hashFinalizeBytes ctx))
+            else consume (hashUpdateChunk ctx chunk)
+     in consume initialCtx
+
+-- | Read-chunk size for hashing a placed output file.
+fixedOutputHashChunk :: Int
+fixedOutputHashChunk = 65536
 
 -- | Deduplicate store paths by their (unique) hash.
 dedupStorePaths :: [StorePath] -> [StorePath]

--- a/src/Nix/Eval.hs
+++ b/src/Nix/Eval.hs
@@ -57,6 +57,9 @@ module Nix.Eval
     evaluated,
     readThunkValue,
 
+    -- * Fetcher transport validation (pure, exported for tests)
+    checkGitUrl,
+
     -- * Builtin registry
     BuiltinDef (..),
     builtinRegistry,
@@ -3406,22 +3409,20 @@ tarballSourceName = "source"
 -- copy the tree to its content-addressed store path.  The pin is the
 -- recursive NAR hash of the EXTRACTED tree, as upstream.  Download and
 -- extraction share one shell pipeline to avoid binary-as-text encoding
--- issues; the scratch dir is cleared first so an interrupted earlier
--- extraction cannot leak stale files into this one.
+-- issues.  The scratch dir is exclusively created with an unpredictable
+-- name ('createScratchDir') and removed once the tree reaches the store.
 fetchAndExtractTarball :: (MonadEval m) => Text -> Maybe Text -> Text -> m NixValue
 fetchAndExtractTarball url mSha256 name = do
-  sysTmp <- getTempDir
-  let urlHash = sha256Hex (TE.encodeUtf8 url)
-      extractDir = sysTmp <> "/nova-nix-tarball-" <> urlHash
+  extractDir <- createScratchDir "nova-nix-tarball-"
   -- The -- separator prevents argument injection from the URL.
   (code, _, errOut) <-
     runProcess
       "sh"
       [ "-c",
-        "rm -rf \"$1\" && mkdir -p \"$1\" && curl -sSfL -- \"$2\" | tar -xz -C \"$1\" --strip-components=1",
+        "curl -sSfL -- \"$1\" | tar -xz -C \"$2\" --strip-components=1",
         "--",
-        extractDir,
-        url
+        url,
+        extractDir
       ]
       ""
   case code of
@@ -3432,19 +3433,77 @@ fetchAndExtractTarball url mSha256 name = do
           extractDir
           name
           (fmap ("builtins.fetchTarball: " <> url,) pin)
+      removeScratchDir extractDir
       pure (VPath storePath)
-    _ -> throwEvalError ("builtins.fetchTarball: " <> errOut)
+    _ -> do
+      removeScratchDir extractDir
+      throwEvalError ("builtins.fetchTarball: " <> errOut)
+
+-- | Transports 'builtinFetchGit' accepts.  Also spelled into the
+-- clone's @protocol.*.allow@ config, so git enforces the same set
+-- internally.
+allowedGitSchemes :: [Text]
+allowedGitSchemes = ["http", "https", "ssh", "git", "file"]
+
+-- | Validate a fetchGit URL's transport before anything spawns.  git's
+-- transport-helper syntax (@\<helper\>::\<address\>@) makes the helper
+-- name a command to run as the transport (@ext::@ runs a shell command,
+-- @fd::@ reads a descriptor), so evaluating an expression carrying such
+-- a URL would execute it.  Accepted: an allowlisted explicit scheme, an
+-- scp-like remote, or a local path.  Left carries the eval-error text.
+checkGitUrl :: Text -> Either Text Text
+checkGitUrl url
+  | T.null url = Left "builtins.fetchGit: empty url"
+  | not (T.null schemeRest),
+    schemeShaped scheme,
+    T.toLower scheme `elem` allowedGitSchemes =
+      Right url
+  | not (T.null schemeRest) = Left (disallowed scheme)
+  | Just helper <- helperPrefix = Left (disallowed helper)
+  | otherwise = Right url
+  where
+    (scheme, schemeRest) = T.breakOn "://" url
+    -- RFC 3986 scheme shape; anything else before :// is not a scheme.
+    schemeShaped s = case T.uncons s of
+      Just (leading, rest) -> asciiAlpha leading && T.all schemeChar rest
+      Nothing -> False
+    schemeChar c = asciiAlpha c || isDigit c || c == '+' || c == '-' || c == '.'
+    asciiAlpha c = isAsciiLower c || isAsciiUpper c
+    -- <helper>:: counts only when the prefix is shaped like a helper
+    -- name; "[::1]"-style scp hosts contain :: but are not helpers.
+    helperPrefix = case T.breakOn "::" url of
+      (prefix, rest)
+        | not (T.null rest),
+          T.null prefix || T.all helperChar prefix ->
+            Just prefix
+      _ -> Nothing
+    helperChar c = asciiAlpha c || isDigit c || c == '-' || c == '_'
+    disallowed t =
+      "builtins.fetchGit: transport '" <> t <> "' is not allowed in url: " <> url
+
+-- | @-c@ config pinning the clone to 'allowedGitSchemes': every
+-- transport defaults to never, each allowed scheme is re-enabled.  This
+-- enforces what URL validation cannot see up front - a helper reached
+-- indirectly, or a @remote-\<helper\>@ binary on PATH.
+gitTransportConfig :: [Text]
+gitTransportConfig =
+  ["-c", "protocol.allow=never"]
+    ++ concat [["-c", "protocol." <> scheme <> ".allow=always"] | scheme <- allowedGitSchemes]
 
 builtinFetchGit :: (MonadEval m) => NixValue -> m NixValue
 builtinFetchGit (VStr rawUrl _) = do
   url <- decodedText "builtins.fetchGit" rawUrl
-  sysTmp <- getTempDir
-  let urlHash = sha256Hex (TE.encodeUtf8 url)
-      cloneDir = sysTmp <> "/nova-nix-fetchgit-" <> urlHash
-  (code, _, errOut) <- runProcess "git" ["clone", "--depth", "1", "--", url, cloneDir] ""
-  case code of
-    0 -> pure (VPath cloneDir)
-    _ -> throwEvalError ("builtins.fetchGit: git clone failed: " <> errOut)
+  case checkGitUrl url of
+    Left err -> throwEvalError err
+    Right allowedUrl -> do
+      cloneDir <- createScratchDir "nova-nix-fetchgit-"
+      (code, _, errOut) <-
+        runProcess "git" (gitTransportConfig ++ ["clone", "--depth", "1", "--", allowedUrl, cloneDir]) ""
+      case code of
+        0 -> pure (VPath cloneDir)
+        _ -> do
+          removeScratchDir cloneDir
+          throwEvalError ("builtins.fetchGit: git clone failed: " <> errOut)
 builtinFetchGit (VAttrs attrs) = do
   url <- forceAttrStr "builtins.fetchGit" "url" attrs
   builtinFetchGit (mkStr url)

--- a/src/Nix/Eval/IO.hs
+++ b/src/Nix/Eval/IO.hs
@@ -33,6 +33,7 @@ import Control.Exception (Exception, SomeAsyncException, SomeException, displayE
 import Control.Monad (unless, when)
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Reader (ReaderT (..), ask, asks, local)
+import Crypto.Random (getRandomBytes)
 import qualified Data.ByteString as BS
 import Data.IORef (IORef, modifyIORef', newIORef, readIORef)
 import Data.Int (Int64)
@@ -341,6 +342,19 @@ instance MonadEval EvalIO where
           ExitFailure n -> n
     pure (code, T.pack stdoutStr, T.pack stderrStr)
 
+  createScratchDir prefix = wrapIO $ do
+    tmpBase <- Dir.getTemporaryDirectory
+    suffix <- getRandomBytes scratchSuffixBytes
+    -- Forward-slash join: the scratch path feeds sh pipelines (tar -C)
+    -- and store copies, both of which accept '/' on every host.
+    let dir = tmpBase <> "/" <> T.unpack (prefix <> bytesToHexText suffix)
+    -- createDirectory is exclusive: an already-existing path fails the
+    -- fetch rather than being silently adopted.
+    Dir.createDirectory dir
+    pure (T.pack dir)
+
+  removeScratchDir dir = wrapIO (Dir.removePathForcibly (T.unpack dir))
+
   copyPathToStore srcPath name expectedSha256 = do
     -- The name is checked before the tree read: it arrives independently
     -- of the source, and the tree can be arbitrarily large.
@@ -534,6 +548,11 @@ readComputed ptr = do
 -- from retaining huge attr sets like nixpkgs' 30k-entry all-packages.nix.
 importCacheMaxAttrs :: Int
 importCacheMaxAttrs = 1000
+
+-- | Random bytes in a scratch-dir name suffix (hex-encoded).  128 bits:
+-- unguessable by another local process, collision-free in practice.
+scratchSuffixBytes :: Int
+scratchSuffixBytes = 16
 
 -- ---------------------------------------------------------------------------
 -- Helpers

--- a/src/Nix/Eval/Types.hs
+++ b/src/Nix/Eval/Types.hs
@@ -1138,6 +1138,17 @@ class (Monad m) => MonadEval m where
   -- | Run an external process: @(command, args, stdin) -> (exitCode, stdout, stderr)@.
   runProcess :: Text -> [Text] -> Text -> m (Int, Text, Text)
 
+  -- | Create a fetcher scratch directory under the system temp dir: the
+  -- given name prefix plus an unpredictable suffix, exclusively created.
+  -- A fixed scratch name in the shared temp dir gives any other local
+  -- process a pre-place\/swap window between creation and the store
+  -- copy, so the name must be unguessable and creation must fail rather
+  -- than adopt an existing directory.
+  createScratchDir :: Text -> m Text
+
+  -- | Recursively remove a directory 'createScratchDir' created.
+  removeScratchDir :: Text -> m ()
+
   -- | Resolve a path literal to a canonical path.
   -- In IO evaluation, @~/@ resolves against the home directory and other
   -- relative paths resolve against the current file's directory
@@ -1278,6 +1289,8 @@ instance MonadEval PureEval where
   readFileBytes _ = throwEvalError "readFile: not available in pure evaluation"
   getFileType _ = throwEvalError "readFileType: not available in pure evaluation"
   runProcess _ _ _ = throwEvalError "runProcess: not available in pure evaluation"
+  createScratchDir _ = throwEvalError "createScratchDir: not available in pure evaluation"
+  removeScratchDir _ = pure ()
   copyPathToStore _ _ _ = throwEvalError "builtins.path: not available in pure evaluation"
   isExecutableFile _ = throwEvalError "builtins.path: not available in pure evaluation"
   readSymlinkTarget _ = throwEvalError "builtins.path: not available in pure evaluation"

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -29,7 +29,7 @@ import Nix.Builder.Unpack (UnpackLimits (..), builtinUnpackBuilder, entryCompone
 import Nix.Builtins (builtinEnv, parseNixPath, splitNixPath)
 import qualified Nix.DependencyGraph as DepGraph
 import Nix.Derivation (Derivation (..), DerivationOutput (..), Platform (..), currentPlatform, fromATerm, platformToText, toATerm, toATermForHash)
-import Nix.Eval (MonadEval (..), NixValue (..), StringContext (..), StringContextElement (..), Thunk (..), attrSetFromMap, attrSetLookup, attrSetNull, attrSetSize, builtinNames, emptyContext, emptyEnv, eval, force, mkStr, readThunkValue, runPureEval)
+import Nix.Eval (MonadEval (..), NixValue (..), StringContext (..), StringContextElement (..), Thunk (..), attrSetFromMap, attrSetLookup, attrSetNull, attrSetSize, builtinNames, checkGitUrl, emptyContext, emptyEnv, eval, force, mkStr, readThunkValue, runPureEval)
 import Nix.Eval.Arena (arenaDestroy, arenaInit)
 import Nix.Eval.CAttrSet (cattrsetFreeze, cattrsetInsert, cattrsetKeys, cattrsetLookup, cattrsetNew, cattrsetSize, cattrsetUnion)
 import Nix.Eval.CBytecode (binaryAdd, captureSlots, captureWithScopes, cbcArg1, cbcArg2, cbcArg3, cbcData, cbcFlags, cbcOpCount, cbcOpcode, cbcShortArg, formalName, formalNamedSet, formalSet, strpartInterp, strpartLit, unaryNegate, pattern OpApp, pattern OpAssert, pattern OpAttrs, pattern OpBinary, pattern OpHasAttr, pattern OpIf, pattern OpIndStr, pattern OpLambda, pattern OpLet, pattern OpList, pattern OpLitBool, pattern OpLitFloat, pattern OpLitInt, pattern OpLitNull, pattern OpLitPath, pattern OpLitUri, pattern OpResolvedVar, pattern OpSelect, pattern OpStr, pattern OpUnary, pattern OpVar, pattern OpWith, pattern OpWithVar)
@@ -5044,6 +5044,103 @@ testFromTOML = do
           (mkStr "z")
     ]
 
+testFetchGitTransport :: IO [Bool]
+testFetchGitTransport = do
+  putStrLn "eval/fetchgit-transport"
+  sequence
+    [ runTest "allowed schemes pass" $
+        assertEqual
+          "schemes"
+          [ Right "https://example.com/repo.git",
+            Right "http://example.com/repo.git",
+            Right "ssh://git@example.com/repo.git",
+            Right "git://example.com/repo.git",
+            Right "file:///srv/repo"
+          ]
+          ( map
+              checkGitUrl
+              [ "https://example.com/repo.git",
+                "http://example.com/repo.git",
+                "ssh://git@example.com/repo.git",
+                "git://example.com/repo.git",
+                "file:///srv/repo"
+              ]
+          ),
+      runTest "scheme match is case-insensitive" $
+        assertEqual "upper" (Right "HTTPS://example.com/r") (checkGitUrl "HTTPS://example.com/r"),
+      runTest "scp-like remotes and local paths pass" $
+        assertEqual
+          "plain"
+          [ Right "git@github.com:owner/repo.git",
+            Right "user@[::1]:repo",
+            Right "/srv/repo",
+            Right "./repo",
+            Right "C:\\Users\\devon\\repo"
+          ]
+          ( map
+              checkGitUrl
+              [ "git@github.com:owner/repo.git",
+                "user@[::1]:repo",
+                "/srv/repo",
+                "./repo",
+                "C:\\Users\\devon\\repo"
+              ]
+          ),
+      runTest "helper transports are rejected" $
+        let rejected = ["ext::sh -c 'printf x'", "fd::17", "my-helper_2::payload", "::payload"]
+         in case [url | url <- rejected, either (const False) (const True) (checkGitUrl url)] of
+              [] -> Pass
+              slipped -> Fail ("helper urls accepted: " <> T.pack (show slipped)),
+      runTest "an unknown explicit scheme is rejected" $
+        assertLeft "hg scheme" (checkGitUrl "hg://example.com/repo"),
+      runTest "the empty url is rejected" $
+        assertLeft "empty" (checkGitUrl ""),
+      runTestM "fetchGit refuses a helper transport at eval time" $ do
+        outcome <- evalNixIO "." "builtins.fetchGit { url = \"ext::printf x\"; }"
+        pure $ case outcome of
+          Left err
+            | "transport" `T.isInfixOf` err -> Pass
+            | otherwise -> Fail ("wrong error: " <> err)
+          Right _ -> Fail "helper transport url evaluated"
+    ]
+
+testScratchDirs :: IO [Bool]
+testScratchDirs = do
+  putStrLn "eval/scratch-dirs"
+  st <- newEvalState "."
+  sequence
+    [ runTestM "scratch dirs are distinct, real, and removable" $ do
+        createdA <- runEvalIO st (createScratchDir "nova-nix-test-scratch-")
+        createdB <- runEvalIO st (createScratchDir "nova-nix-test-scratch-")
+        case (createdA, createdB) of
+          (Right dirA, Right dirB)
+            | dirA == dirB -> pure (Fail "two scratch dirs share a name")
+            | otherwise -> do
+                existedA <- Dir.doesDirectoryExist (T.unpack dirA)
+                existedB <- Dir.doesDirectoryExist (T.unpack dirB)
+                removed <- runEvalIO st (removeScratchDir dirA >> removeScratchDir dirB)
+                goneA <- not <$> Dir.doesDirectoryExist (T.unpack dirA)
+                goneB <- not <$> Dir.doesDirectoryExist (T.unpack dirB)
+                pure $ case removed of
+                  Left err -> Fail ("removeScratchDir failed: " <> err)
+                  Right ()
+                    | existedA && existedB && goneA && goneB -> Pass
+                    | otherwise -> Fail "scratch dir lifecycle out of order"
+          (Left err, _) -> pure (Fail ("createScratchDir failed: " <> err))
+          (_, Left err) -> pure (Fail ("createScratchDir failed: " <> err)),
+      runTestM "scratch names carry the requested prefix" $ do
+        created <- runEvalIO st (createScratchDir "nova-nix-test-scratch-")
+        case created of
+          Left err -> pure (Fail ("createScratchDir failed: " <> err))
+          Right dir -> do
+            removed <- runEvalIO st (removeScratchDir dir)
+            pure $ case removed of
+              Left err -> Fail ("removeScratchDir failed: " <> err)
+              Right ()
+                | "nova-nix-test-scratch-" `T.isInfixOf` dir -> Pass
+                | otherwise -> Fail ("prefix missing from: " <> dir)
+    ]
+
 testNarKnownAnswer :: IO [Bool]
 testNarKnownAnswer = do
   putStrLn "nar/known-answer"
@@ -5749,6 +5846,21 @@ mkTestBuildDrv shell outSP script =
       drvEnv = Map.fromList [("name", "test-build"), ("system", TE.encodeUtf8 (platformToText currentPlatform))]
     }
 
+-- | 'mkTestBuildDrv' with a fixed-output spec: registration must
+-- re-verify the placed bytes against the declared digest.
+mkFixedOutputDrv :: Text -> StorePath -> Text -> Text -> Text -> Derivation
+mkFixedOutputDrv shell outSP script algoField hexDigest =
+  (mkTestBuildDrv shell outSP script)
+    { drvOutputs =
+        [ DerivationOutput
+            { doName = "out",
+              doPath = outSP,
+              doHashAlgo = algoField,
+              doHash = hexDigest
+            }
+        ]
+    }
+
 testBuilder :: IO [Bool]
 testBuilder = do
   putStrLn "builder"
@@ -6016,7 +6128,114 @@ testBuilder = do
         closeStore store
         forceRemoveIfExists tmpStore
         forceRemoveIfExists tmpDir
-        pure $ if not buildDirExists then Pass else Fail "build dir not cleaned up after failure"
+        pure $ if not buildDirExists then Pass else Fail "build dir not cleaned up after failure",
+      -- Fixed-output: registration re-checks the placed bytes
+      runTestM "fixed-output flat output verifies and registers" $ do
+        tmpBase <- getTemporaryDirectory
+        let tmpStore = tmpBase </> "nova-nix-test-fo1"
+        forceRemoveIfExists tmpStore
+        store <- openStore (StoreDir tmpStore)
+        let payload = "fixed output payload\n"
+            digest = maybe "" Hash.bytesToHexText (Hash.rawHashWithAlgo "sha256" payload)
+            outSP = StorePath "ffffffffffffffffffffffffffffff01" "fo-flat-good"
+            drv = mkFixedOutputDrv shell outSP "printf 'fixed output payload\\n' > $out" "sha256" digest
+            config = (defaultBuildConfig (stDir store)) {bcTmpDir = tmpBase </> "nova-nix-test-fo1-tmp"}
+        result <- buildDerivation config store drv
+        registered <- isValid store outSP
+        closeStore store
+        forceRemoveIfExists tmpStore
+        forceRemoveIfExists (bcTmpDir config)
+        pure $ case result of
+          BuildSuccess _
+            | registered -> Pass
+            | otherwise -> Fail "built but not registered valid"
+          BuildFailure msg code -> Fail ("expected success (" <> T.pack (show code) <> "): " <> msg),
+      runTestM "fixed-output flat mismatch fails and removes the output" $ do
+        tmpBase <- getTemporaryDirectory
+        let tmpStore = tmpBase </> "nova-nix-test-fo2"
+        forceRemoveIfExists tmpStore
+        store <- openStore (StoreDir tmpStore)
+        let digest = maybe "" Hash.bytesToHexText (Hash.rawHashWithAlgo "sha256" "expected content\n")
+            outSP = StorePath "ffffffffffffffffffffffffffffff02" "fo-flat-bad"
+            drv = mkFixedOutputDrv shell outSP "printf 'tampered content\\n' > $out" "sha256" digest
+            config = (defaultBuildConfig (stDir store)) {bcTmpDir = tmpBase </> "nova-nix-test-fo2-tmp"}
+        result <- buildDerivation config store drv
+        registered <- isValid store outSP
+        onDisk <- Dir.doesPathExist (storePathToFilePath (stDir store) outSP)
+        closeStore store
+        forceRemoveIfExists tmpStore
+        forceRemoveIfExists (bcTmpDir config)
+        pure $ case result of
+          BuildFailure msg _
+            | "hash mismatch" `T.isInfixOf` msg && not registered && not onDisk -> Pass
+            | otherwise ->
+                Fail
+                  ( "wrong failure shape (valid="
+                      <> T.pack (show registered)
+                      <> ", onDisk="
+                      <> T.pack (show onDisk)
+                      <> "): "
+                      <> msg
+                  )
+          BuildSuccess _ -> Fail "mismatched fixed output registered",
+      runTestM "fixed-output recursive tree verifies against its NAR hash" $ do
+        tmpBase <- getTemporaryDirectory
+        let tmpStore = tmpBase </> "nova-nix-test-fo3"
+        forceRemoveIfExists tmpStore
+        store <- openStore (StoreDir tmpStore)
+        let tree = NAR.NarDirectory [("data.txt", NAR.NarRegular False "inner bytes\n")]
+            digest = maybe "" Hash.bytesToHexText (Hash.rawHashWithAlgo "sha256" (NAR.serialise tree))
+            outSP = StorePath "ffffffffffffffffffffffffffffff03" "fo-rec-good"
+            drv = mkFixedOutputDrv shell outSP "mkdir -p $out && printf 'inner bytes\\n' > $out/data.txt" "r:sha256" digest
+            config = (defaultBuildConfig (stDir store)) {bcTmpDir = tmpBase </> "nova-nix-test-fo3-tmp"}
+        result <- buildDerivation config store drv
+        registered <- isValid store outSP
+        closeStore store
+        forceRemoveIfExists tmpStore
+        forceRemoveIfExists (bcTmpDir config)
+        pure $ case result of
+          BuildSuccess _
+            | registered -> Pass
+            | otherwise -> Fail "built but not registered valid"
+          BuildFailure msg code -> Fail ("expected success (" <> T.pack (show code) <> "): " <> msg),
+      runTestM "fixed-output recursive mismatch fails the build" $ do
+        tmpBase <- getTemporaryDirectory
+        let tmpStore = tmpBase </> "nova-nix-test-fo4"
+        forceRemoveIfExists tmpStore
+        store <- openStore (StoreDir tmpStore)
+        let tree = NAR.NarDirectory [("data.txt", NAR.NarRegular False "declared bytes\n")]
+            digest = maybe "" Hash.bytesToHexText (Hash.rawHashWithAlgo "sha256" (NAR.serialise tree))
+            outSP = StorePath "ffffffffffffffffffffffffffffff04" "fo-rec-bad"
+            drv = mkFixedOutputDrv shell outSP "mkdir -p $out && printf 'other bytes\\n' > $out/data.txt" "r:sha256" digest
+            config = (defaultBuildConfig (stDir store)) {bcTmpDir = tmpBase </> "nova-nix-test-fo4-tmp"}
+        result <- buildDerivation config store drv
+        registered <- isValid store outSP
+        closeStore store
+        forceRemoveIfExists tmpStore
+        forceRemoveIfExists (bcTmpDir config)
+        pure $ case result of
+          BuildFailure msg _
+            | "hash mismatch" `T.isInfixOf` msg && not registered -> Pass
+            | otherwise -> Fail ("wrong failure shape: " <> msg)
+          BuildSuccess _ -> Fail "mismatched fixed output registered",
+      runTestM "fixed-output flat mode rejects a directory output" $ do
+        tmpBase <- getTemporaryDirectory
+        let tmpStore = tmpBase </> "nova-nix-test-fo5"
+        forceRemoveIfExists tmpStore
+        store <- openStore (StoreDir tmpStore)
+        let digest = maybe "" Hash.bytesToHexText (Hash.rawHashWithAlgo "sha256" "whatever\n")
+            outSP = StorePath "ffffffffffffffffffffffffffffff05" "fo-flat-dir"
+            drv = mkFixedOutputDrv shell outSP "mkdir -p $out && printf 'x' > $out/f" "sha256" digest
+            config = (defaultBuildConfig (stDir store)) {bcTmpDir = tmpBase </> "nova-nix-test-fo5-tmp"}
+        result <- buildDerivation config store drv
+        closeStore store
+        forceRemoveIfExists tmpStore
+        forceRemoveIfExists (bcTmpDir config)
+        pure $ case result of
+          BuildFailure msg _
+            | "directory" `T.isInfixOf` msg -> Pass
+            | otherwise -> Fail ("wrong failure: " <> msg)
+          BuildSuccess _ -> Fail "directory output passed a flat fixed-output check"
     ]
 
 -- ---------------------------------------------------------------------------
@@ -6683,6 +6902,8 @@ instance MonadEval StubStoreEval where
   readFileBytes _ = throwEvalError "readFile: not available in the stub evaluator"
   getFileType _ = throwEvalError "readFileType: not available in the stub evaluator"
   runProcess _ _ _ = throwEvalError "runProcess: not available in the stub evaluator"
+  createScratchDir _ = throwEvalError "createScratchDir: not available in the stub evaluator"
+  removeScratchDir _ = pure ()
   copyPathToStore _ _ _ = throwEvalError "builtins.path: not available in the stub evaluator"
   isExecutableFile _ = throwEvalError "builtins.path: not available in the stub evaluator"
   readSymlinkTarget _ = throwEvalError "builtins.path: not available in the stub evaluator"
@@ -7840,6 +8061,8 @@ main = bracket_ arenaInit arenaDestroy $ do
           testUpstreamConformance,
           testHashHelpers,
           testNarKnownAnswer,
+          testFetchGitTransport,
+          testScratchDirs,
           testEvalLiterals,
           testEvalVariables,
           testEvalArithmetic,

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -5075,7 +5075,7 @@ testFetchGitTransport = do
             Right "user@[::1]:repo",
             Right "/srv/repo",
             Right "./repo",
-            Right "C:\\Users\\devon\\repo"
+            Right "C:\\src\\repo"
           ]
           ( map
               checkGitUrl
@@ -5083,7 +5083,7 @@ testFetchGitTransport = do
                 "user@[::1]:repo",
                 "/srv/repo",
                 "./repo",
-                "C:\\Users\\devon\\repo"
+                "C:\\src\\repo"
               ]
           ),
       runTest "helper transports are rejected" $


### PR DESCRIPTION
Fixes the three single-PR-sized findings of #47. K2 and K5 remain open in that issue.

**Fixed-output verification at registration (K3, and closes the K4 window).**
A fixed-output derivation declares both its store path and the content that
path must carry, but the builder process writes the actual bytes. Registration
now re-hashes the placed output against the declared hash before it registers
as valid: flat mode streams the output file through the hash, recursive mode
hashes the canonical NAR of the placed tree. A mismatch removes the placed tree
and fails the build. The verified bytes are now exactly the placed-and-registered
bytes, which is what K4 asked for.

**fetchGit transport allowlist (K1).**
builtins.fetchGit passed its url straight to git clone. git's transport-helper
syntax (helper::address) runs the helper name as a command, so an expression
carrying such a url would run that command during evaluation. The url is now
checked against an allowlist of network schemes (plus scp-like and local-path
forms) before anything spawns, and the clone is additionally pinned with
protocol.allow config so git enforces the same set internally.

**Exclusive fetcher scratch dirs (K7).**
fetchGit and fetchTarball wrote to fixed, name-predictable scratch dirs in the
shared temp dir, leaving a pre-place/swap window for another local process.
Both now use exclusively-created dirs with unpredictable names, removed once the
tree reaches the store.

Verified: -Werror build clean, 1078/1078 tests pass, ormolu and hlint clean. New
coverage: the transport validator (allowed schemes, scp-like and local paths,
rejected helper transports, unknown scheme, eval-time refusal), the scratch-dir
lifecycle, and flat/recursive fixed-output verify plus both mismatch cases.

Remaining in #47: K2 (restricted/pure-eval mode) and K5 (fetchGit rev/ref
pinning to a store path). Both feature-sized; to be split into their own issues.
