### PR TITLE
Store: a delete command - rows, trees, and referrer refusal

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -38,7 +38,7 @@ import Nix.Eval.IO (EvalState (..), newEvalState, runEvalIO)
 import Nix.Eval.Types (bytesToTextLossy, clistFromThunks, clistThunks, thunkToCPtr)
 import Nix.Parser (parseNix, readFileAutoEncoding)
 import Nix.Push (PushConfig (..), PushSummary (..), loadApiKeyFile, pushPaths)
-import Nix.Store (Store (..), closeStore, materializeEvalSources, openStore, queryAllValidPaths, writeDrv, writeDrvClosure)
+import Nix.Store (DeleteOutcome (..), Store (..), closeStore, deleteStorePathRaw, materializeEvalSources, openStore, queryAllValidPaths, resolveDeleteTarget, writeDrv, writeDrvClosure)
 import Nix.Store.Path (StoreDir (..), StorePath (..), defaultStoreDir, parseStorePath, platformStoreDir, storePathHashLen, storePathToFilePath)
 import Nix.Substituter (CacheConfig (..))
 import Paths_nova_nix (getDataDir)
@@ -71,6 +71,7 @@ data Command
   | CmdEvalExpr !T.Text
   | CmdBuild !FilePath
   | CmdPush !PushArgs
+  | CmdStoreDelete ![String]
   | CmdHelp
 
 -- | Arguments to the push command.
@@ -109,6 +110,7 @@ parseArgs = go (CliOpts [] False False Nothing Nothing Nothing CmdHelp)
     go opts ("build" : path : rest) =
       go (opts {optCommand = CmdBuild path}) rest
     go opts ("push" : rest) = goPush opts emptyPushArgs rest
+    go opts ("store" : rest) = goStore opts rest
     go _ [flag]
       | flag `elem` valueFlags = Left (flag ++ " requires a value")
     go _ (arg : _) = Left ("unknown argument: " ++ arg ++ " (run nova-nix with no arguments for usage)")
@@ -140,6 +142,20 @@ parseArgs = go (CliOpts [] False False Nothing Nothing Nothing CmdHelp)
     goPush _ _ (arg@('-' : _) : _) = Left ("unknown push flag: " ++ arg)
     goPush opts pushArgs (path : rest) =
       goPush opts (pushArgs {paPaths = paPaths pushArgs ++ [path]}) rest
+    -- Sub-parser for store maintenance verbs.
+    goStore _ [] = Left "store: expected a subcommand (delete)"
+    goStore opts ("delete" : rest) = goStoreDelete opts [] rest
+    goStore _ (sub : _) = Left ("unknown store subcommand: " ++ sub ++ " (expected: delete)")
+    goStoreDelete opts paths []
+      | null paths = Left "store delete: name at least one store path"
+      | otherwise = Right opts {optCommand = CmdStoreDelete paths}
+    goStoreDelete opts paths ("--store" : dir : rest) =
+      goStoreDelete (opts {optStore = Just dir}) paths rest
+    goStoreDelete _ _ [flag]
+      | flag `elem` valueFlags = Left (flag ++ " requires a value")
+    goStoreDelete _ _ (arg@('-' : _) : _) = Left ("unknown store delete flag: " ++ arg)
+    goStoreDelete opts paths (path : rest) =
+      goStoreDelete opts (paths ++ [path]) rest
     -- Flags that consume the following argument as their value.
     valueFlags =
       ["--nix-path", "--store", "--substituter", "--trusted-key", "--expr", "--cache", "--key-file"]
@@ -175,6 +191,7 @@ main = do
       | otherwise -> evalExpr (optStrict opts) (optNixPaths opts) dataDir expr
     CmdBuild filePath -> buildFile opts dataDir filePath
     CmdPush pushArgs -> pushCommand opts pushArgs
+    CmdStoreDelete paths -> storeDeleteCommand opts paths
     CmdHelp -> do
       hPutStrLn stderr "Usage: nova-nix [--nix-path NAME=PATH] <command>"
       hPutStrLn stderr ""
@@ -183,6 +200,7 @@ main = do
       hPutStrLn stderr "  eval --expr 'EXPR'     Evaluate an inline expression"
       hPutStrLn stderr "  build FILE.nix         Build a derivation from a .nix file"
       hPutStrLn stderr "  push --cache URL       Push store paths (and their closures) to a binary cache"
