### PR TITLE
CI: exercise the C data layer under ASan/UBSan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,66 @@ jobs:
           cabal build --enable-tests
 
   # ---------------------------------------------------------------------------
+  # Exercise the C data layer under ASan/UBSan (Linux-only).  The C99-strict
+  # job only compiles; this one RUNS the full suite with instrumented cbits,
+  # so memory errors and UB in the manual-memory surface (arena, attrset,
+  # thunk, bytecode, ...) fail CI instead of lurking.  Linux is the host:
+  # sanitizer support under mingw is unreliable, and the eval C layer is
+  # platform-independent, so Linux execution is real coverage.  The
+  # Windows-only nn_winfs body stays compile-checked by the strict job.
+  # ---------------------------------------------------------------------------
+
+  sanitizers:
+    name: ASan/UBSan
+    needs: [cabal-check]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: haskell-actions/setup@v2
+        id: setup
+        with:
+          ghc-version: "9.8"
+          cabal-version: "latest"
+
+      # Dependencies build unsanitized (the flags below are scoped to this
+      # package), so the plain Linux dependency cache applies as-is.
+      - name: Cache Cabal store
+        uses: actions/cache@v5
+        with:
+          path: ${{ steps.setup.outputs.cabal-store }}
+          key: cabal-Linux-${{ hashFiles('nova-nix.cabal') }}
+          restore-keys: cabal-Linux-
+
+      # Scoped via cabal.project.local so only this package's cbits compile
+      # instrumented and only its executables link the sanitizer runtimes -
+      # a command-line --ghc-options would rebuild every dependency too.
+      # -fno-sanitize-recover makes every UBSan report fatal rather than a
+      # log line CI would scroll past.  No -Werror here: the warnings gate
+      # is the build matrix; this job's signal is runtime findings.
+      - name: Scope sanitizer flags to this package
+        run: |
+          {
+            echo "package nova-nix"
+            echo "  ghc-options: -optc-fsanitize=address,undefined -optc-fno-sanitize-recover=all -optl-fsanitize=address,undefined"
+          } > cabal.project.local
+
+      - name: Build with instrumented cbits
+        run: cabal build --enable-tests
+
+      - name: Provision the store root
+        run: sudo mkdir -p /nix && sudo chown "$USER" /nix
+
+      # detect_leaks=0: LeakSanitizer would report the GHC RTS's deliberate
+      # process-lifetime allocations, not cbits defects - the arena's
+      # bulk-free discipline is exercised by the suite itself.
+      - name: Test under sanitizers
+        env:
+          ASAN_OPTIONS: detect_leaks=0
+          UBSAN_OPTIONS: print_stacktrace=1
+        run: cabal test
+
+  # ---------------------------------------------------------------------------
   # Build + Test (cross-platform matrix)
   # ---------------------------------------------------------------------------
 

--- a/cbits/nn_symbol.c
+++ b/cbits/nn_symbol.c
@@ -196,6 +196,14 @@ void nn_symbol_destroy(void)
 
 nn_symbol_t nn_symbol_intern(const char *str, size_t len)
 {
+    /* An empty string arrives from Haskell's zero-copy marshalling as
+     * (NULL, 0).  memcpy/memcmp require valid pointers even for a zero
+     * length, so normalize at the boundary.  Empty symbols are reachable
+     * from evaluated input ({ "" = 1; }), so the branch survives release
+     * builds. */
+    if (len == 0) {
+        str = "";
+    }
     uint32_t hash = fnv1a(str, len);
     uint32_t idx = hash & g_sym.slots_mask;
 

--- a/cbits/nn_symbol.h
+++ b/cbits/nn_symbol.h
@@ -45,7 +45,8 @@ void nn_symbol_destroy(void);
 /* Intern a string, returning its symbol.  If the string was already
  * interned, returns the existing symbol (O(1) amortized).
  * The input string is copied - the caller may free it after this call.
- * str must not be NULL.  len is the byte length (not null-terminated). */
+ * len is the byte length (not null-terminated).  (NULL, 0) denotes the
+ * empty string; str must not be NULL when len > 0. */
 nn_symbol_t nn_symbol_intern(const char *str, size_t len);
 
 /* Return the string data for a symbol.  The pointer is valid until


### PR DESCRIPTION
Closes the enforcement gap for the C data layer's sanitizer rule: the
C99-strict job only compiles, so -fsanitize=address,undefined passing
clean was a documented requirement with nothing running it. The new
Linux-only sanitizers job builds the test suite with instrumented cbits
and runs the full suite under ASan/UBSan.

Decisions carried in the job:

- The sanitizer flags live in a cabal.project.local stanza scoped to
  this package, not command-line --ghc-options: the command-line form
  applies to every dependency, forcing a full instrumented rebuild of
  the world; scoping keeps dependencies unsanitized and reuses the
  plain Linux dependency cache.
- -fno-sanitize-recover=all makes every UBSan report fatal rather than
  a log line to scroll past; ASan reports are fatal by default.
- detect_leaks=0: LeakSanitizer would report the GHC RTS's deliberate
  process-lifetime allocations, not cbits defects - the arena's
  bulk-free discipline is exercised by the suite itself.
- The store root is provisioned as in the Linux matrix job, so the
  store-writing eval tests execute under the sanitizers too.
- Linux is the host: sanitizer support under mingw is unreliable and
  the eval C layer is platform-independent; the Windows-only nn_winfs
  body stays covered by the strict compile job.

Closes #71.
