### PR TITLE
Toolchain: GHC 9.14.1 (the first GHC LTS)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: haskell-actions/setup@v2
         with:
-          ghc-version: "9.8"
+          ghc-version: "9.14.1"
           cabal-version: "latest"
       - name: Validate package
         run: cabal check
@@ -111,7 +111,7 @@ jobs:
       - uses: haskell-actions/setup@v2
         id: setup
         with:
-          ghc-version: "9.8"
+          ghc-version: "9.14.1"
           cabal-version: "latest"
 
       - name: Cache Cabal store
@@ -148,7 +148,7 @@ jobs:
       - uses: haskell-actions/setup@v2
         id: setup
         with:
-          ghc-version: "9.8"
+          ghc-version: "9.14.1"
           cabal-version: "latest"
 
       # Dependencies build unsanitized (the flags below are scoped to this
@@ -212,7 +212,7 @@ jobs:
       - uses: haskell-actions/setup@v2
         id: setup
         with:
-          ghc-version: "9.8"
+          ghc-version: "9.14.1"
           cabal-version: "latest"
 
       - name: Cache Cabal store

--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -56,7 +56,7 @@ jobs:
       - uses: haskell-actions/setup@v2
         id: setup
         with:
-          ghc-version: "9.8"
+          ghc-version: "9.14.1"
           cabal-version: "latest"
 
       - name: Cache Cabal store

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,7 +47,7 @@ jobs:
 
       - uses: haskell-actions/setup@v2
         with:
-          ghc-version: "9.8"
+          ghc-version: "9.14.1"
           cabal-version: "latest"
 
       - name: Build sdist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- **Toolchain: GHC 9.14.1 (the first GHC LTS release)** - CI, the release pipeline, and the README badge move from GHC 9.8.4 to 9.14.1. GHC 9.14 opens GHC's new LTS scheme (a minimum of two years of bugfix releases), and under that scheme every earlier series stops receiving fixes, so no version in between had a future. Dependency bounds already admitted the newer compiler and the full set resolves on it. The project targets the LTS alone: base >= 4.22, and foldl' comes from the Prelude, so its eleven redundant Data.List imports are gone. The deprecated pattern namespace specifier stays for now - hlint cannot yet parse the data replacement GHC suggests - with its deprecation warning muted in the cabal file until hlint learns the new spelling.
