### PR TITLE
Store: an opaque StorePath, decoded hash comparison, drv output-name parsing

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -39,7 +39,7 @@ import Nix.Eval.Types (bytesToTextLossy, clistFromThunks, clistThunks, thunkToCP
 import Nix.Parser (parseNix, readFileAutoEncoding)
 import Nix.Push (PushConfig (..), PushSummary (..), loadApiKeyFile, pushPaths)
 import Nix.Store (DeleteOutcome (..), Store (..), closeStore, deleteStorePathRaw, materializeEvalSources, openStore, queryAllValidPaths, resolveDeleteTarget, writeDrv, writeDrvClosure)
-import Nix.Store.Path (StoreDir (..), StorePath (..), defaultStoreDir, parseStorePath, platformStoreDir, storePathHashLen, storePathToFilePath)
+import Nix.Store.Path (StoreDir (..), StorePath, defaultStoreDir, parseStorePath, parseStorePathBaseName, platformStoreDir, storePathToFilePath)
 import Nix.Substituter (CacheConfig (..))
 import Paths_nova_nix (getDataDir)
 import System.Directory (canonicalizePath, getCurrentDirectory, getTemporaryDirectory)
@@ -524,18 +524,13 @@ resolvePushRoots store pushArgs
             [ parseStorePath (stDir store) txt,
               parseStorePath platformStoreDir txt,
               parseStorePath defaultStoreDir txt,
-              parseBareBasename txt
+              -- A bare basename passes the same charset gate as every
+              -- other spelling: push targets are real store paths.
+              parseStorePathBaseName txt
             ]
        in case catMaybes attempts of
             (sp : _) -> Right sp
             [] -> Left ("not a store path: " <> txt)
-    parseBareBasename txt
-      | T.length txt >= storePathHashLen + 2,
-        (hashPart, rest) <- T.splitAt storePathHashLen txt,
-        Just ('-', name) <- T.uncons rest,
-        not (T.null name) =
-          Just (StorePath hashPart name)
-      | otherwise = Nothing
 
 -- | Print an error to stderr and exit.
 failWith :: T.Text -> IO a

--- a/nova-nix.cabal
+++ b/nova-nix.cabal
@@ -76,6 +76,7 @@ library
     Nix.Eval.Arena
     Nix.Store
     Nix.Store.Path
+    Nix.Store.Path.Internal
     Nix.Store.DB
     Nix.Store.CaseSensitive
     Nix.DependencyGraph

--- a/src/Nix/Builder.hs
+++ b/src/Nix/Builder.hs
@@ -69,7 +69,7 @@ import qualified Nix.DependencyGraph
 import Nix.Derivation (Derivation (..), DerivationOutput (..), fromATerm)
 import Nix.Hash (IncrementalHash, bytesToHexText, hashFinalizeBytes, hashInitWithAlgo, hashUpdateChunk, hexToBytes, rawHashWithAlgo)
 import Nix.Store (PathRegistration, Store (..), isValid, placeInStore, registerPaths, scanReferences, scanTempReferences)
-import Nix.Store.Path (StoreDir (..), StorePath (..), storePathToFilePath)
+import Nix.Store.Path (StoreDir (..), StorePath (spHash, spName), storePathToFilePath)
 import Nix.Substituter (CacheConfig, SubstResult (..), trySubstitute)
 import qualified NovaCache.NAR as NAR
 import System.Directory (createDirectoryIfMissing, doesDirectoryExist, doesPathExist, removeDirectoryRecursive, removePathForcibly)

--- a/src/Nix/Derivation.hs
+++ b/src/Nix/Derivation.hs
@@ -80,7 +80,7 @@ import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import Data.Text.Encoding.Error (lenientDecode)
-import Nix.Store.Path (StorePath (..))
+import Nix.Store.Path (StorePath)
 import qualified Nix.Store.Path as SP
 import qualified System.Info as SI
 
@@ -451,6 +451,10 @@ pSepBy pItem pSep = Parser $ \input ->
             Right (item, rest2) -> goMore rest2 (item : acc)
 
 -- | Parse a single output tuple: @(name, path, hashAlgo, hash)@.
+-- The output name is validated with the store-name rules at this parse
+-- boundary: it later becomes a filesystem component under the build
+-- dir and an environment variable name, and a @.drv@ read from disk
+-- is input, not trusted state.
 pOutput :: Parser DerivationOutput
 pOutput = do
   pChar '('
@@ -462,9 +466,11 @@ pOutput = do
   pChar ','
   hashVal <- pQuotedText
   pChar ')'
-  case parseStorePathFromATerm pathStr of
-    Just sp -> pure (DerivationOutput name sp hashAlgo hashVal)
-    Nothing -> parserFail ("invalid output store path: " <> pathStr)
+  case SP.checkStorePathName name of
+    Left err -> parserFail ("invalid output name: " <> SP.storePathNameErrorText err)
+    Right () -> case parseStorePathFromATerm pathStr of
+      Just sp -> pure (DerivationOutput name sp hashAlgo hashVal)
+      Nothing -> parserFail ("invalid output store path: " <> pathStr)
 
 -- | Parse a store path from an ATerm string.
 -- Tries defaultStoreDir first, then Windows store dir.

--- a/src/Nix/Eval.hs
+++ b/src/Nix/Eval.hs
@@ -169,7 +169,8 @@ import Nix.Expr.Types
     UnaryOp (..),
   )
 import Nix.Hash (base64HashLen, bytesToHexText, hashAlgoBytes, hashPlaceholder, hexHashLen, hexToBytes, makeFixedOutputPath, makeOutputPath, makeTextPath, nix32HashLen, sha256Digest, sha256Hex)