+      hPutStrLn stderr "  store delete PATH...   Remove store paths, refused while other valid paths reference them"
       hPutStrLn stderr ""
       hPutStrLn stderr "Flags:"
       hPutStrLn stderr "  --strict               Deep-force all thunks before printing (warning: OOM on large results)"
@@ -458,6 +476,32 @@ pushCommand opts pushArgs = do
                 <> T.pack (show (psSkipped summary))
                 <> " already cached"
             )
+
+-- | Delete store paths: registration rows and on-disk trees.  Paths are
+-- processed in argument order and the first failure stops the run, so a
+-- reference chain deletes leaf-first in one invocation.
+storeDeleteCommand :: CliOpts -> [String] -> IO ()
+storeDeleteCommand opts rawPaths = do
+  store <- openStore (chosenStoreDir opts)
+  result <- deleteEach store rawPaths
+  closeStore store
+  either failWith pure result
+  where
+    deleteEach _ [] = pure (Right ())
+    deleteEach store (raw : rest) =
+      case resolveDeleteTarget (stDir store) (T.pack raw) of
+        Left err -> pure (Left ("store delete: " <> err))
+        Right basename -> do
+          outcome <- deleteStorePathRaw store basename
+          case outcome of
+            Left err -> pure (Left ("store delete: " <> err))
+            Right removed -> do
+              TIO.putStrLn ("deleted " <> basename <> describeOutcome removed)
+              deleteEach store rest
+    describeOutcome removed
+      | doRowRemoved removed && doTreeRemoved removed = ""
+      | doRowRemoved removed = " (no tree on disk)"
+      | otherwise = " (unregistered tree)"
 
 -- | Resolve push roots: every valid path with @--all@, otherwise each named
 -- path.  Named paths may be full store paths in either store-dir form, or a

--- a/nova-nix.cabal
+++ b/nova-nix.cabal
@@ -180,6 +180,7 @@ test-suite nova-nix-test
     , nova-cache          >= 0.6 && < 0.7
     , nova-nix
     , process             >= 1.6 && < 1.7
+    , sqlite-simple       >= 0.4 && < 0.5
     , tar                 >= 0.7.1 && < 0.8
     , text                >= 2.0 && < 2.2
     , zstd                >= 0.1 && < 0.2

--- a/src/Nix/Store.hs
+++ b/src/Nix/Store.hs
@@ -40,6 +40,11 @@ module Nix.Store
     isValid,
     pathExists,
 
+    -- * Deletion
+    DeleteOutcome (..),
+    deleteStorePathRaw,
+    resolveDeleteTarget,
+
     -- * Store operations
     addToStore,
     copyPathInto,
@@ -127,6 +132,85 @@ isValid = isValidPath . stDB
 -- | Check if a store path exists on disk (file or directory, regardless of DB).
 pathExists :: Store -> StorePath -> IO Bool
 pathExists store sp = doesPathExist (storePathToFilePath (stDir store) sp)
