### PR TITLE
Store: builtin:unpack resolves srcs through the store dir

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,12 +291,10 @@ jobs:
         shell: pwsh
         run: |
           $exe = "$env:RUNNER_TEMP\bin\nova-nix.exe"
-          $src = Join-Path $env:GITHUB_WORKSPACE "pkgs\windows\hello.nix"
-          # The logical store dir /nix/store resolves drive-relative on
-          # Windows, and this runner's workspace lives on D:.  Run from C:\
-          # so every resolution lands on the provisioned C:\nix\store.
-          Set-Location C:\
-          $out = (& $exe build $src) | Select-Object -Last 1
+          # The workspace lives on D: while the store is anchored on C: -
+          # building from here is deliberate: it exercises the #101 fix
+          # (canonical /nix/store text rendered through the store dir).
+          $out = (& $exe build pkgs\windows\hello.nix) | Select-Object -Last 1
           if ($LASTEXITCODE -ne 0) { Write-Error "nova-nix build failed"; exit 1 }
           Write-Host "out path: $out"
           $hello = Join-Path $out "hello.exe"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- **builtin:unpack resolves srcs through the store dir.** The srcs env value carries eval's canonical /nix/store spelling; unpack opened it verbatim, and on Windows a bare /-rooted path resolves against the current drive - the build worked only when the process happened to run from C:. Found by the e2e job's first flights (#100) on GitHub's D:-workspace runners. Each srcs entry now parses as a store path and renders through the configured store dir (the identity on Unix), a non-store-path entry fails loudly, and the e2e job no longer pins its working directory. (#101)
 - **Toolchain: GHC 9.14.1 (the first GHC LTS release)** - CI, the release pipeline, and the README badge move from GHC 9.8.4 to 9.14.1. GHC 9.14 opens GHC's new LTS scheme (a minimum of two years of bugfix releases), and under that scheme every earlier series stops receiving fixes, so no version in between had a future. Dependency bounds already admitted the newer compiler and the full set resolves on it. The project targets the LTS alone: base >= 4.22, and foldl' comes from the Prelude, so its eleven redundant Data.List imports are gone. The deprecated pattern namespace specifier stays for now - hlint cannot yet parse the data replacement GHC suggests - with its deprecation warning muted in the cabal file until hlint learns the new spelling.
 
 ## 0.6.0.0 - 2026-06-12

--- a/src/Nix/Builder.hs
+++ b/src/Nix/Builder.hs
@@ -232,7 +232,7 @@ buildDerivationInner config store drv = do
         exitResult <- case drvBuilder drv of
           b
             | b == builtinFetchurlBuilder -> runBuiltinFetchurl drv outputDirs
-            | b == builtinUnpackBuilder -> runBuiltinUnpack (bcUnpackLimits config) drv outputDirs
+            | b == builtinUnpackBuilder -> runBuiltinUnpack (bcStoreDir config) (bcUnpackLimits config) drv outputDirs
           _ -> case decodeBuilderStrings drv of
             Left errMsg -> pure (Left (1, errMsg))
             Right (builderText, argTexts, decodedEnv) ->

--- a/src/Nix/Builder/Unpack.hs
+++ b/src/Nix/Builder/Unpack.hs
@@ -68,6 +68,7 @@ import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import Nix.Derivation (Derivation (..))
+import Nix.Store.Path (StoreDir, defaultStoreDir, parseStorePath, storePathToFilePath)
 import System.Directory
   ( copyFile,
     createDirectoryIfMissing,
@@ -176,26 +177,36 @@ type DecodeError = Either Tar.FormatError Tar.DecodeLongNamesError
 -- @Either (exit, msg) ()@ shape as the process runner, so the shared
 -- output-validation and registration path in "Nix.Builder" is reused
 -- unchanged.
-runBuiltinUnpack :: UnpackLimits -> Derivation -> [(Text, FilePath)] -> IO (Either (Int, Text) ())
-runBuiltinUnpack limits drv outputDirs =
+--
+-- @srcs@ carries eval's canonical @\/nix\/store@ spelling, and the physical
+-- root may live elsewhere - @C:\\nix\\store@ on Windows, where a bare
+-- \/-rooted path resolves against the current DRIVE - so each entry is
+-- parsed as a store path and rendered through the store dir rather than
+-- opened verbatim (#101).  On Unix the rendering is the identity.
+runBuiltinUnpack :: StoreDir -> UnpackLimits -> Derivation -> [(Text, FilePath)] -> IO (Either (Int, Text) ())
+runBuiltinUnpack storeDir limits drv outputDirs =
   case (Map.lookup envSrcs (drvEnv drv), lookup unpackOutputName outputDirs) of
     (Nothing, _) -> failure "derivation has no 'srcs'"
     (Just srcsBytes, mOutDir) -> case TE.decodeUtf8' srcsBytes of
       -- Store paths are ASCII; a non-UTF-8 srcs value cannot name any.
       Left _ -> failure "'srcs' contains invalid UTF-8"
       Right srcs
-        | null (sourcePaths srcs) -> failure "'srcs' is empty"
-        | otherwise -> case mOutDir of
-            Nothing -> failure "derivation defines no 'out' output"
-            Just outDir -> do
-              createDirectoryIfMissing True outDir
-              result <- unpackAll outDir limits (sourcePaths srcs)
-              pure $ case result of
-                Left msg -> Left (1, "builtin:unpack: " <> msg)
-                Right () -> Right ()
+        | null (T.words srcs) -> failure "'srcs' is empty"
+        | otherwise -> case traverse resolveSrc (T.words srcs) of
+            Left bad -> failure ("'srcs' entry is not a store path: " <> bad)
+            Right archives -> case mOutDir of
+              Nothing -> failure "derivation defines no 'out' output"
+              Just outDir -> do
+                createDirectoryIfMissing True outDir
+                result <- unpackAll outDir limits archives
+                pure $ case result of
+                  Left msg -> Left (1, "builtin:unpack: " <> msg)
+                  Right () -> Right ()
   where
     failure msg = pure (Left (1, "builtin:unpack: " <> msg))
-    sourcePaths = map T.unpack . T.words
+    resolveSrc word = case parseStorePath defaultStoreDir word of
+      Just sp -> Right (storePathToFilePath storeDir sp)
+      Nothing -> Left word
 
 -- | Extract archives in order, stopping at the first failure.  One
 -- budget spans all of them: the caps bound the BUILD's output, not any

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -4221,24 +4221,25 @@ testUnpackBuildIO = do
       pure []
     else withTempStore $ \store -> do
       let storeDir = stDir store
-      tmpBase <- getTemporaryDirectory
-      let workDir = tmpBase </> "nova-nix-test-unpack-src"
-      forceRemoveIfExists workDir
-      createDirectoryIfMissing True workDir
-      let archiveTools = workDir </> "pkg-tools.tar.zst"
-          archiveData = workDir </> "pkg-data.tar.zst"
-          archiveCollide = workDir </> "pkg-collide.tar.zst"
-          archiveEscape = workDir </> "pkg-escape.tar.zst"
-          archiveRootFile = workDir </> "pkg-root-file.tar.zst"
-          archiveEscapeSymlink = workDir </> "pkg-escape-symlink.tar.zst"
-          archiveEscapeHardlink = workDir </> "pkg-escape-hardlink.tar.zst"
-          archiveDirLink = workDir </> "pkg-dirlink.tar.zst"
-          archiveDirLinkBase = workDir </> "pkg-dirlink-base.tar.zst"
-          archiveDirLinkCollide = workDir </> "pkg-dirlink-collide.tar.zst"
-          archiveHardLinkCollide = workDir </> "pkg-hardlink-collide.tar.zst"
-          archiveManyEntries = workDir </> "pkg-many-entries.tar.zst"
-          archiveBigFile = workDir </> "pkg-big-file.tar.zst"
-          archiveAmplify = workDir </> "pkg-amplify.tar.zst"
+      -- Archives live in the temp store under store-path names: the srcs
+      -- env is store paths by contract, and runBuiltinUnpack insists on
+      -- that now (#101) - each entry is parsed and rendered through the
+      -- build's store dir, which for these builds is the temp store.
+      let archiveFile name = storePathToFilePath storeDir (StorePath (T.replicate 32 "0") name)
+          archiveTools = archiveFile "pkg-tools.tar.zst"
+          archiveData = archiveFile "pkg-data.tar.zst"
+          archiveCollide = archiveFile "pkg-collide.tar.zst"
+          archiveEscape = archiveFile "pkg-escape.tar.zst"
+          archiveRootFile = archiveFile "pkg-root-file.tar.zst"
+          archiveEscapeSymlink = archiveFile "pkg-escape-symlink.tar.zst"
+          archiveEscapeHardlink = archiveFile "pkg-escape-hardlink.tar.zst"
+          archiveDirLink = archiveFile "pkg-dirlink.tar.zst"
+          archiveDirLinkBase = archiveFile "pkg-dirlink-base.tar.zst"
+          archiveDirLinkCollide = archiveFile "pkg-dirlink-collide.tar.zst"
+          archiveHardLinkCollide = archiveFile "pkg-hardlink-collide.tar.zst"
+          archiveManyEntries = archiveFile "pkg-many-entries.tar.zst"
+          archiveBigFile = archiveFile "pkg-big-file.tar.zst"
+          archiveAmplify = archiveFile "pkg-amplify.tar.zst"
       BL.writeFile archiveTools $
         compressArchive
           [ tarDir "pkg",
@@ -4311,7 +4312,12 @@ testUnpackBuildIO = do
             tarSymLink "dup1" "base",
             tarSymLink "dup2" "base"
           ]
-      let mkUnpackDrv outP srcFiles =
+      let -- srcs carries the canonical /nix/store spelling, as eval writes
+          -- it; the physical archives live under the temp store dir.
+          canonicalSrc file = case parseStorePath storeDir (T.pack file) of
+            Just sp -> storePathToText defaultStoreDir sp
+            Nothing -> T.pack file
+          mkUnpackDrv outP srcFiles =
             Derivation
               { drvOutputs =
                   [ DerivationOutput
@@ -4328,7 +4334,7 @@ testUnpackBuildIO = do
                 drvArgs = [],
                 drvEnv =
                   Map.fromList
-                    [(envSrcs, TE.encodeUtf8 (T.intercalate " " (map T.pack srcFiles)))]
+                    [(envSrcs, TE.encodeUtf8 (T.intercalate " " (map canonicalSrc srcFiles)))]
               }
           seedOut = StorePath (T.replicate 31 "0" <> "2") "unpack-seed"
           collideOut = StorePath (T.replicate 31 "0" <> "3") "unpack-collide"
@@ -4361,7 +4367,6 @@ testUnpackBuildIO = do
       bigFileResult <- buildDerivation (tinyBudget 64 1000) store (mkUnpackDrv bigFileOut [archiveBigFile])
       amplifyResult <- buildDerivation (tinyBudget 100 1000) store (mkUnpackDrv amplifyOut [archiveAmplify])
       forceRemoveIfExists buildTmp
-      forceRemoveIfExists workDir
       seedChecks <- case seedResult of
         BuildFailure msg code ->
           sequence


### PR DESCRIPTION
Fixes #101. The srcs env value carries eval's canonical `/nix/store` spelling; unpack used the words verbatim as FilePaths, and on Windows a bare /-rooted path resolves against the current drive - extraction worked if and only if the process happened to run from C:. Dev machines always did; GitHub's windows-latest workspace lives on D:, and the e2e job's second flight (#100) failed exactly there.

- Each srcs entry now parses as a store path and renders through the configured store dir (`bcStoreDir`) - the same translation every other consumer applies. On Unix the rendering is the identity.
- A srcs word that is not a store path fails loudly instead of being opened as an arbitrary file (srcs is documented as store paths).
- The unpack tests move their archives into the temp store under store-path names, spelled canonically the way eval spells them - they now exercise the real contract instead of the loophole.

**Self-proving**: this PR also removes the e2e job's `Set-Location C:\` workaround, so `E2E (Windows)` builds from the D: workspace - the exact configuration that failed - and its green check is the fix's verification on real Windows hardware.

Verified locally: full gate (build `-Werror`, 1102-test suite, ormolu, hlint, ASCII) green.