-import Nix.Store.Path (StorePath (..), StorePathNameError (..), checkStorePathName, defaultStoreDir, defaultStoreDirText, parseStorePath, parseStorePathBaseName, storePathNameErrorText, storePathNameReasonText, storePathToText)
+import Nix.Store.Path (StorePath (spName), StorePathNameError (..), checkStorePathName, defaultStoreDir, defaultStoreDirText, parseStorePath, parseStorePathBaseName, storePathNameErrorText, storePathNameReasonText, storePathToText)
+import Nix.Store.Path.Internal (maskedOutputPath)
 import qualified NovaCache.Base32 as Nix32
 import qualified NovaCache.Base64 as B64
 import qualified NovaCache.NAR as NAR
@@ -3806,7 +3807,7 @@ builtinDerivationStrict (VAttrs attrs) = do
             drvEnv = env
           }
       -- Output carrying only its name; the path is masked at render time.
-      maskedOutput name = DerivationOutput name (StorePath "" "") "" ""
+      maskedOutput name = DerivationOutput name maskedOutputPath "" ""
 
   -- Fixed-output derivations (fetchurl etc.) are content-addressed and hash
   -- via the @fixed:out:@ scheme; input-addressed derivations recurse through

--- a/src/Nix/Eval/Types.hs
+++ b/src/Nix/Eval/Types.hs
@@ -139,7 +139,8 @@ import Nix.Eval.Compile (compileExpr, compileFormalsToEval)
 import Nix.Eval.EvalFormals (EvalFormal (..), EvalFormals (..))
 import Nix.Eval.Symbol (Symbol (..), symbolBytes, symbolIntern, symbolInternBytes, symbolText)
 import Nix.Expr.Types (CaptureInfo (..), Expr (..), NixAtom (..))
-import Nix.Store.Path (StorePath (..), StorePathNameError, storePathNameErrorText)
+import Nix.Store.Path (StorePath, StorePathNameError, storePathNameErrorText)
+import Nix.Store.Path.Internal (StorePath (StorePath))
 import System.IO.Unsafe (unsafePerformIO)
 import qualified Text.Regex.TDFA as RE
 