+
+-- ---------------------------------------------------------------------------
+-- Deletion
+-- ---------------------------------------------------------------------------
+
+-- | What 'deleteStorePathRaw' removed.
+data DeleteOutcome = DeleteOutcome
+  { -- | A ValidPaths row (with its outgoing reference edges) was removed.
+    doRowRemoved :: !Bool,
+    -- | An on-disk tree was removed.
+    doTreeRemoved :: !Bool
+  }
+  deriving (Eq, Show)
+
+-- | Resolve a @store delete@ argument to the basename it names: a bare
+-- @hash-name@ basename, or a full path spelled under the opened store's
+-- directory, the platform store, or the canonical store.  The basename is
+-- NOT validated as a store path - the entries deletion exists to remove
+-- are the ones current name rules reject - so only traversal shapes are
+-- refused: separators (excluded by construction), dot-leading names (the
+-- store's metadata directory lives at a dot name), and colons (an NTFS
+-- alternate-data-stream spelling).
+resolveDeleteTarget :: StoreDir -> Text -> Either Text Text
+resolveDeleteTarget storeDir raw
+  | T.null basename = Left (raw <> ": empty store path name")
+  | T.isPrefixOf "." basename =
+      Left (basename <> ": dot-leading names are not store paths")
+  | T.any (== ':') basename =
+      Left (basename <> ": ':' is not valid in a store path name")
+  | not dirOk = Left (raw <> ": not a path under this store")
+  | otherwise = Right basename
+  where
+    basename = T.takeWhileEnd (\c -> c /= '/' && c /= '\\') raw
+    dirPart =
+      normalizeSeps
+        (T.dropWhileEnd (\c -> c == '/' || c == '\\') (T.dropEnd (T.length basename) raw))
+    dirOk =
+      T.null dirPart
+        || dirPart
+          `elem` [ normalizeSeps (T.pack (unStoreDir storeDir)),
+                   normalizeSeps (T.pack (unStoreDir platformStoreDir)),
+                   normalizeSeps (T.pack (unStoreDir defaultStoreDir))
+                 ]
+    normalizeSeps = T.map (\c -> if c == '\\' then '/' else c)
+
+-- | Delete one store entry by basename: the registration row (refused
+-- while other valid paths reference it) and the on-disk tree.  Row first,
+-- tree second: an orphan tree left by a failed removal is inert debris,
+-- while a still-registered row whose tree is gone would be adopted as
+-- valid by existence checks.  A row without a tree and a tree without a
+-- row both delete (the repair cases); only a target with neither is an
+-- error.
+deleteStorePathRaw :: Store -> Text -> IO (Either Text DeleteOutcome)
+deleteStorePathRaw store basename = do
+  let target = unStoreDir (stDir store) </> T.unpack basename
+  rowResult <- unregisterPathRow (stDB store) (T.pack target)
+  case rowResult of
+    RowReferenced referrers ->
+      pure
+        ( Left
+            ( basename
+                <> " is referenced by:"
+                <> T.concat ["\n  " <> r | r <- referrers]
+            )
+        )
+    _ -> do
+      -- 'doesPathExist' follows links, so a dangling top-level symlink
+      -- would read as absent; links are leaves here (as in store walks),
+      -- and leftover link debris must still be removable.
+      treeExisted <- do
+        onDisk <- doesPathExist target
+        if onDisk
+          then pure True
+          else Dir.pathIsSymbolicLink target `catch` \(_ :: IOException) -> pure False
+      when treeExisted (Dir.removePathForcibly target)
+      let rowRemoved = rowResult == RowUnregistered
+      if rowRemoved || treeExisted
+        then pure (Right DeleteOutcome {doRowRemoved = rowRemoved, doTreeRemoved = treeExisted})
+        else pure (Left (basename <> ": not in this store (no registration row, no tree on disk)"))
 
 -- ---------------------------------------------------------------------------
 -- Store operations

--- a/src/Nix/Store/DB.hs
+++ b/src/Nix/Store/DB.hs
@@ -41,6 +41,10 @@ module Nix.Store.DB
     queryPathInfo,
     queryAllValidPaths,
 
+    -- * Unregistration
+    UnregisterResult (..),
+    unregisterPathRow,
+
     -- * Constants
     metaDirName,
     dbFileName,
@@ -280,6 +284,54 @@ queryDeriver db sp = do
   case rows of
     (Only deriver : _) -> pure deriver
     [] -> pure Nothing
+
+-- ---------------------------------------------------------------------------
+-- Unregistration
+-- ---------------------------------------------------------------------------
+
+-- | Outcome of 'unregisterPathRow'.
+data UnregisterResult
+  = -- | The row and its outgoing reference edges were removed.
+    RowUnregistered
+  | -- | No row carries this path text.
+    RowAbsent
+  | -- | Other valid paths still reference this one (their path texts,
+    -- sorted); nothing was changed.
+    RowReferenced ![Text]
+  deriving (Eq, Show)
+
+-- | Remove a path's ValidPaths row and outgoing Refs edges, keyed by the
+-- EXACT stored path text.  Deliberately not keyed by 'StorePath': the
+-- rows this exists to clean up include ones whose names the current
+-- validator rejects, and those cannot round-trip through a parse.
+--
+-- Refuses while any OTHER valid path references this one; a
+-- self-reference does not block.  Lookup, referrer check, and deletion
+-- run in one transaction, so a registration cannot interleave between
+-- the check and the delete.
+unregisterPathRow :: StoreDB -> Text -> IO UnregisterResult
+unregisterPathRow db pathText = withTransaction conn $ do
+  idRows <- query conn "SELECT id FROM ValidPaths WHERE path = ?" (Only pathText) :: IO [Only Int]
+  case idRows of
+    [] -> pure RowAbsent
+    (Only pathId : _) -> do
+      referrerRows <-
+        query
+          conn
+          "SELECT vp.path FROM Refs r \
+          \JOIN ValidPaths vp ON r.referrer = vp.id \
+          \WHERE r.reference = ? AND r.referrer != ? \
+          \ORDER BY vp.path"
+          (pathId, pathId) ::
+          IO [Only Text]
+      case [p | Only p <- referrerRows] of
+        referrers@(_ : _) -> pure (RowReferenced referrers)
+        [] -> do
+          execute conn "DELETE FROM Refs WHERE referrer = ?" (Only pathId)
+          execute conn "DELETE FROM ValidPaths WHERE id = ?" (Only pathId)
+          pure RowUnregistered
+  where
+    conn = sdbConn db
 
 -- | Query full path info for a registered store path.
 queryPathInfo :: StoreDB -> StorePath -> IO (Maybe PathInfo)

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -22,6 +22,7 @@ import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import Data.Text.Encoding.Error (lenientDecode)
 import qualified Data.Text.IO as TIO