+
 ## 0.6.0.0 - 2026-06-12
 
 ### Milestone: A Stage-1 stdenv That Builds Real Software

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 [![CI](https://github.com/Novavero-AI/nova-nix/actions/workflows/ci.yml/badge.svg)](https://github.com/Novavero-AI/nova-nix/actions/workflows/ci.yml)
 [![Hackage](https://img.shields.io/hackage/v/nova-nix.svg)](https://hackage.haskell.org/package/nova-nix)
-![GHC](https://img.shields.io/badge/GHC-9.8-purple)
+![GHC](https://img.shields.io/badge/GHC-9.14-purple)
 ![License](https://img.shields.io/badge/license-Apache--2.0-blue)
 
 </div>
@@ -134,7 +134,7 @@ cabal build
 cabal test
 ```
 
-Requires GHC 9.8+ and cabal-install 3.10+.
+Requires GHC 9.14+ and cabal-install 3.10+.
 
 ---
 

--- a/nova-nix.cabal
+++ b/nova-nix.cabal
@@ -27,7 +27,7 @@ bug-reports:        https://github.com/Novavero-AI/nova-nix/issues
 category:           Nix, Distribution, System
 stability:          experimental
 build-type:         Simple
-tested-with:        GHC == 9.8.4
+tested-with:        GHC == 9.14.1
 extra-doc-files:
     CHANGELOG.md
     NOTICE
@@ -89,7 +89,7 @@ library
     Nix.Hash
 
   build-depends:
-      base                >= 4.16 && < 5
+      base                >= 4.22 && < 5
     , array               >= 0.5 && < 0.6
     , bytestring          >= 0.11 && < 0.13
     , containers          >= 0.6 && < 0.9
@@ -136,6 +136,11 @@ library
     -Wcompat
     -Wincomplete-record-updates
     -Wincomplete-uni-patterns
+    -- GHC 9.14 deprecates the pattern namespace specifier in import and
+    -- export lists in favour of data, but hlint (through 3.10) cannot
+    -- parse the replacement.  The old spelling stays, warning muted,
+    -- until hlint learns it (then: pattern -> data, drop these flags).
+    -Wno-pattern-namespace-specifier
 
 -- ---------------------------------------------------------------------------
 -- CLI executable
@@ -151,7 +156,7 @@ executable nova-nix
   ghc-options:      -Wall -Wcompat -threaded -rtsopts
 
   build-depends:
-      base                >= 4.16 && < 5
+      base                >= 4.22 && < 5
     , bytestring          >= 0.11 && < 0.13
     , containers          >= 0.6 && < 0.9
     , directory           >= 1.3 && < 1.4
@@ -169,10 +174,10 @@ test-suite nova-nix-test
   default-language: Haskell2010
   default-extensions:
     OverloadedStrings
-  ghc-options:      -Wall -Wcompat
+  ghc-options:      -Wall -Wcompat -Wno-pattern-namespace-specifier
 
   build-depends:
-      base                >= 4.16 && < 5
+      base                >= 4.22 && < 5
     , bytestring          >= 0.11 && < 0.13
     , containers          >= 0.6 && < 0.9
     , directory           >= 1.3 && < 1.4

--- a/src/Nix/DependencyGraph.hs
+++ b/src/Nix/DependencyGraph.hs
@@ -22,7 +22,6 @@ module Nix.DependencyGraph
   )
 where
 
-import Data.List (foldl')
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe)

--- a/src/Nix/Eval.hs
+++ b/src/Nix/Eval.hs
@@ -80,7 +80,7 @@ import qualified Data.ByteString.Char8 as BC
 import Data.Char (chr, digitToInt, isAsciiLower, isAsciiUpper, isDigit, isHexDigit, isOctDigit, ord)
 import Data.IORef (IORef, atomicModifyIORef', newIORef)
 import Data.Int (Int64)
-import Data.List (find, foldl', partition, sort)
+import Data.List (find, partition, sort)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (catMaybes, fromMaybe, isJust, isNothing, listToMaybe)

--- a/src/Nix/Eval/CanonPath.hs
+++ b/src/Nix/Eval/CanonPath.hs
@@ -27,7 +27,6 @@ module Nix.Eval.CanonPath
 where
 
 import Data.Char (isAlpha)
-import Data.List (foldl')
 import Data.Text (Text)
 import qualified Data.Text as T
 import System.FilePath (isPathSeparator, pathSeparator)

--- a/src/Nix/Eval/Context.hs
+++ b/src/Nix/Eval/Context.hs
@@ -25,7 +25,6 @@ module Nix.Eval.Context
   )
 where
 
-import Data.List (foldl')
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set

--- a/src/Nix/Eval/StringInterp.hs
+++ b/src/Nix/Eval/StringInterp.hs
@@ -16,7 +16,6 @@ where
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BC
-import Data.List (foldl')
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE

--- a/src/Nix/Expr/ClosureTrim.hs
+++ b/src/Nix/Expr/ClosureTrim.hs
@@ -19,7 +19,7 @@ module Nix.Expr.ClosureTrim
   )
 where
 
-import Data.List (foldl', sortBy)
+import Data.List (sortBy)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Ord (comparing)

--- a/src/Nix/Expr/Resolve.hs
+++ b/src/Nix/Expr/Resolve.hs
@@ -15,7 +15,6 @@ module Nix.Expr.Resolve
   )
 where
 
-import Data.List (foldl')
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Set (Set)

--- a/src/Nix/Hash.hs
+++ b/src/Nix/Hash.hs
@@ -68,7 +68,6 @@ import Data.Bits (xor)
 import qualified Data.ByteArray as BA
 import qualified Data.ByteString as BS
 import Data.Char (digitToInt, isHexDigit)
-import Data.List (foldl')
 import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as T

--- a/src/Nix/Parser/Expr.hs
+++ b/src/Nix/Parser/Expr.hs
@@ -23,7 +23,6 @@ module Nix.Parser.Expr
 where
 
 import Control.Monad (foldM, when)
-import Data.List (foldl')
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Text (Text)

--- a/src/Nix/Store.hs
+++ b/src/Nix/Store.hs
@@ -78,7 +78,7 @@ import Control.Exception (IOException, SomeException, catch, throwIO, try)
 import Control.Monad (unless, when)
 import qualified Data.ByteString as BS
 import Data.Char (isDigit, toUpper)
-import Data.List (foldl', inits)
+import Data.List (inits)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (catMaybes)

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -13,7 +13,7 @@ import Data.Bits (shiftR, (.&.))
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BL
 import Data.IORef (atomicModifyIORef', newIORef, readIORef)
-import Data.List (foldl', sort)
+import Data.List (sort)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe, isJust, listToMaybe)
 import qualified Data.Set as Set


### PR DESCRIPTION
Moves the toolchain to GHC 9.14.1 - the first release under GHC's LTS scheme (two years of bugfixes, while every earlier series winds down). There was no version between 9.8.4 and 9.14.1 worth stopping at, so this goes straight to the LTS and drops the interim 9.8 compat job: one compiler, one gate.

Pins: the ci/parity/publish workflows, the README badge, tested-with, and base >= 4.22.

Code fallout, all mechanical:

- foldl' comes from the Prelude now, so eleven redundant Data.List imports are removed
- GHC 9.14 deprecates `pattern` in import/export lists in favour of `data`, but hlint (through 3.10) cannot parse the replacement - checked with a minimal repro that GHC compiles and hlint refuses. The old spelling stays, that single warning muted in the cabal file, undo condition documented next to the flag.

Green locally on 9.14.1: full -Werror build, cabal check, hlint clean, 1109/1109 tests. First CI run rebuilds the dependency caches, so it will be slower than usual.

Supersedes #95 (auto-closed by a branch rename).