@@ -1003,6 +1004,10 @@ unmarshalStringContext ptr = do
       tag <- cctxstrElemTag cptr idx
       hashSym <- cctxstrElemHash cptr idx
       nameSym <- cctxstrElemName cptr idx
+      -- Raw construction (Nix.Store.Path.Internal): provenance-safe -
+      -- these symbols were interned from a validated StorePath's own
+      -- fields by marshalStringContext, so this is a round-trip, not a
+      -- parse boundary.
       let sp = StorePath (symbolText (Symbol hashSym)) (symbolText (Symbol nameSym))
       case tag of
         0 -> pure (SCPlain sp)

--- a/src/Nix/Hash.hs
+++ b/src/Nix/Hash.hs
@@ -74,7 +74,8 @@ import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Text.Encoding (encodeUtf8)
 import Data.Word (Word8)
-import Nix.Store.Path (StoreDir (..), StorePath (..), StorePathNameError, checkStorePathName, defaultStoreDir, storePathToText)
+import Nix.Store.Path (StoreDir (..), StorePath, StorePathNameError, checkStorePathName, defaultStoreDir, storePathToText)
+import Nix.Store.Path.Internal (StorePath (StorePath))
 import NovaCache.Base32 (encode)
 import NovaCache.Hash (formatNixHash, hashBytes, parseNixHash)
 

--- a/src/Nix/Push.hs
+++ b/src/Nix/Push.hs
@@ -46,6 +46,7 @@ module Nix.Push
     stripHashPrefix,
     storePathBasename,
     checkRecordedNarHash,
+    narHashMatches,
   )
 where
 
@@ -66,7 +67,7 @@ import qualified Network.HTTP.Client.TLS as HTTPS
 import qualified Network.HTTP.Types as HTTP
 import Nix.Store (Store (..), queryDeriver, queryPathInfo, queryReferences)
 import qualified Nix.Store.DB as DB
-import Nix.Store.Path (StorePath (..), defaultStoreDir, parseStorePath, storePathToFilePath, storePathToText)
+import Nix.Store.Path (StorePath (spHash, spName), defaultStoreDir, parseStorePath, storePathToFilePath, storePathToText)
 import qualified NovaCache.Hash as Hash
 import qualified NovaCache.NAR as NAR
 import NovaCache.NarInfo (NarInfo (..), parseNarInfo, renderNarInfo)
@@ -330,7 +331,7 @@ checkRecordedNarHash recorded narHash sp = case recorded of
           <> " is on disk but not registered as valid; refusing to publish it with unknown references"
       )
   Just info
-    | DB.piNarHash info /= narHash ->
+    | not (narHashMatches (DB.piNarHash info) narHash) ->
         Left
           ( "store integrity: "
               <> storePathBasename sp
@@ -340,6 +341,17 @@ checkRecordedNarHash recorded narHash sp = case recorded of
               <> DB.piNarHash info
           )
     | otherwise -> Right ()
+
+-- | Recorded and computed NAR hashes match when their decoded digests
+-- agree, so any valid spelling of one digest matches (a foreign cache
+-- may record base16 where local hashing renders nix-base32).  A
+-- recorded value no spelling parses falls back to exact text equality,
+-- keeping legacy rows comparable rather than un-checkable.
+narHashMatches :: Text -> Text -> Bool
+narHashMatches recorded computed =
+  case (Hash.parseNixHash recorded, Hash.parseNixHash computed) of
+    (Right a, Right b) -> a == b
+    _ -> recorded == computed
 
 -- | Upload a rendered narinfo (the server validates and signs it).
 uploadNarInfo :: HTTP.Manager -> PushConfig -> StorePath -> NarInfo -> ExceptT Text IO ()

--- a/src/Nix/Store/DB.hs
+++ b/src/Nix/Store/DB.hs
@@ -65,7 +65,7 @@ import Database.SQLite.Simple
     query,
     withTransaction,
   )
-import Nix.Store.Path (StoreDir (..), StorePath (..), storePathToFilePath)
+import Nix.Store.Path (StoreDir (..), StorePath, storePathToFilePath)
 import System.Directory (createDirectoryIfMissing)
 import System.FilePath ((</>))
 