+import qualified Database.SQLite.Simple as SQL
 import Foreign.Ptr (castPtr)
 import Foreign.StablePtr (StablePtr, castPtrToStablePtr, castStablePtrToPtr, deRefStablePtr, freeStablePtr, newStablePtr)
 import qualified Network.HTTP.Client as HTTP
@@ -48,9 +49,9 @@ import qualified Nix.Hash as Hash
 import Nix.Parser (parseNix)
 import Nix.Parser.Lexer (Located (..), Token (..), tokenize)
 import Nix.Push (checkRecordedNarHash, computeClosure, loadApiKeyFile, mkNarInfo, narFileName, planMissing, storePathBasename, stripHashPrefix)
-import Nix.Store (Store (..), addToStore, caseHackDiskNames, closeStore, copyPathInto, isSafeNarName, isValid, materializeEvalSources, openStore, orderLinks, pathExists, scanReferences, scanTempReferences, setReadOnly, writeDrv, writeDrvClosure)
+import Nix.Store (DeleteOutcome (..), Store (..), addToStore, caseHackDiskNames, closeStore, copyPathInto, deleteStorePathRaw, isSafeNarName, isValid, materializeEvalSources, openStore, orderLinks, pathExists, resolveDeleteTarget, scanReferences, scanTempReferences, setReadOnly, writeDrv, writeDrvClosure)
 import Nix.Store.CaseSensitive (trySetCaseSensitiveDir)
-import Nix.Store.DB (PathInfo (..), PathRegistration (..), closeStoreDB, isValidPath, openStoreDB, queryDeriver, queryPathInfo, queryReferences, registerPath, registerPaths)
+import Nix.Store.DB (PathInfo (..), PathRegistration (..), closeStoreDB, dbFileName, isValidPath, metaDirName, openStoreDB, queryAllValidPaths, queryDeriver, queryPathInfo, queryReferences, registerPath, registerPaths)
 import Nix.Store.Path (StoreDir (..), StorePath (..), defaultStoreDir, defaultStoreDirText, isCanonicalStoreText, parseStorePath, platformStoreDir, platformStoreDirText, storePathToFilePath, storePathToText, storeTextToFilePath, windowsStoreDir)
 import qualified Nix.Substituter as Subst
 import qualified NovaCache.Base64 as B64
@@ -5212,6 +5213,136 @@ testNarKnownAnswer = do
           Nothing -> Fail "path not registered"
     ]
 
