### PR TITLE
Store: NAR names as raw bytes - nova-cache 0.7 and the write-boundary decode

### DIFF
--- a/nova-nix.cabal
+++ b/nova-nix.cabal
@@ -100,7 +100,7 @@ library
     , http-types          >= 0.12 && < 0.13
     , ram                 >= 0.20 && < 1
     , mtl                 >= 2.2 && < 2.4
-    , nova-cache          >= 0.6 && < 0.7
+    , nova-cache          >= 0.7 && < 0.8
     , process             >= 1.6 && < 1.7
     , regex-tdfa          >= 1.3 && < 1.4
     , sqlite-simple       >= 0.4 && < 0.5
@@ -177,7 +177,7 @@ test-suite nova-nix-test
     , directory           >= 1.3 && < 1.4
     , filepath            >= 1.4 && < 1.6
     , http-client         >= 0.7 && < 0.8
-    , nova-cache          >= 0.6 && < 0.7
+    , nova-cache          >= 0.7 && < 0.8
     , nova-nix
     , process             >= 1.6 && < 1.7
     , sqlite-simple       >= 0.4 && < 0.5

--- a/src/Nix/Eval.hs
+++ b/src/Nix/Eval.hs
@@ -4906,7 +4906,7 @@ filteredSourceNar filterFn rootPath = do
         executable <- isExecutableFile path
         bytes <- readFileBytes path
         pure (NAR.NarRegular executable bytes)
-      "symlink" -> NAR.NarSymlink <$> readSymlinkTarget path
+      "symlink" -> NAR.NarSymlink . TE.encodeUtf8 <$> readSymlinkTarget path
       "directory" -> do
         children <- listDirectory path
         kept <- mapM (keepChild path) children
@@ -4916,7 +4916,7 @@ filteredSourceNar filterFn rootPath = do
       let childPath = parent <> "/" <> name
       keep <- filterAccepts childPath childType
       if keep
-        then Just . (,) name <$> buildEntry childPath childType
+        then Just . (,) (TE.encodeUtf8 name) <$> buildEntry childPath childType
         else pure Nothing
     filterAccepts path fileType = do
       partial <- applyValue filterFn (mkStr path)

--- a/src/Nix/Store.hs
+++ b/src/Nix/Store.hs
@@ -504,7 +504,9 @@ unpackTree path entry = case entry of
       perms <- Dir.getPermissions path
       setPermissions path (Dir.setOwnerExecutable True perms)
     pure (Right [])
-  NAR.NarSymlink target -> pure (Right [(path, target)])
+  NAR.NarSymlink target -> pure $ case decodeNarText "symlink target" target of
+    Left err -> Left err
+    Right decoded -> Right [(path, decoded)]
   NAR.NarDirectory entries -> do
     createDirectoryIfMissing True path
     unpackChildren path entries
@@ -544,6 +546,24 @@ firstNameCollision = go Map.empty
 platformStripsCaseHack :: Bool
 platformStripsCaseHack = NAR.defaultCaseHack == NAR.CaseHackEnabled
 
+-- | 'NAR.caseHackSuffix' as Text for the name machinery here, which
+-- runs on decoded names ('decodeNarText').  The suffix is ASCII, so
+-- the latin1 read is exact.
+caseHackSuffixText :: Text
+caseHackSuffixText = TE.decodeLatin1 NAR.caseHackSuffix
+
+-- | Decode a NAR-carried byte string that must become a filesystem
+-- name.  The NAR format carries entry names and symlink targets as
+-- raw bytes and the parser accepts them; the store's invariant is
+-- stricter - every materialized name exists identically on every
+-- platform the store targets, and NTFS names are UTF-16 - so bytes
+-- with no Unicode reading are refused at the write boundary rather
+-- than approximated.
+decodeNarText :: Text -> BS.ByteString -> Either Text Text
+decodeNarText what bytes = case TE.decodeUtf8' bytes of
+  Right decoded -> Right decoded
+  Left _ -> Left ("NAR " <> what <> " is not valid UTF-8: " <> T.pack (show bytes))
+
 -- | Disk names for a sibling list on a folding filesystem WITHOUT
 -- per-directory case sensitivity: upstream's case-hack.  The first
 -- occurrence of each folded name keeps its spelling; every later
@@ -559,11 +579,27 @@ caseHackDiskNames = reverse . snd . foldl' step (Map.empty, [])
             Nothing -> (Map.insert key (0 :: Int) seen, (name, name) : acc)
             Just occurrences ->
               let next = occurrences + 1
-                  disk = name <> NAR.caseHackSuffix <> T.pack (show next)
+                  disk = name <> caseHackSuffixText <> T.pack (show next)
                in (Map.insert key next seen, (name, disk) : acc)
 
