### PR TITLE
CI: run checks on stacked pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,10 @@ name: CI
 on:
   push:
     branches: [main]
+  # No base-branch filter on pull_request: a stacked PR bases on its
+  # predecessor, not main, and a [main] filter leaves it checkless -
+  # unmergeable under branch protection's required contexts.
   pull_request:
-    branches: [main]
   workflow_call:
 
 env:

--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -26,8 +26,9 @@ on:
       - "nova-nix.cabal"
       - ".github/workflows/parity.yml"
       - ".github/parity/**"
+  # No base-branch filter: stacked PRs base on each other, and a filter
+  # keeps them checkless (see ci.yml).  The path filter still applies.
   pull_request:
-    branches: [main]
     paths:
       - "src/**"
       - "cbits/**"


### PR DESCRIPTION
Both workflows filtered pull_request events to base [main], so a stacked PR (one whose base is its predecessor branch, the shape the substituter review chain uses right now) never ran a single check, and under branch protection's required contexts could never merge. The base filter is gone; push triggers still cover main only, and parity keeps its path filter. The comment in each workflow states the constraint so a future tidy-up does not reintroduce the filter.