+-- | store delete: row-and-tree removal with referrer refusal.  The raw
+-- basename channel exists for rows the current name rules reject; the
+-- legacy-row case plants one over SQL exactly as a pre-name-rules store
+-- carries it.
+testStoreDelete :: IO [Bool]
+testStoreDelete = do
+  putStrLn "store/delete"
+  withTempStore $ \store -> do
+    let sd = stDir store
+        basenameOf sp = spHash sp <> "-" <> spName sp
+        dep = StorePath (T.replicate 32 "a") "del-dep"
+        user = StorePath (T.replicate 32 "b") "del-user"
+    sequence
+      [ runTestM "referenced path is refused with its referrers listed" $ do
+          registerPaths
+            (stDB store)
+            [ PathRegistration dep "sha256:d" 1 Nothing [],
+              PathRegistration user "sha256:u" 1 Nothing [dep]
+            ]
+          outcome <- deleteStorePathRaw store (basenameOf dep)
+          stillValid <- isValid store dep
+          pure $ case outcome of
+            Left err
+              | "referenced by" `T.isInfixOf` err,
+                T.pack (storePathToFilePath sd user) `T.isInfixOf` err,
+                stillValid ->
+                  Pass
+              | otherwise -> Fail ("wrong refusal: " <> err)
+            Right removed -> Fail ("deleted a referenced path: " <> T.pack (show removed)),
+        runTestM "a reference chain deletes leaf-first" $ do
+          userGone <- deleteStorePathRaw store (basenameOf user)
+          depGone <- deleteStorePathRaw store (basenameOf dep)
+          depValid <- isValid store dep
+          userValid <- isValid store user
+          pure $ case (userGone, depGone) of
+            (Right _, Right _)
+              | not depValid && not userValid -> Pass
+              | otherwise -> Fail "rows survived deletion"
+            other -> Fail ("chain deletion failed: " <> T.pack (show other)),
+        runTestM "a registered row without a tree deletes (repair case)" $ do
+          let ghost = StorePath (T.replicate 32 "c") "del-ghost"
+          registerPath (stDB store) (PathRegistration ghost "sha256:g" 1 Nothing [])
+          outcome <- deleteStorePathRaw store (basenameOf ghost)
+          pure $ case outcome of
+            Right removed
+              | doRowRemoved removed && not (doTreeRemoved removed) -> Pass
+              | otherwise -> Fail ("wrong outcome: " <> T.pack (show removed))
+            Left err -> Fail err,
+        runTestM "an unregistered tree deletes (repair case)" $ do
+          let strayBase = T.replicate 32 "d" <> "-del-stray"
+              treePath = unStoreDir sd </> T.unpack strayBase
+          createDirectoryIfMissing True treePath
+          TIO.writeFile (treePath </> "junk.txt") "stray"
+          outcome <- deleteStorePathRaw store strayBase
+          gone <- not <$> Dir.doesPathExist treePath
+          pure $ case outcome of
+            Right removed
+              | not (doRowRemoved removed), doTreeRemoved removed, gone -> Pass
+              | otherwise -> Fail ("wrong outcome: " <> T.pack (show removed))
+            Left err -> Fail err,
+        runTestM "a read-only registered tree deletes fully" $ do
+          let solid = StorePath (T.replicate 32 "e") "del-solid"
+              treePath = storePathToFilePath sd solid
+          registerPath (stDB store) (PathRegistration solid "sha256:s" 1 Nothing [])
+          createDirectoryIfMissing True treePath
+          TIO.writeFile (treePath </> "data.txt") "content"
+          setReadOnly treePath
+          outcome <- deleteStorePathRaw store (basenameOf solid)
+          gone <- not <$> Dir.doesPathExist treePath
+          stillValid <- isValid store solid
+          pure $ case outcome of
+            Right removed
+              | doRowRemoved removed, doTreeRemoved removed, gone, not stillValid -> Pass
+              | otherwise -> Fail ("wrong outcome: " <> T.pack (show removed))
+            Left err -> Fail err,
+        runTestM "a self-referencing path deletes" $ do
+          let selfp = StorePath (T.replicate 32 "f") "del-self"
+          registerPath (stDB store) (PathRegistration selfp "sha256:f" 1 Nothing [selfp])
+          outcome <- deleteStorePathRaw store (basenameOf selfp)
+          pure (assertEqual "self delete" (Right (DeleteOutcome True False)) outcome),
+        runTestM "a target with neither row nor tree is an error" $ do
+          outcome <- deleteStorePathRaw store (T.replicate 32 "9" <> "-del-nothing")
+          pure $ case outcome of
+            Left err | "not in this store" `T.isInfixOf` err -> Pass
+            other -> Fail ("expected not-in-store, got: " <> T.pack (show other)),
+        runTestM "a legacy row the validator rejects deletes by raw text" $ do
+          let legacyBase = T.replicate 32 "g" <> "-old~marker"
+              treePath = unStoreDir sd </> T.unpack legacyBase
+              legacyPathText = T.pack treePath
+          conn <- SQL.open (unStoreDir sd </> metaDirName </> dbFileName)
+          SQL.execute
+            conn
+            "INSERT INTO ValidPaths (path, hash, registrationTime, deriver, narSize) VALUES (?, ?, 0, NULL, 0)"
+            (legacyPathText, "sha256:legacy" :: T.Text)
+          SQL.close conn
+          createDirectoryIfMissing True treePath
+          TIO.writeFile (treePath </> "seed.txt") "epoch"
+          let resolved = resolveDeleteTarget sd legacyPathText
+          outcome <- either (pure . Left) (deleteStorePathRaw store) resolved
+          remaining <- queryAllValidPaths (stDB store)
+          gone <- not <$> Dir.doesPathExist treePath
+          pure $ case outcome of
+            Right removed
+              | doRowRemoved removed, doTreeRemoved removed, gone, legacyPathText `notElem` remaining -> Pass
+              | otherwise -> Fail ("wrong outcome: " <> T.pack (show removed))
+            Left err -> Fail err,
+        runTest "resolveDeleteTarget accepts bare, store-dir, platform, and canonical spellings" $
+          let nameBase = T.replicate 32 "h" <> "-name"
+              spellings =
+                [ nameBase,
+                  T.pack (unStoreDir sd </> T.unpack nameBase),
+                  T.pack (unStoreDir platformStoreDir) <> "\\" <> nameBase,
+                  defaultStoreDirText <> "/" <> nameBase
+                ]
+           in assertEqual "all resolve" (replicate 4 (Right nameBase)) (map (resolveDeleteTarget sd) spellings),
+        runTest "resolveDeleteTarget refuses traversal shapes" $
+          let refused =
+                [ ".nova-nix",
+                  "..",
+                  ".",
+                  "",
+                  T.pack (unStoreDir sd) <> "/",
+                  "/somewhere/else/" <> T.replicate 32 "h" <> "-name",
+                  T.replicate 32 "h" <> "-na:me"
+                ]
+           in case [t | t <- refused, either (const False) (const True) (resolveDeleteTarget sd t)] of
+                [] -> Pass
+                accepted -> Fail ("accepted: " <> T.pack (show accepted))
+      ]
+
 testStoreOps :: IO [Bool]
 testStoreOps = do
   putStrLn "store/ops"