--- a/src/Nix/Store/Path.hs
+++ b/src/Nix/Store/Path.hs
@@ -38,7 +38,7 @@ module Nix.Store.Path
     windowsStoreDir,
 
     -- * Store paths
-    StorePath (..),
+    StorePath (spHash, spName),
     storePathToFilePath,
     storePathToText,
     isCanonicalStoreText,
@@ -62,6 +62,7 @@ where
 import Data.Char (isAsciiLower, isAsciiUpper, isDigit)
 import Data.Text (Text)
 import qualified Data.Text as T
+import Nix.Store.Path.Internal (StorePath (..))
 import System.FilePath ((</>))
 import qualified System.Info
 
@@ -95,15 +96,6 @@ platformStoreDirText = T.pack (unStoreDir platformStoreDir)
 -- | Default store directory on Windows: @C:\\nix\\store@.
 windowsStoreDir :: StoreDir
 windowsStoreDir = StoreDir "C:\\nix\\store"
-
--- | A parsed store path: the hash and name components.
-data StorePath = StorePath
-  { -- | The 32-character Nix base-32 hash.
-    spHash :: !Text,
-    -- | The human-readable name (e.g. @hello-2.12.1@).
-    spName :: !Text
-  }
-  deriving (Eq, Ord, Show)
 
 -- | Convert a 'StorePath' to a full filesystem path under a 'StoreDir'.
 storePathToFilePath :: StoreDir -> StorePath -> FilePath

--- a/src/Nix/Store/Path/Internal.hs
+++ b/src/Nix/Store/Path/Internal.hs
@@ -1,0 +1,38 @@
+-- | The bare 'StorePath' representation.  Importing this module is an
+-- assertion: every value constructed here satisfies the store-path
+-- invariants (32 nix-base32 hash characters; a name
+-- 'Nix.Store.Path.checkStorePathName' accepts) - or is
+-- 'maskedOutputPath', which exists only for derivation-hash masking
+-- and is never a real identity.  Production code imports this at
+-- exactly the validated construction gates
+-- ("Nix.Store.Path", "Nix.Hash") and the two documented
+-- provenance-safe sites (the C string-context unmarshal, the masking
+-- placeholder).  Everything else constructs through
+-- 'Nix.Store.Path.parseStorePath' \/
+-- 'Nix.Store.Path.parseStorePathBaseName' and reads through the
+-- exported selectors.  Tests may construct fixtures freely.
+module Nix.Store.Path.Internal
+  ( StorePath (..),
+    maskedOutputPath,
+  )
+where
+
+import Data.Text (Text)
+
+-- | A parsed store path: the hash and name components.
+data StorePath = StorePath
+  { -- | The 32-character Nix base-32 hash.
+    spHash :: !Text,
+    -- | The human-readable name (e.g. @hello-2.12.1@).
+    spName :: !Text
+  }
+  deriving (Eq, Ord, Show)
+
+-- | The empty output-path placeholder that derivation-hash masking
+-- renders: upstream computes a derivation's modulo hash over an ATerm
+-- whose output path fields are empty strings, and this value exists
+-- only to carry that rendering through 'DerivationOutput'.  It is
+-- never a real store identity and must never reach the store, the
+-- builder, or a context element.
+maskedOutputPath :: StorePath
+maskedOutputPath = StorePath "" ""

--- a/src/Nix/Substituter.hs
+++ b/src/Nix/Substituter.hs
@@ -76,7 +76,7 @@ import qualified Network.HTTP.Client.TLS as HTTPS
 import qualified Network.HTTP.Types.Status as HTTP
 import Nix.Store (Store (..), setReadOnly, unpackNarEntry)
 import Nix.Store.DB (PathRegistration (..))
