### PR TITLE
CI: run the suite on demand against any branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
   # unmergeable under branch protection's required contexts.
   pull_request:
   workflow_call:
+  # Run the suite against any branch without opening a pull request:
+  # verifying a fix on a branch otherwise meant a throwaway PR, since
+  # pull_request was the only trigger that reached a non-main ref.
+  workflow_dispatch:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true


### PR DESCRIPTION
Verifying a fix on a branch meant opening a throwaway pull request, because `pull_request` was the only trigger that reached a non-main ref: `push` is filtered to main and `workflow_call` only fires from the publish pipeline. `workflow_dispatch` puts a branch selector on the Actions tab instead.

Parity already had the trigger; this brings CI in line.

No changelog entry: nothing here changes nova-nix's behavior.