@@ -8181,6 +8312,7 @@ main = bracket_ arenaInit arenaDestroy $ do
           testStoreDB,
           testParseStorePath,
           testStoreOps,
+          testStoreDelete,
           testSymlinkWalksIO,
           testLinkOrdering,
           testFromATerm,


### PR DESCRIPTION
Adds the first store maintenance verb: `store delete PATH...` removes a
path's registration row and on-disk tree, refusing while any other valid
path references it. Full GC (roots, reachability, sweep) stays #24.

**Raw-text targeting.** The command's motivating targets are rows the
current name rules reject (pre-name-charset stores carry '~'-named seed
paths that fail parseStorePath, breaking `push --all`), so the argument
is resolved to a basename and matched against the DB by exact text, never
through the store-path parser. The only argument validation is traversal
shape: separators, dot-leading names (the store's metadata directory is a
dot name), and colons (an NTFS alternate-data-stream spelling) are
refused. Bare basenames and full paths under the opened, platform, or
canonical store dir all resolve.

**Semantics.** Row and outgoing reference edges delete in one
transaction; the referrer check (self-references excluded) runs inside
it, so a concurrent registration cannot interleave. Row first, tree
second: an orphan tree left by a failed removal is inert, while a
still-registered row without its tree would be adopted as valid by
existence checks. A row without a tree and a tree without a row both
delete (the repair cases); only a target with neither is an error.
Multiple paths process in argument order and stop at the first failure,
so a reference chain deletes leaf-first in one invocation.

Coverage: referrer refusal with listing, leaf-first chain, both repair
cases, read-only tree removal, self-reference, not-found, resolver
accept/refuse tables, and the motivating case end to end - a '~'-named
legacy row planted over SQL and deleted by raw text (the test suite
gains sqlite-simple, matching the library bound, to plant it).

Verified: -Werror build clean, 1099/1099 tests pass (10 new), ormolu and
hlint clean, plus a CLI smoke against a scratch store (not-found errors
with exit 1; a full-path target deletes with exit 0).

Closes #23.
