### PR TITLE
CI: ormolu 0.9.0.0 and hlint 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: haskell-actions/hlint-setup@v2
         with:
-          version: "3.8"
+          version: "3.10"
       - uses: haskell-actions/hlint-run@v2
         with:
           path: '["src/", "app/", "test/"]'
@@ -55,13 +55,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: haskell-actions/run-ormolu@v19
+      - uses: haskell-actions/run-ormolu@v21
         with:
           # Pinned to the version the repo is formatted with: formatting
           # is not stable across ormolu releases, and a floating version
           # would fail CI on untouched code when upstream ships one.
           # Upgrades bump this and the local binary together.
-          version: "0.7.7.0"
+          version: "0.9.0.0"
           pattern: |
             src/**/*.hs
             app/**/*.hs

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -40,20 +40,21 @@ import Nix.Store.Path (defaultStoreDirText)
 builtinEnv :: Int64 -> [Thunk] -> Env
 builtinEnv timestamp searchPaths =
   let scope =
-        attrSetFromMap $
-          Map.fromList $
-            -- Values
-            [ ("true", evaluated (VBool True)),
-              ("false", evaluated (VBool False)),
-              ("null", evaluated VNull),
-              ("builtins", evaluated (builtinsAttrSet timestamp searchPaths)),
-              -- Search path support: <name> desugars to __findFile __nixPath "name"
-              -- (matching C++ Nix's parser desugaring).
-              ("__findFile", evaluated (VBuiltin "findFile" [])),
-              ("__nixPath", evaluated (VList (clistFromThunks (map thunkToCPtr searchPaths))))
-            ]
-              -- Top-level builtin functions (available without builtins. prefix)
-              ++ map topLevelBuiltin topLevelBuiltinNames
+        attrSetFromMap
+          $ Map.fromList
+          $
+          -- Values
+          [ ("true", evaluated (VBool True)),
+            ("false", evaluated (VBool False)),
+            ("null", evaluated VNull),
+            ("builtins", evaluated (builtinsAttrSet timestamp searchPaths)),
+            -- Search path support: <name> desugars to __findFile __nixPath "name"
+            -- (matching C++ Nix's parser desugaring).
+            ("__findFile", evaluated (VBuiltin "findFile" [])),
+            ("__nixPath", evaluated (VList (clistFromThunks (map thunkToCPtr searchPaths))))
+          ]
+            -- Top-level builtin functions (available without builtins. prefix)
+            ++ map topLevelBuiltin topLevelBuiltinNames
    in newCEnv nullPtr 0 (Just scope) Nothing nullPtr 0
 
 -- | Builtins exposed at the top level (without @builtins.@ prefix).

--- a/src/Nix/Derivation.hs
+++ b/src/Nix/Derivation.hs
@@ -202,23 +202,23 @@ toATerm = toATermForHash False Nothing
 -- @toATermForHash False Nothing@ is exactly 'toATerm'.
 toATermForHash :: Bool -> Maybe [(Text, [Text])] -> Derivation -> ByteString
 toATermForHash maskOutputs inputSubst drv =
-  LBS.toStrict $
-    B.toLazyByteString $
-      "Derive("
-        <> atermOutputsWith maskOutputs (drvOutputs drv)
-        <> ","
-        <> inputDrvsSection
-        <> ","
-        <> atermInputSrcs (drvInputSrcs drv)
-        <> ","
-        <> atermStringT (platformToText (drvPlatform drv))
-        <> ","
-        <> atermString (drvBuilder drv)
-        <> ","
-        <> atermList (map atermString (drvArgs drv))
-        <> ","
-        <> atermEnv (drvEnv drv)
-        <> ")"
+  LBS.toStrict
+    $ B.toLazyByteString
+    $ "Derive("
+      <> atermOutputsWith maskOutputs (drvOutputs drv)
+      <> ","
+      <> inputDrvsSection
+      <> ","
+      <> atermInputSrcs (drvInputSrcs drv)
+      <> ","
+      <> atermStringT (platformToText (drvPlatform drv))
+      <> ","
+      <> atermString (drvBuilder drv)
+      <> ","
+      <> atermList (map atermString (drvArgs drv))
+      <> ","
+      <> atermEnv (drvEnv drv)
+      <> ")"
   where
     inputDrvsSection = case inputSubst of
       Nothing -> atermInputDrvs (drvInputDrvs drv)

--- a/src/Nix/Eval.hs
+++ b/src/Nix/Eval.hs
@@ -2436,10 +2436,10 @@ formalsToAttrs (EFNamedSet _ formals _) = formalsListToAttrs formals
 
 formalsListToAttrs :: [EvalFormal] -> NixValue
 formalsListToAttrs formals =
-  VAttrs $
-    attrSetFromMap $
-      Map.fromList
-        [(efName f, evaluated (VBool (isJust (efDefault f)))) | f <- formals]
+  VAttrs
+    $ attrSetFromMap
+    $ Map.fromList
+      [(efName f, evaluated (VBool (isJust (efDefault f)))) | f <- formals]
 
 builtinZipAttrsWith :: (MonadEval m) => NixValue -> NixValue -> m NixValue
 builtinZipAttrsWith func (VList cl) = do

--- a/src/Nix/Eval/Types.hs
+++ b/src/Nix/Eval/Types.hs
@@ -864,9 +864,9 @@ newComputedPathPtr p =
 {-# NOINLINE newComputedListPtrC #-}
 newComputedListPtrC :: CList -> CThunkPtr
 newComputedListPtrC (CList clistPtr) =
-  unsafePerformIO $
-    clistPtr `seq`
-      cthunkNewComputedList (castPtr clistPtr)
+  unsafePerformIO
+    $ clistPtr
+    `seq` cthunkNewComputedList (castPtr clistPtr)
 
 -- | Wrap a string with context in a pre-computed C thunk (no StablePtr).
 -- Interns the payload bytes and all StorePath fields as symbols, builds nn_ctxstr_t.
@@ -1020,9 +1020,9 @@ unmarshalStringContext ptr = do
 {-# NOINLINE newComputedAttrsPtr #-}
 newComputedAttrsPtr :: CAttrSet -> CThunkPtr
 newComputedAttrsPtr cset =
-  unsafePerformIO $
-    cset `seq`
-      cthunkNewComputedAttrs (castPtr cset)
+  unsafePerformIO
+    $ cset
+    `seq` cthunkNewComputedAttrs (castPtr cset)
 
 -- | Build a C-allocated slot array from a list of 'Thunk' values.
 -- Each thunk is converted to 'CThunkPtr' via 'thunkToCPtr'.


### PR DESCRIPTION
Bumps both lint pins to their current releases: hlint 3.8 -> 3.10 and ormolu 0.7.7.0 -> 0.9.0.0, with the four-file reformat the new ormolu asks for (spacing only - the dollar-placement style changed in 0.8.2).

One discovery worth recording: ormolu moved from tweag/ormolu to mrkkrp/ormolu. The package's homepage, bug tracker, and source-repository all point at the new home, and it is where the run-ormolu action downloads its binaries. The old repo's releases stop at 0.8.1.1, so version checks against it give stale answers.

Verified locally with the exact release binaries CI will use: ormolu check clean over the tree after the reformat, hlint reports no hints, full -Werror build and all 1109 tests pass. The same ormolu 0.9.0.0 binary is installed locally, so the pin and the local formatter agree.

Targets main directly so CI exercises both new pins now; the diff collapses to just this commit once #97 merges.