### PR TITLE
Class K remainders: outputHash algorithm cross-check, narinfo validation before fingerprinting

### DIFF
--- a/nova-nix.cabal
+++ b/nova-nix.cabal
@@ -176,6 +176,7 @@ test-suite nova-nix-test
     , containers          >= 0.6 && < 0.9
     , directory           >= 1.3 && < 1.4
     , filepath            >= 1.4 && < 1.6
+    , http-client         >= 0.7 && < 0.8
     , nova-cache          >= 0.6 && < 0.7
     , nova-nix
     , process             >= 1.6 && < 1.7

--- a/src/Nix/Eval.hs
+++ b/src/Nix/Eval.hs
@@ -3948,15 +3948,34 @@ optDrvStrAttr key attrs =
 
 -- | Decode a fixed-output hash (SRI @algo-base64@, @algo:hash@, or a bare
 -- hash plus a separate algorithm) to its algorithm name and raw bytes.
+-- A non-empty @outputHashAlgo@ must name a known algorithm and agree with
+-- the algorithm an SRI or prefixed spelling carries: the enforced
+-- algorithm must be the declared one, never a silent substitute.
 normalizeFixedHash :: (MonadEval m) => Text -> Text -> m (Text, BS.ByteString)
 normalizeFixedHash ohash ohAlgo
   | Just (algo, b64) <- parseSRI ohash = do
+      requireDeclaredAlgo algo
       bytes <- decodeSRI "derivation" algo b64
       pure (algo, bytes)
-  | Just (algo, rest) <- parseAlgoPrefix ohash = decodeWithAlgo algo rest
+  | Just (algo, rest) <- parseAlgoPrefix ohash = do
+      requireDeclaredAlgo algo
+      decodeWithAlgo algo rest
   | not (T.null ohAlgo) = decodeWithAlgo ohAlgo ohash
   | otherwise =
       throwEvalError ("derivation: cannot determine outputHash algorithm for " <> ohash)
+  where
+    -- 'decodeSha256Pin's requireSha256 with the expected type supplied by
+    -- @outputHashAlgo@ instead of fixed at sha256 (upstream's typed Hash
+    -- parse, hash.cc parseAny with an expected type).  An unknown declared
+    -- algorithm is an error even when the spelling carries its own tag.
+    requireDeclaredAlgo embedded
+      | T.null ohAlgo = pure ()
+      | Nothing <- hashAlgoBytes ohAlgo =
+          throwEvalError ("unknown hash algorithm '" <> ohAlgo <> "'")
+      | embedded == ohAlgo = pure ()
+      | otherwise =
+          throwEvalError
+            ("derivation: hash '" <> ohash <> "' should have type '" <> ohAlgo <> "', not '" <> embedded <> "'")
 
 -- | Lazy @derivation@ wrapper - mirrors C++ Nix's @corepkgs/derivation.nix@.
 -- Returns a WHNF attrset whose @drvPath@/@outPath@/output-path/@_derivation@

--- a/src/Nix/Substituter.hs
+++ b/src/Nix/Substituter.hs
@@ -10,7 +10,8 @@
 -- 1. Compute the output store path hash from the derivation
 -- 2. @GET https:\/\/cache.example.com\/\<hash\>.narinfo@
 -- 3. If 200: parse the narinfo (NAR hash, size, references, signature)
--- 4. Verify the signature against a trusted public key
+-- 4. Validate the narinfo's fields, then verify the signature against a
+--    trusted public key
 -- 5. @GET https:\/\/cache.example.com\/nar\/\<narhash\>.nar.xz@
 -- 6. Decompress, verify NAR hash, unpack into store path
 -- 7. Register in the store DB with references from narinfo
@@ -44,6 +45,8 @@ module Nix.Substituter
     readBodyCapped,
     sortCaches,
     tryCachesWith,
+    validateNarInfoFields,
+    verifyAndDecompress,
     verifySigs,
     verifyNarHash,
     verifyNarSize,
