### PR TITLE
Toolchain: GHC 9.14.1 (the first GHC LTS)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: haskell-actions/setup@v2
         with:
-          ghc-version: "9.8"
+          ghc-version: "9.14.1"
           cabal-version: "latest"
       - name: Validate package
         run: cabal check
@@ -111,7 +111,7 @@ jobs:
       - uses: haskell-actions/setup@v2
         id: setup
         with:
-          ghc-version: "9.8"
+          ghc-version: "9.14.1"
           cabal-version: "latest"
 
       - name: Cache Cabal store
@@ -148,7 +148,7 @@ jobs:
       - uses: haskell-actions/setup@v2
         id: setup
         with:
-          ghc-version: "9.8"
+          ghc-version: "9.14.1"
           cabal-version: "latest"
 
       # Dependencies build unsanitized (the flags below are scoped to this
@@ -212,7 +212,7 @@ jobs:
       - uses: haskell-actions/setup@v2
         id: setup
         with:
-          ghc-version: "9.8"
+          ghc-version: "9.14.1"
           cabal-version: "latest"
 
       - name: Cache Cabal store
@@ -239,3 +239,32 @@ jobs:
 
       - name: Test
         run: cabal test
+
+  # ---------------------------------------------------------------------------
+  # Compat floor: the package still builds on GHC 9.8 (Stackage LTS 23).
+  # Build-only and not a required check - the -Werror gate is the 9.14
+  # matrix; a warning that exists only on the older compiler must not block.
+  # ---------------------------------------------------------------------------
+
+  ghc98-compat:
+    name: GHC 9.8 compat (Linux)
+    needs: [cabal-check]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: haskell-actions/setup@v2
+        id: setup
+        with:
+          ghc-version: "9.8.4"
+          cabal-version: "latest"
+
+      - name: Cache Cabal store
+        uses: actions/cache@v5
+        with:
+          path: ${{ steps.setup.outputs.cabal-store }}
+          key: cabal-ghc98-${{ hashFiles('nova-nix.cabal') }}
+          restore-keys: cabal-ghc98-
+
+      - name: Build
+        run: cabal build --enable-tests

--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -56,7 +56,7 @@ jobs:
       - uses: haskell-actions/setup@v2
         id: setup
         with:
-          ghc-version: "9.8"
+          ghc-version: "9.14.1"
           cabal-version: "latest"
 
       - name: Cache Cabal store

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,7 +47,7 @@ jobs:
 
       - uses: haskell-actions/setup@v2
         with:
-          ghc-version: "9.8"
+          ghc-version: "9.14.1"
           cabal-version: "latest"
 
       - name: Build sdist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- **Toolchain: GHC 9.14.1 (the first GHC LTS release)** - CI, the release pipeline, and the README badge move from GHC 9.8.4 to 9.14.1. GHC 9.14 opens GHC's new LTS scheme (a minimum of two years of bugfix releases), and under that scheme every earlier series stops receiving fixes, so no version in between had a future. Dependency bounds already admitted the newer compiler and the full set resolves on it. A build-only Linux compat job keeps the package building on 9.8.4 (Stackage LTS 23) for users on the older series.
+
 ## 0.6.0.0 - 2026-06-12
 
 ### Milestone: A Stage-1 stdenv That Builds Real Software

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 [![CI](https://github.com/Novavero-AI/nova-nix/actions/workflows/ci.yml/badge.svg)](https://github.com/Novavero-AI/nova-nix/actions/workflows/ci.yml)
 [![Hackage](https://img.shields.io/hackage/v/nova-nix.svg)](https://hackage.haskell.org/package/nova-nix)
-![GHC](https://img.shields.io/badge/GHC-9.8-purple)
+![GHC](https://img.shields.io/badge/GHC-9.14-purple)
 ![License](https://img.shields.io/badge/license-Apache--2.0-blue)
 
 </div>

--- a/nova-nix.cabal
+++ b/nova-nix.cabal
@@ -27,7 +27,7 @@ bug-reports:        https://github.com/Novavero-AI/nova-nix/issues
 category:           Nix, Distribution, System
 stability:          experimental
 build-type:         Simple
-tested-with:        GHC == 9.8.4
+tested-with:        GHC == 9.8.4 || == 9.14.1
 extra-doc-files:
     CHANGELOG.md
     NOTICE


### PR DESCRIPTION
## What

- `ci.yml` (cabal-check, sdist, sanitizers, three-OS matrix), `parity.yml`, `publish.yml`: `ghc-version` 9.8 -> 9.14.1
- README badge GHC 9.8 -> 9.14
- `tested-with: GHC == 9.8.4 || == 9.14.1`
- CHANGELOG: Unreleased entry
- `ghc98-compat` job: build-only floor on GHC 9.8.4 / Stackage LTS 23 (deliberately not a required check)

## Why 9.14.1

GHC 9.14 is the first release under GHC's LTS scheme (minimum two years of bugfix releases), and under that scheme every earlier series stops receiving fixes - there is no version between 9.8.4 and 9.14.1 with a future. Verified locally 2026-08-19: the full dependency set resolves on 9.14.1; a full -Werror build + test run is in progress. Known tradeoff: HLS support is currently "basic" and improves underneath us without another toolchain change.

## Verification and fallback

This PR's matrix run is the port's verification, especially windows-latest. If 9.14.1 fails the matrix in a deep way, one commit reverts the pins to 9.10.3 (already verified there: solver and Cabal Check green). First run rebuilds dependency caches, so expect it to be slower than usual.