### PR TITLE
Eval: separator-aware path builtins, appendContext and storePath validation

### DIFF
--- a/src/Nix/Eval.hs
+++ b/src/Nix/Eval.hs
@@ -98,7 +98,7 @@ import Nix.Eval.CBytecode (cbcArg1, cbcArg2, cbcArg3, cbcCountedPayload, cbcData
 import Nix.Eval.CEnv (cenvPushWith)
 import Nix.Eval.CList (CList (..), clistGet)
 import Nix.Eval.CThunk (CThunkPtr)
-import Nix.Eval.CanonPath (canonPath)
+import Nix.Eval.CanonPath (canonBaseName, canonDirName, canonPath)
 import Nix.Eval.Compile (BcAttrKey (..), BcBinding (..), compileExpr, decodeBcBindings, decodeBcCaptureInfo, decodeBcFormals, reassembleDouble, reassembleInt64)
 import Nix.Eval.Context (extractAllOutputRefs, extractInputDrvs, extractInputSrcs, plainContext)
 import Nix.Eval.Operator (checkedAdd, checkedMul, checkedSub, evalBinary, evalUnary, nixCompare, nixEqual)
@@ -169,7 +169,7 @@ import Nix.Expr.Types
     UnaryOp (..),
   )
 import Nix.Hash (base64HashLen, bytesToHexText, hashAlgoBytes, hashPlaceholder, hexHashLen, hexToBytes, makeFixedOutputPath, makeOutputPath, makeTextPath, nix32HashLen, sha256Digest, sha256Hex)
-import Nix.Store.Path (StorePath (..), StorePathNameError (..), checkStorePathName, defaultStoreDir, defaultStoreDirText, parseStorePath, storePathNameErrorText, storePathNameReasonText, storePathToText)
+import Nix.Store.Path (StorePath (..), StorePathNameError (..), checkStorePathName, defaultStoreDir, defaultStoreDirText, parseStorePath, parseStorePathBaseName, storePathNameErrorText, storePathNameReasonText, storePathToText)
 import qualified NovaCache.Base32 as Nix32
 import qualified NovaCache.Base64 as B64
 import qualified NovaCache.NAR as NAR
@@ -2252,9 +2252,13 @@ parseContextAttrs attrs = do
       val <- force thunk
       case val of
         VAttrs inner -> do
-          let sp = case parseStorePath defaultStoreDir pathText of
-                Just parsed -> parsed
-                Nothing -> StorePath (T.take 32 (T.drop (T.length storeDirPrefix) pathText)) (T.drop 33 (T.drop (T.length storeDirPrefix) pathText))
+          -- The key must parse as a store path, as upstream requires; a
+          -- fabricated identity here would flow into derivation inputs.
+          sp <- case parseStorePath defaultStoreDir pathText of
+            Just parsed -> pure parsed
+            Nothing ->
+              throwEvalError
+                ("builtins.appendContext: context key is not a store path: " <> pathText)
           hasPath <- getBoolAttr "path" inner
           hasAllOuts <- getBoolAttr "allOutputs" inner
           outNames <- getOutputsList inner
@@ -2286,41 +2290,34 @@ parseContextAttrs attrs = do
         VStr s _ -> decodedText "builtins.appendContext" s
         _ -> throwEvalError "builtins.appendContext: output name must be a string"
 