@@ -78,6 +81,7 @@ import qualified NovaCache.Hash as Hash
 import qualified NovaCache.NAR as NAR
 import qualified NovaCache.NarInfo as NarInfo
 import qualified NovaCache.Signing as Signing
+import qualified NovaCache.Validate as Validate
 import qualified System.Directory as Dir
 
 -- ---------------------------------------------------------------------------
@@ -197,8 +201,9 @@ substituteFromCache mgr store cache sp = do
                 Left err -> pure (SubstError err)
                 Right rawNar -> unpackAndVerify store sp narInfo rawNar
 
--- | Pure pipeline: verify signature and resolve the decompressor, then
--- produce an IO action that downloads and decompresses.  Unsupported
+-- | Pure pipeline: validate the narinfo's fields, verify the signature,
+-- and resolve the decompressor, then produce an IO action that downloads
+-- and decompresses.  Unsupported
 -- compression rejects HERE, before the action runs: the value is known
 -- from the narinfo, and a multi-hundred-MB download that can only fail
 -- in decompression is pure waste.
@@ -208,11 +213,47 @@ verifyAndDecompress ::
   NarInfo.NarInfo ->
   Either Text (IO (Either Text BS.ByteString))
 verifyAndDecompress cache mgr narInfo = do
+  validateNarInfoFields narInfo
   verifySigs cache narInfo
   decompress <- decompressorFor (NarInfo.niCompression narInfo)
   pure $ do
     downloaded <- downloadNarWithRetry mgr cache narInfo
     pure $ downloaded >>= decompress
+
+-- | Validate narinfo field syntax before anything consumes the fields -
+-- above all before 'verifySigs' builds the signed fingerprint from them.
+-- The fingerprint is delimited text (semicolons between fields, commas
+-- between references), so each field must have parsed as well-formed
+-- before it is spliced in; a malformed narinfo fails here as a plain
+-- parse error instead of flowing onward.  The checks are nova-cache's
+-- 'Validate.validateNarInfo': store path, references, hash spellings,
+-- sizes, and the no-@.drv@ rule.
+validateNarInfoFields :: NarInfo.NarInfo -> Either Text ()
+validateNarInfoFields narInfo = case Validate.validateNarInfo narInfo of
+  Right _ -> Right ()
+  Left errs ->
+    Left ("invalid narinfo: " <> T.intercalate "; " (map renderValidationError errs))
+
+-- | One 'Validate.ValidationError' in the register the other
+-- substitution errors use.
+renderValidationError :: Validate.ValidationError -> Text
+renderValidationError verr = case verr of
+  Validate.NegativeFileSize n -> "negative FileSize " <> T.pack (show n)
+  Validate.NegativeNarSize n -> "negative NarSize " <> T.pack (show n)
+  Validate.InvalidStorePath raw parseErr -> fieldError "StorePath" raw parseErr
+  Validate.InvalidFileHash raw parseErr -> fieldError "FileHash" raw parseErr
+  Validate.InvalidNarHash raw parseErr -> fieldError "NarHash" raw parseErr
+  Validate.InvalidReference raw parseErr -> fieldError "Reference" raw parseErr
+  Validate.NarHashMismatch expected actual ->
+    "NarHash mismatch: declared " <> expected <> ", computed " <> actual
+  Validate.FileHashMismatch expected actual ->
+    "FileHash mismatch: declared " <> expected <> ", computed " <> actual
+  Validate.SignatureInvalid sig -> "signature failed verification: " <> sig
+  Validate.NoSignatures -> "narinfo has no signatures"
+  Validate.DerivationStorePath path -> "StorePath names a derivation: " <> path
+  where
+    fieldError field raw parseErr =
+      field <> " '" <> raw <> "' does not parse: " <> T.pack parseErr
 
 -- | Verify the NAR hash and size, deserialize, unpack to the store, and set
 -- permissions.  Returns the path's registration for the caller to record;

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -24,6 +24,7 @@ import Data.Text.Encoding.Error (lenientDecode)
 import qualified Data.Text.IO as TIO
 import Foreign.Ptr (castPtr)
 import Foreign.StablePtr (StablePtr, castPtrToStablePtr, castStablePtrToPtr, deRefStablePtr, freeStablePtr, newStablePtr)
