### PR TITLE
Toolchain: nova-cache 0.11.0.1 - bzip2 parity and decoder teardown

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -3,4 +3,4 @@ packages: .
 -- Pin the dependency universe: local, CI, and contributor builds resolve
 -- identical versions regardless of when they last ran cabal update.  Bump
 -- deliberately - a fresh timestamp - when adopting new releases.
-index-state: 2026-08-21T13:46:59Z
+index-state: 2026-08-21T18:24:54Z


### PR DESCRIPTION
One line: the `index-state` pin moves to nova-cache 0.11.0.1's upload second, `2026-08-21T18:24:54Z`. The `>= 0.11 && < 0.12` bound from #122 already admits it, so nothing else changes.

Picks up two bzip2 fixes released in nova-cache 0.11.0.1:

- **Trailing bytes that do not begin another stream end the output instead of failing it.** Upstream Nix routes bzip2 through libarchive, which ignores such a trailer. Measured against libarchive 3.8.2 driven exactly as Nix drives it, 4 of 7 cases diverged before and 8 of 10 agree now. Directly relevant here: a historical `.nar.bz2` carrying one stray trailing byte substituted fine under `nix copy` and failed in the Substituter with `Bzip2StreamError`, falling through to a source build.
- **The bzip2 decoder is released on every exit** rather than at a GC finalizer's leisure. Matters for the Substituter specifically, since it retries transient failures and each retry opened a fresh decoder whose libbz2 block table (up to 3.6 MB, invisible to the RTS) stayed live.

## Verification

- `cabal build --dry-run all` resolves `nova-cache-0.11.0.1` for `lib:xz`, `lib:bzip2`, and `lib:zstandard`
- `cabal build --enable-tests --ghc-options="-Werror" all` clean
- `cabal test all`: **1167/1167 passed**