-import Nix.Store.Path (StoreDir, StorePath (..), parseStorePathBaseName, storePathHashLen, storePathToFilePath)
+import Nix.Store.Path (StoreDir, StorePath (spHash), parseStorePathBaseName, storePathHashLen, storePathToFilePath)
 import qualified NovaCache.Hash as Hash
 import qualified NovaCache.NAR as NAR
 import qualified NovaCache.NarInfo as NarInfo
@@ -266,9 +266,9 @@ unpackAndVerify store sp narInfo rawNar =
   -- network corruption or a compromised cache must be caught here.
   -- Narinfo metadata is likewise parsed before any disk write: a malformed
   -- narinfo must not leave an unpacked-but-unregistered path behind.
-  case verifyNarHash narInfo rawNar >> verifyNarSize narInfo rawNar >> registrationMeta of
+  case verifiedInputs of
     Left err -> pure (SubstError err)
-    Right (refs, deriver) -> case NAR.deserialise rawNar of
+    Right (declared, (refs, deriver)) -> case NAR.deserialise rawNar of
       Left err -> pure (SubstError ("NAR deserialisation failed: " <> T.pack err))
       Right narEntry -> do
         let destPath = storePathToFilePath (stDir store) sp
@@ -297,12 +297,15 @@ unpackAndVerify store sp narInfo rawNar =
                           <> T.pack destPath
                       )
                   )
-              Right () ->
+              Right _ ->
                 pure $
                   SubstSuccess
                     PathRegistration
                       { prPath = sp,
-                        prNarHash = NarInfo.niNarHash narInfo,
+                        -- The canonical spelling of the verified digest,
+                        -- so the DB converges on one hash spelling
+                        -- regardless of the cache's.
+                        prNarHash = Hash.formatNixHash declared,
                         -- The verified actual byte count (equal to the declared
                         -- NarSize per 'verifyNarSize') - no Integer conversion
                         -- that could wrap.
@@ -311,20 +314,26 @@ unpackAndVerify store sp narInfo rawNar =
                         prReferences = refs
                       }
   where
+    verifiedInputs = do
+      declared <- verifyNarHash narInfo rawNar
+      verifyNarSize narInfo rawNar
+      meta <- registrationMeta
+      pure (declared, meta)
     registrationMeta = do
       refs <- parseReferences (NarInfo.niReferences narInfo)
       deriver <- parseDeriver (stDir store) (NarInfo.niDeriver narInfo)
       pure (refs, deriver)
 
 -- | Verify that the downloaded NAR bytes hash to the narinfo's declared
--- NarHash.  Compares decoded hash bytes, so any valid encoding of the digest
--- validates; @prNarHash@ stays sourced from the (now-verified) narinfo.
-verifyNarHash :: NarInfo.NarInfo -> BS.ByteString -> Either Text ()
+-- NarHash, returning the decoded digest on success so registration can
+-- record its canonical spelling.  Compares decoded hash bytes, so any
+-- valid encoding of the digest validates.
+verifyNarHash :: NarInfo.NarInfo -> BS.ByteString -> Either Text Hash.NixHash
 verifyNarHash narInfo rawNar =
   case Hash.parseNixHash (NarInfo.niNarHash narInfo) of
     Left err -> Left ("invalid narinfo NarHash: " <> T.pack err)
     Right declared
