### PR TITLE
Docs: commit and changelog conventions, and where AI-assisted work stands

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,12 +9,34 @@ and pull requests are welcome.
 - Code must build warning-clean and pass the test suite (`cabal build && cabal test`).
 - Match the existing style (ormolu-formatted, hlint-clean).
 
+## Commit messages
+
+- Subject is `Area: summary` - `Eval:`, `Store:`, `Parser:`, `Builder:`,
+  `Pkgs:`, `CI:`, `Toolchain:`, and so on.
+- The body says why, not what. What changed is in the diff; the message is for
+  whoever reads `git log` later asking why a line looks the way it does.
+
+## Changelog
+
+User-visible changes get a bullet under `## Unreleased` in `CHANGELOG.md`: a
+bold lead sentence, then the why - the upstream behavior matched, the hazard
+closed, the reason the obvious approach does not work - in full sentences.
+
+The bold lead is what someone scanning a release reads. Everything after it is
+for whoever needs the reasoning, and it is worth the space. Match the entries
+already in the file; they are the specification.
+
 ## Licensing of contributions
 
 nova-nix is licensed under Apache-2.0. Per Section 5 of the license, any
 contribution intentionally submitted for inclusion in this project is licensed
 under Apache-2.0, without additional terms or conditions. You keep the
 copyright to your work. Submit only work you have the right to license.
+
+Tooling does not change this. AI-assisted work is fine here, and noting it in
+a commit is optional - you are responsible for what you submit either way.
+Code is judged on review, and how it was written is not evidence in either
+direction.
 
 This is the standard inbound=outbound arrangement: you contribute under the
 same terms you received the project under, nothing more.


### PR DESCRIPTION
The conventions existed only in practice and in a local file, nowhere a contributor could read them. Written down now: the subject form, what the commit body is for, and the shape of a changelog entry, with the entries already in the file named as the specification since they teach the voice better than a rule can.

The licensing section was silent on tooling, which leaves a contributor to guess whether provenance needs declaring. It now says what the project holds: AI-assisted work is fine, noting it in a commit is optional, and a contribution is judged on review, because how it was written is not evidence in either direction.

No changelog entry: nothing here changes nova-nix's behavior.