+import qualified Network.HTTP.Client as HTTP
 import Nix.Builder (BuildConfig (..), BuildResult (..), buildDerivation, buildPath, buildWithDeps, defaultBuildConfig, unionEnvs, verifyFetchHash)
 import Nix.Builder.Unpack (UnpackLimits (..), builtinUnpackBuilder, entryComponents, envSrcs, resolveLinkTarget)
 import Nix.Builtins (builtinEnv, parseNixPath, splitNixPath)
@@ -4505,6 +4506,32 @@ testUpstreamConformance = do
             | "wrong length" `T.isInfixOf` err -> Pass
             | otherwise -> Fail ("expected an SRI length error, got: " <> err)
           Right val -> Fail ("expected failure, got: " <> T.pack (show val)),
+      -- An SRI or prefixed outputHash carries its own algorithm tag; a
+      -- non-empty outputHashAlgo must agree with it (hash.cc parseAny
+      -- with an expected type), and an unknown declared algorithm is an
+      -- error even when the spelling carries a valid tag of its own.
+      runTest "fixed-output SRI algorithm must match outputHashAlgo" $
+        case evalNix "(derivation { name = \"t\"; system = \"x86_64-linux\"; builder = \"/bin/sh\"; outputHash = \"sha1-2jmj7l5rSw0yVb/vlWAYkK/YBwk=\"; outputHashAlgo = \"sha256\"; }).drvPath" of
+          Left err
+            | "should have type 'sha256'" `T.isInfixOf` err -> Pass
+            | otherwise -> Fail ("expected a hash-type error, got: " <> err)
+          Right val -> Fail ("expected failure, got: " <> T.pack (show val)),
+      runTest "fixed-output prefixed algorithm must match outputHashAlgo" $
+        case evalNix "(derivation { name = \"t\"; system = \"x86_64-linux\"; builder = \"/bin/sh\"; outputHash = \"md5:d41d8cd98f00b204e9800998ecf8427e\"; outputHashAlgo = \"sha256\"; }).drvPath" of
+          Left err
+            | "should have type 'sha256'" `T.isInfixOf` err -> Pass
+            | otherwise -> Fail ("expected a hash-type error, got: " <> err)
+          Right val -> Fail ("expected failure, got: " <> T.pack (show val)),
+      runTest "fixed-output SRI agreeing with outputHashAlgo accepted" $
+        case evalNix "(derivation { name = \"t\"; system = \"x86_64-linux\"; builder = \"/bin/sh\"; outputHash = \"sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=\"; outputHashAlgo = \"sha256\"; }).drvPath" of
+          Right _ -> Pass
+          Left err -> Fail ("expected success, got: " <> err),
+      runTest "fixed-output unknown outputHashAlgo rejected despite SRI tag" $
+        case evalNix "(derivation { name = \"t\"; system = \"x86_64-linux\"; builder = \"/bin/sh\"; outputHash = \"sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=\"; outputHashAlgo = \"sha3\"; }).drvPath" of
+          Left err
+            | "unknown hash algorithm" `T.isInfixOf` err -> Pass
+            | otherwise -> Fail ("expected an unknown-algorithm error, got: " <> err)
+          Right val -> Fail ("expected failure, got: " <> T.pack (show val)),
       runTest "builtins.path pin rejects a truncated SRI digest" $
         case evalNix "builtins.path { path = ./x; sha256 = \"sha256-YWJj\"; }" of
           Left err
@@ -7871,6 +7898,37 @@ testVerifySigs = do
             assertLeft "bad pubkey" (Subst.verifySigs (sigTestCache "not-a-key") sigTestNarInfo {NarInfo.niSigs = [validSig]})
         ]
 