--- | Unpack directory children, short-circuiting with a typed failure on the
--- first unsafe entry name rather than crashing on untrusted input.
+-- | Unpack directory children.  Entry names arrive as the raw bytes
+-- the NAR carries; the store's invariant is that every materialized
+-- name is valid Unicode - a name every platform the store targets can
+-- hold - so each name is decoded here at the write boundary, and a
+-- byte name with no Unicode reading refuses the unpack
+-- ('decodeNarText') rather than approximating a spelling.
+unpackChildren :: FilePath -> [(BS.ByteString, NAR.NarEntry)] -> IO (Either Text [(FilePath, Text)])
+unpackChildren path rawEntries = case traverse decodeChild rawEntries of
+  Left err -> pure (Left err)
+  Right entries -> unpackNamedChildren path entries
+  where
+    decodeChild (nameBytes, child) = do
+      name <- decodeNarText "directory entry name" nameBytes
+      Right (name, child)
+
+-- | Unpack decoded directory children, short-circuiting with a typed
+-- failure on the first unsafe entry name rather than crashing on
+-- untrusted input.
 --
 -- Sibling names folding to one on-disk name (NTFS, default APFS) take
 -- the TRUE-NAME path when the platform provides one: the just-created
@@ -573,8 +609,8 @@ caseHackDiskNames = reverse . snd . foldl' step (Map.empty, [])
 -- back to upstream's case-hack renaming, which the platform serialiser
 -- reverses.  Either way a registered path re-serialises to its NAR
 -- byte-for-byte - the substituter's on-disk recheck verifies it.
-unpackChildren :: FilePath -> [(Text, NAR.NarEntry)] -> IO (Either Text [(FilePath, Text)])
-unpackChildren path entries = do
+unpackNamedChildren :: FilePath -> [(Text, NAR.NarEntry)] -> IO (Either Text [(FilePath, Text)])
+unpackNamedChildren path entries = do
   diskNames <- resolveDiskNames
   walkChildren (zip diskNames entries)
   where
@@ -592,7 +628,7 @@ unpackChildren path entries = do
     walkChildren ((diskName, (name, child)) : rest)
       | not (isSafeNarName name) =
           pure (Left ("unsafe NAR directory entry name: " <> name))
-      | platformStripsCaseHack && NAR.caseHackSuffix `T.isInfixOf` name =
+      | platformStripsCaseHack && caseHackSuffixText `T.isInfixOf` name =
           pure (Left ("NAR entry name contains the case-hack suffix: " <> name))
       | otherwise = do
           result <- unpackTree (path </> T.unpack diskName) child

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -3157,6 +3157,28 @@ testSubstituter = do
           if all (\case Left _ -> True; Right () -> False) results
             then Pass
             else Fail ("accepted an unsafe name: " <> T.pack (show results)),
+      -- unpackNarEntry: names and targets arrive as the raw bytes the
+      -- wire carries; the store materializes only valid-Unicode names,
+      -- so a byte name with no Unicode reading refuses the unpack
+      -- before anything is written
+      runTestM "unpackNarEntry refuses a non-UTF-8 entry name" $ do
+        tmpBase <- getTemporaryDirectory
+        let dest = tmpBase </> "nova-nix-test-unpack-rawname"
+            tree = NAR.NarDirectory [(BS.pack [0xFF], NAR.NarRegular False "x")]
+        result <- Subst.unpackNarEntry dest tree
+        Subst.clearStaleDestination dest
+        pure $ case result of
+          Left err -> if "not valid UTF-8" `T.isInfixOf` err then Pass else Fail ("wrong error: " <> err)
+          Right () -> Fail "accepted a non-UTF-8 entry name",
+      runTestM "unpackNarEntry refuses a non-UTF-8 symlink target" $ do
+        tmpBase <- getTemporaryDirectory
+        let dest = tmpBase </> "nova-nix-test-unpack-rawtarget"
+            tree = NAR.NarDirectory [("link", NAR.NarSymlink (BS.pack [0xFF]))]
+        result <- Subst.unpackNarEntry dest tree
+        Subst.clearStaleDestination dest
+        pure $ case result of
+          Left err -> if "not valid UTF-8" `T.isInfixOf` err then Pass else Fail ("wrong error: " <> err)
+          Right () -> Fail "accepted a non-UTF-8 symlink target",
       -- unpackNarEntry: a NAR symlink materializes as a REAL link or fails
       -- loudly - never as a regular file holding the target text, which
       -- would silently diverge from the signed NAR hash


### PR DESCRIPTION
## What and why

nova-cache 0.7.0.0 carries NAR entry names and symlink targets as raw byte strings, as upstream does; the parser no longer rejects a non-UTF-8 name, so those bytes now reach the store. The store's invariant is unchanged: every materialized name is valid Unicode - a name every platform the store targets can hold - so the decode moves to the write boundary. `decodeNarText` decodes each directory entry name and symlink target at unpack, and bytes with no Unicode reading refuse the unpack with a typed error before anything is written.

The name machinery (`isSafeNarName`, case-hack renaming, collision detection, link ordering) is unchanged and stays `Text`-based: under the invariant, every policy-passed name is decoded text. `caseHackSuffix`'s `Text` form is derived once from the library constant (a total latin1 read of the ASCII suffix). NAR building from the filesystem (`builtins.path` / `filterSource`) encodes its Unicode names to UTF-8 at the two construction sites.

Bounds move to `nova-cache >= 0.7 && < 0.8`, built against the published Hackage release.

## Tests and measurement

Two new refusal tests (non-UTF-8 entry name, non-UTF-8 symlink target); the rest of the suite is unchanged and green. Benchmarked before and after on the profiling harness: allocation and residency identical to the byte, timing differences within run-to-run noise.