+-- | For a STRING operand, upstream's rule is textual: everything after
+-- the final @/@.  For a PATH operand the value may be native-spelled
+-- (eval's base dir can be a native Windows path), so the split is
+-- separator-aware via 'canonBaseName'.
 builtinBaseNameOf :: (MonadEval m) => NixValue -> m NixValue
 builtinBaseNameOf (VStr s ctx) = pure (VStr (lastComponentBytes s) ctx)
-builtinBaseNameOf (VPath p) = pure (mkStr (lastComponent p))
+builtinBaseNameOf (VPath p) = pure (mkStr (canonBaseName p))
 builtinBaseNameOf other =
   throwEvalError ("builtins.baseNameOf: expected a string or path, got " <> typeName other)
 
-lastComponent :: Text -> Text
-lastComponent t = case reverse (filter (not . T.null) (T.splitOn "/" t)) of
-  [] -> ""
-  (final : _) -> final
-
--- | Byte-level 'lastComponent' for string operands ('/' is a single byte
+-- | Byte-level last component for string operands ('/' is a single byte
 -- in UTF-8 and never occurs inside a multi-byte sequence).
 lastComponentBytes :: BS.ByteString -> BS.ByteString
 lastComponentBytes t = case reverse (filter (not . BS.null) (BC.split '/' t)) of
   [] -> ""
   (final : _) -> final
 
+-- | String operands keep upstream's textual '/'-only rule
+-- ('dirComponentBytes'); path operands may be native-spelled and split
+-- separator-aware via 'canonDirName'.
 builtinDirOf :: (MonadEval m) => NixValue -> m NixValue
 builtinDirOf (VStr s ctx) = pure (VStr (dirComponentBytes s) ctx)
-builtinDirOf (VPath p) = pure (VPath (dirComponent p))
+builtinDirOf (VPath p) = pure (VPath (canonDirName p))
 builtinDirOf other =
   throwEvalError ("builtins.dirOf: expected a string or path, got " <> typeName other)
 
-dirComponent :: Text -> Text
-dirComponent t =
-  case T.findIndex (== '/') (T.reverse t) of
-    Nothing -> "."
-    Just n ->
-      let dir = T.take (T.length t - n - 1) t
-       in -- A leading or sole '/' leaves an empty prefix; Nix's dirOf yields "/".
-          if T.null dir then "/" else dir
-
--- | Byte-level 'dirComponent' for string operands: everything before the
--- last '/' byte, with the same "." / "/" edge results.
+-- | Byte-level dir component for string operands: everything before the
+-- last '/' byte, with upstream's "." / "/" edge results.
 dirComponentBytes :: BS.ByteString -> BS.ByteString
 dirComponentBytes t =
   case BC.elemIndexEnd '/' t of
@@ -3255,16 +3252,12 @@ validateStorePath p = case enclosingStorePath p of
 -- 'Nothing' if the path is not in the store.  Accepts a bare store path and a
 -- subpath (@\/nix\/store\/\<hash\>-\<name\>\/sub@ resolves to its
 -- @\<hash\>-\<name\>@ component), the way upstream marks the enclosing store
--- path Opaque for either.
+-- path Opaque for either.  The component passes the same charset
+-- validation as every other store-path parse boundary.
 enclosingStorePath :: Text -> Maybe StorePath
 enclosingStorePath p = do
   rest <- T.stripPrefix storeDirPrefix p
-  let component = T.takeWhile (/= '/') rest
-      (hash, hyphenName) = T.splitAt 32 component
-  (hyphen, name) <- T.uncons hyphenName
-  if hyphen == '-' && not (T.null name) && T.length hash == 32
-    then Just (StorePath hash name)
-    else Nothing
+  parseStorePathBaseName (T.takeWhile (/= '/') rest)
 
 -- ---------------------------------------------------------------------------
 -- Builtin implementations - Nix search path

--- a/src/Nix/Eval/CanonPath.hs
+++ b/src/Nix/Eval/CanonPath.hs
@@ -21,6 +21,7 @@
 module Nix.Eval.CanonPath
   ( canonPath,
     canonBaseName,
+    canonDirName,
   )
 where
 
@@ -88,3 +89,16 @@ splitOnSeparators = T.split isPathSeparator
 -- trailing separator, which the caller treats as "no base name".
 canonBaseName :: Text -> Text
 canonBaseName = T.takeWhileEnd (not . isPathSeparator)
+
+-- | Parent of a path VALUE - upstream @dirOf@ on paths.  Splits on the
+-- platform's separators like 'canonBaseName', because path values may
+-- be native-spelled; the textual '/'-only rule for STRING operands
+-- lives with its builtin.  A sole leading separator is its own parent
+-- (@dirOf \/foo@ is @\/@, and a drive root @C:\\foo@ keeps its rooted
+-- @C:\\@); a separatorless path has parent @.@.
+canonDirName :: Text -> Text
+canonDirName t = case T.dropWhileEnd (not . isPathSeparator) t of
+  "" -> "."
+  prefix ->
+    let dir = T.dropWhileEnd isPathSeparator prefix
+     in if T.null dir || fst (splitDriveLetter dir) == dir then prefix else dir

--- a/src/Nix/Eval/IO.hs
+++ b/src/Nix/Eval/IO.hs
@@ -425,8 +425,11 @@ instance MonadEval EvalIO where
     baseDir <- EvalIO (asks esBaseDir)
     -- ~/x resolves against the home directory (upstream lexes HPATH and
     -- expands it at eval); everything else relative joins the base dir.
-    -- Both end in lexical canonicalization, so no dot segment, repeated
-    -- separator, or platform backslash survives into the path value.
+    -- Both end in lexical canonicalization: no dot segment or repeated
+    -- separator survives into the path value.  Native separators are
+    -- PRESERVED (CanonPath's style rule), so a native base dir yields a
+    -- native-spelled value - path-value consumers split separator-aware
+    -- ('canonBaseName' \/ 'canonDirName'), never on '/' alone.
     expanded <- case T.stripPrefix "~/" path of
       Just below -> do
         home <- wrapIO Dir.getHomeDirectory

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1488,6 +1488,55 @@ testBatch1 = do
         assertEval "dirOf-flat" "builtins.dirOf \"filename\"" (mkStr "."),
       runTest "dirOf root-level path" $
         assertEval "dirOf-root" "builtins.dirOf \"/foo\"" (mkStr "/"),
+      -- Path VALUES arrive native-spelled when eval's base dir is a
+      -- native path (the CLI case); the path-operand splits must be
+      -- separator-aware.  The forward-slash tests above use a '/'
+      -- base and cannot see this.
+      runTestM "baseNameOf on a native-based path value" $ do
+        cwd <- Dir.getCurrentDirectory
+        result <- evalNixIO cwd "builtins.baseNameOf ./regression-name.nix"
+        pure $ case result of
+          Right v
+            | v == mkStr "regression-name.nix" -> Pass
+            | otherwise -> Fail ("wrong basename: " <> T.pack (show v))
+          Left err -> Fail ("eval failed: " <> T.pack (show err)),
+      runTestM "dirOf on a native-based path value" $ do
+        cwd <- Dir.getCurrentDirectory
+        dirResult <- evalNixIO cwd "builtins.dirOf ./sub/regression-name.nix"
+        parentResult <- evalNixIO cwd "./sub"
+        pure $
+          if dirResult == parentResult
+            then Pass
+            else
+              Fail
+                ( "dirOf mismatch: "
+                    <> T.pack (show dirResult)
+                    <> " vs "
+                    <> T.pack (show parentResult)
+                ),
+      -- appendContext: a key that is not a store path must refuse, as
+      -- upstream does - a fabricated identity would flow into
+      -- derivation inputs.
+      runTest "appendContext rejects a non-store-path key" $
+        assertEvalFail
+          "appendContext-badkey"
+          "builtins.appendContext \"x\" { \"not-a-store-path\" = { path = true; }; }",
+      runTest "appendContext accepts a store-path key" $
+        assertEval
+          "appendContext-ok"
+          "if (builtins.appendContext \"x\" { \"/nix/store/00000000000000000000000000000000-y\" = { path = true; }; }) == \"x\" then \"ok\" else \"no\""
+          (mkStr "ok"),
+      -- storePath: the hash component is charset-validated like every
+      -- other store-path parse boundary ('E' is outside nix-base32).
+      runTest "storePath rejects a non-base32 hash" $
+        assertEvalFail
+          "storePath-badhash"
+          "builtins.storePath \"/nix/store/EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE-x\"",
+      runTest "storePath accepts a valid store path" $
+        assertEval
+          "storePath-ok"
+          "if (builtins.storePath \"/nix/store/00000000000000000000000000000000-x\") == \"/nix/store/00000000000000000000000000000000-x\" then \"ok\" else \"no\""
+          (mkStr "ok"),
       runTest "dirOf root" $
         assertEval "dirOf-slash" "builtins.dirOf \"/\"" (mkStr "/"),
       -- concatLists


### PR DESCRIPTION
Three verified findings from the boundary-type audit (#85), each a live behavior fix with a regression test.

## baseNameOf / dirOf on path values

Path values may be native-spelled: eval's base dir can be a native Windows path, and lexical canonicalization preserves the separator style, so a path literal resolves to a backslashed value. Both builtins split path operands on `/` alone - `baseNameOf ./file` returned the entire path and `dirOf ./file` returned `.`. Path operands now split separator-aware through `CanonPath` (`canonBaseName`, new `canonDirName`, which also keeps a drive root rooted); string operands keep upstream's textual `/`-only rule, unchanged. The existing path tests could not see this: the test harness feeds a forward-slash base dir, so the new regression tests eval against the process's real working directory - native on Windows, `/` on POSIX, honest on both. The comment at the literal-resolution site claiming no platform backslash survives into path values was false and now states the real contract.

## appendContext key validation

When `parseStorePath` rejected a context key, a fallback fabricated a `StorePath` by blind slicing - on a key not under the store dir at all, `T.drop` of the prefix length shreds arbitrary text - and the garbage identity flowed into string context and from there into derivation inputs. The key now refuses with a typed eval error, as upstream does.

## storePath hash validation

`enclosingStorePath` (behind `builtins.storePath` and store-subpath coercion) accepted any 32-character component before a dash - no nix-base32 charset check, no name rules. It now validates through `parseStorePathBaseName`, the same gate as every other store-path parse boundary, which also removes a hand-rolled duplicate of the hash-length split.

## Measurement

Benchmarked before and after on the profiling harness: allocation identical to the byte, residency within 24 bytes, timing inside the established run-to-run noise band.

Part of #85.
