### PR TITLE
Toolchain: pin the Hackage index-state

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,1 +1,6 @@
 packages: .
+
+-- Pin the dependency universe: local, CI, and contributor builds resolve
+-- identical versions regardless of when they last ran cabal update.  Bump
+-- deliberately - a fresh timestamp - when adopting new releases.
+index-state: 2026-08-20T01:41:58Z


### PR DESCRIPTION
From #96 (last unblocked checkbox). Without a pin, local, CI, and contributor builds each resolve against whatever index their last `cabal update` fetched, so the same commit can build different dependency versions on different days. The pin makes the dependency universe part of the repository: every build of a given commit solves against the same index, and adopting newer releases is a deliberate one-line bump.

`2026-08-20T01:41:58Z` is the index every current bound resolves against (verified with a fresh solve).

Note: with strict up-to-date protection, this merges after #102 and will need a branch update first.
