### PR TITLE
Contributing: inbound=outbound wording, project credit up top

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,7 @@
 # Contributing to nova-nix
 
-Thanks for your interest. Issues and pull requests are welcome.
+nova-nix is a project of Novavero AI Inc. Thanks for your interest - issues
+and pull requests are welcome.
 
 ## Ground rules
 
@@ -12,8 +13,8 @@ Thanks for your interest. Issues and pull requests are welcome.
 
 nova-nix is licensed under Apache-2.0. Per Section 5 of the license, any
 contribution intentionally submitted for inclusion in this project is licensed
-under Apache-2.0, without additional terms or conditions, with Novavero AI Inc.
-as the project licensor. If you do not agree with this, do not submit the
-contribution. Submit only work you have the right to license.
+under Apache-2.0, without additional terms or conditions. You keep the
+copyright to your work. Submit only work you have the right to license.
 
-This keeps the project's licensing simple and its future flexible for everyone.
+This is the standard inbound=outbound arrangement: you contribute under the
+same terms you received the project under, nothing more.

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 nova-nix
-Copyright 2026 Novavero AI Inc.
+Copyright 2026 Novavero AI Inc. and contributors
 
 This product is licensed under the Apache License, Version 2.0.
 A copy of the License is provided in the LICENSE file, or at


### PR DESCRIPTION
Softens the contribution-licensing section to the standard inbound=outbound arrangement: contributors keep their copyright and contribute under the same Apache-2.0 terms they receive. The removed "project licensor" and "future flexible" phrasing suggested relicensing ambitions the mechanics never supported, and that kind of wording is exactly what makes copyleft-minded contributors hesitate.

Novavero AI Inc.'s credit is not weakened by this: it now leads the document ("nova-nix is a project of Novavero AI Inc."), and the legally durable credit was always the NOTICE file, which Apache-2.0 section 4(d) obliges every downstream redistribution to preserve.