+-- | Narinfo field validation gates the pipeline ahead of the signed
+-- fingerprint: a malformed field must fail as a parse error before its
+-- text can reach the fingerprint or anything downstream.
+testNarInfoValidation :: IO [Bool]
+testNarInfoValidation = do
+  putStrLn "substituter/narinfo-field-validation"
+  mgr <- HTTP.newManager HTTP.defaultManagerSettings
+  sequence
+    [ runTest "well-formed narinfo passes" $
+        assertEqual "valid" (Right ()) (Subst.validateNarInfoFields sigTestNarInfo),
+      runTest "malformed StorePath rejected" $
+        assertLeft "bad store path" (Subst.validateNarInfoFields sigTestNarInfo {NarInfo.niStorePath = "/nix/store/zzz"}),
+      runTest "derivation StorePath rejected" $
+        assertLeft "drv path" (Subst.validateNarInfoFields sigTestNarInfo {NarInfo.niStorePath = "/nix/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-hello-1.0.drv"}),
+      runTest "malformed reference rejected" $
+        assertLeft "bad reference" (Subst.validateNarInfoFields sigTestNarInfo {NarInfo.niReferences = ["../escape"]}),
+      runTest "malformed NarHash rejected" $
+        assertLeft "bad narhash" (Subst.validateNarInfoFields sigTestNarInfo {NarInfo.niNarHash = "sha256:nope"}),
+      runTest "negative NarSize rejected" $
+        assertLeft "negative narsize" (Subst.validateNarInfoFields sigTestNarInfo {NarInfo.niNarSize = -1}),
+      runTest "field validation reports ahead of signature verification" $
+        case sigTestSetup of
+          Left err -> Fail (T.pack err)
+          Right (cache, validSig, _) ->
+            case Subst.verifyAndDecompress cache mgr sigTestNarInfo {NarInfo.niStorePath = "/nix/store/zzz", NarInfo.niSigs = [validSig]} of
+              Left err
+                | "invalid narinfo" `T.isInfixOf` err -> Pass
+                | otherwise -> Fail ("expected the field-validation error, got: " <> err)
+              Right _ -> Fail "expected failure, got a download action"
+    ]
+
 -- ---------------------------------------------------------------------------
 -- Tests: resolver static globals stay in sync with the root env
 -- ---------------------------------------------------------------------------
@@ -8116,6 +8174,7 @@ main = bracket_ arenaInit arenaDestroy $ do
           testDepGraph,
           testSubstituter,
           testVerifySigs,
+          testNarInfoValidation,
           testPushPure,
           testPushClosureIO,
           testBuildOrchestrator,


### PR DESCRIPTION
Lands the two remaining small findings of audit class K.

**outputHash algorithm cross-check (#78).**
normalizeFixedHash took the algorithm embedded in an SRI or prefixed
outputHash and ignored outputHashAlgo entirely, so a derivation declaring
sha256 alongside a sha1-tagged hash was accepted silently, sha1 winning.
A non-empty outputHashAlgo must now agree with the embedded algorithm -
the mismatch errors in the same register as the sha256 pin check - and an
unknown declared algorithm errors even when the spelling carries a valid
tag of its own. Bare hashes decoded via outputHashAlgo alone are
unchanged.

**Narinfo field validation ahead of the fingerprint (#79).**
verifyAndDecompress signature-checked a fetched narinfo by fingerprinting
its raw fields. The fingerprint is delimited text, so every field must
have parsed as well-formed before it is spliced in; the pipeline now runs
nova-cache's validateNarInfo (store path, references, hash spellings,
sizes, no .drv) first, rendering its typed errors into the substituter's
error register. New coverage includes the ordering proof: a validly
signed narinfo with a malformed StorePath reports the field-validation
error, not a signature error.

Verified: -Werror build clean, 1089/1089 tests pass (11 new), ormolu and
hlint clean. The test suite gains http-client (matching the library
bound) for the Manager the ordering test needs.

Closes #78. Closes #79.