-      | declared == actual -> Right ()
+      | declared == actual -> Right declared
       | otherwise ->
           Left
             ( "NAR hash mismatch: narinfo declares "

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -48,11 +48,12 @@ import Nix.Hash (makeFixedOutputPath, sha256Digest)
 import qualified Nix.Hash as Hash
 import Nix.Parser (parseNix)
 import Nix.Parser.Lexer (Located (..), Token (..), tokenize)
-import Nix.Push (checkRecordedNarHash, computeClosure, loadApiKeyFile, mkNarInfo, narFileName, planMissing, storePathBasename, stripHashPrefix)
+import Nix.Push (checkRecordedNarHash, computeClosure, loadApiKeyFile, mkNarInfo, narFileName, narHashMatches, planMissing, storePathBasename, stripHashPrefix)
 import Nix.Store (DeleteOutcome (..), Store (..), addToStore, caseHackDiskNames, closeStore, copyPathInto, deleteStorePathRaw, isSafeNarName, isValid, materializeEvalSources, openStore, orderLinks, pathExists, resolveDeleteTarget, scanReferences, scanTempReferences, setReadOnly, writeDrv, writeDrvClosure)
 import Nix.Store.CaseSensitive (trySetCaseSensitiveDir)
 import Nix.Store.DB (PathInfo (..), PathRegistration (..), closeStoreDB, dbFileName, isValidPath, metaDirName, openStoreDB, queryAllValidPaths, queryDeriver, queryPathInfo, queryReferences, registerPath, registerPaths)
-import Nix.Store.Path (StoreDir (..), StorePath (..), defaultStoreDir, defaultStoreDirText, isCanonicalStoreText, parseStorePath, platformStoreDir, platformStoreDirText, storePathToFilePath, storePathToText, storeTextToFilePath, windowsStoreDir)
+import Nix.Store.Path (StoreDir (..), StorePath, defaultStoreDir, defaultStoreDirText, isCanonicalStoreText, parseStorePath, platformStoreDir, platformStoreDirText, storePathToFilePath, storePathToText, storeTextToFilePath, windowsStoreDir)
+import Nix.Store.Path.Internal (StorePath (..))
 import qualified Nix.Substituter as Subst
 import qualified NovaCache.Base64 as B64
 import qualified NovaCache.Hash as CHash
@@ -3109,19 +3110,24 @@ testSubstituter = do
       -- defaultCacheConfig has priority 40
       runTest "defaultCacheConfig priority" $
         assertEqual "default-prio" 40 (Subst.ccPriority Subst.defaultCacheConfig),
-      -- verifyNarHash: matching NAR hash accepted (HIGH#2 integrity gate)
+      -- verifyNarHash: matching NAR hash accepted (HIGH#2 integrity gate);
+      -- the returned digest is the declared hash, decoded.
       runTest "verifyNarHash accepts matching hash" $
-        assertEqual "narhash-match" (Right ()) (Subst.verifyNarHash (sampleNarInfo sampleNarHash) sampleNarBytes),
+        case Subst.verifyNarHash (sampleNarInfo sampleNarHash) sampleNarBytes of
+          Right declared
+            | CHash.formatNixHash declared == sampleNarHash -> Pass
+            | otherwise -> Fail "returned digest does not match the declared hash"
+          Left err -> Fail ("expected acceptance, got: " <> err),
       -- verifyNarHash: mismatched NAR hash rejected
       runTest "verifyNarHash rejects mismatched hash" $
         case Subst.verifyNarHash (sampleNarInfo wrongNarHash) sampleNarBytes of
           Left _ -> Pass
-          Right () -> Fail "expected mismatch rejection",
+          Right _ -> Fail "expected mismatch rejection",
       -- verifyNarHash: malformed NAR hash rejected
       runTest "verifyNarHash rejects malformed hash" $
         case Subst.verifyNarHash (sampleNarInfo "not-a-hash") sampleNarBytes of
           Left _ -> Pass
-          Right () -> Fail "expected malformed-hash rejection",
+          Right _ -> Fail "expected malformed-hash rejection",
       -- narInfoMatchesPath: identity match accepted
       runTest "narInfoMatchesPath accepts matching identity" $
         if Subst.narInfoMatchesPath (StorePath sampleHash "hello") (sampleNarInfo sampleNarHash)
@@ -3901,7 +3907,25 @@ testPushPure = do
           Left err
             | "DB recorded" `T.isInfixOf` err -> Pass
             | otherwise -> Fail ("wrong error: " <> err)
-          Right () -> Fail "hash mismatch must not be publishable"
+          Right () -> Fail "hash mismatch must not be publishable",
+      -- narHashMatches decodes both spellings before comparing.  Today
+      -- parseNixHash reads only the sha256:nix-base32 spelling, so a
+      -- base16-recorded digest (both literals spell the empty-string
+      -- sha256) falls back to text equality and refuses - the safe
+      -- direction.  When the parser learns more spellings (foreign
+      -- caches), this pin flips and the gate widens with it.
+      runTest "push gate pins the accepted hash spellings" $
+        if narHashMatches
+          "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          "sha256:0mdqa9w1p6cmli6976v4wi0sw9r4p5prkj7lzfd1877wk11c9c73"
+          then Fail "base16 spelling unexpectedly matched - widen this pin"
+          else Pass,
+      runTest "push gate still refuses different digests" $
+        if narHashMatches
+          "sha256:0mdqa9w1p6cmli6976v4wi0sw9r4p5prkj7lzfd1877wk11c9c73"
+          (Hash.formatNixHash (Hash.hashBytes "different"))
+          then Fail "distinct digests must not match"
+          else Pass
     ]
   where
     pathInfoFor recordedHash =
@@ -5878,6 +5902,18 @@ testFromATerm = do
       -- Round-trip: complex derivation
       runTest "fromATerm round-trip complex" $
         assertEqual "complex round-trip" (Right complexTestDrv) (fromATerm (toATerm complexTestDrv)),
+      -- A .drv read from disk is input: an output name that violates the
+      -- store-name rules (here a traversal shape that would later join
+      -- the build dir) must refuse at parse.
+      runTest "fromATerm rejects a traversal-shaped output name" $
+        let evil =
+              simpleTestDrv
+                { drvOutputs =
+                    [DerivationOutput "../evil" (StorePath (T.replicate 32 "a") "pkg") "" ""]
+                }
+         in case fromATerm (toATerm evil) of
+              Left _ -> Pass
+              Right _ -> Fail "parsed a drv with a traversal output name",
       -- drv4: the modulo-substitution section merges input-drv entries that
       -- share a modulo-hash key, unioning their output-name sets, so it is
       -- byte-identical to the already-merged form.  (Just subs replaces the


### PR DESCRIPTION
Audit wave 2 (#85): the structural findings. Three auditors independently traced their sharpest results to one root cause - `StorePath`'s exported constructor made the "validated newtype" a convention rather than a compiler guarantee.

## An opaque StorePath

The constructor and fields move to `Nix.Store.Path.Internal`; `Nix.Store.Path` re-exports the type and selectors only. Importing the Internal module is an assertion that constructed values satisfy the store-path invariants: production code does so at exactly the validated gates (`Nix.Store.Path`, `Nix.Hash`) plus two documented provenance-safe sites - the C string-context unmarshal (a round-trip of symbols interned from a validated path's own fields) and `maskedOutputPath`, the empty placeholder derivation-hash masking renders, now a named constant with its contract stated. Tests construct fixtures freely through the loud door, the `bytestring`/`text` ecosystem pattern. `push`'s bare-basename fallback - the one remaining unvalidated construction - becomes `parseStorePathBaseName`: push targets are real store paths, so the charset gate is correct there.

## Output names validated at .drv parse

`fromATerm` now checks each output name against the store-name rules. A `.drv` read from disk is input, not trusted state, and the output name later becomes a filesystem component under the build dir and an environment variable name; eval already validated names it produces, and now the parse boundary holds the same line for everything else.

## Hash comparisons decode before comparing

`verifyNarHash` returns the decoded digest it proves (instead of discarding it), registration records that digest's canonical spelling so the DB converges on one format regardless of the cache's, and `push`'s recorded-hash integrity gate compares decoded digests, falling back to exact text only for rows no spelling parser accepts. Today `parseNixHash` reads only `sha256:` nix-base32, so a pin test documents the refusal of other spellings - the safe direction - and flips loudly when the parser widens for foreign caches (#27).

## Measurement

Benchmarked before and after: allocation identical to the byte, timing inside the run-to-run noise band. New tests: the traversal-shaped output name refuses at `fromATerm`, the spelling pin, and the `verifyNarHash` value-return adaptation; suite green.

Part of #85.
