### PR TITLE
CI: keep the executables the build matrix already produces

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -307,6 +307,21 @@ jobs:
           fi
           grep -q "was not found in the Nix search path" err.txt
 
+      # CI is the only place that compiles for all three platforms, and it
+      # discarded every result.  Keeping them means a Windows or macOS
+      # failure can be reproduced on a real machine without installing a
+      # toolchain there.  Staged after the tests so a binary that failed
+      # them is never published.
+      - name: Stage the executable
+        run: cabal install exe:nova-nix --install-method=copy --installdir=staged --overwrite-policy=always
+
+      - name: Upload the executable
+        uses: actions/upload-artifact@v7
+        with:
+          name: nova-nix-${{ matrix.name }}
+          path: staged/nova-nix*
+          if-no-files-found: error
+
   # ---------------------------------------------------------------------------
   # End-to-end (Windows-only): the executable this repo ships, driving a real
   # build through the real stdenv - fetch the MinGW-w64 seed, compile hello.c

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -312,15 +312,26 @@ jobs:
       # failure can be reproduced on a real machine without installing a
       # toolchain there.  Staged after the tests so a binary that failed
       # them is never published.
+      # bin/ beside share/ rather than a bare executable: the <nix/*> search
+      # path resolves relative to the binary's own location, so an artifact
+      # without share/ can evaluate but cannot build, which is most of what
+      # someone downloads it to try.  Same layout a release archive ships.
       - name: Stage the executable
-        run: cabal install exe:nova-nix --install-method=copy --installdir=staged --overwrite-policy=always
+        shell: bash
+        run: |
+          set -euo pipefail
+          cabal install exe:nova-nix --install-method=copy --installdir=staged/bin --overwrite-policy=always
+          mkdir -p staged/share/nova-nix/nix
+          cp data/nix/fetchurl.nix staged/share/nova-nix/nix/
 
       - name: Upload the executable
         uses: actions/upload-artifact@v7
         with:
-          name: nova-nix-${{ matrix.name }}
-          path: staged/nova-nix*
+          name: nova-nix-${{ matrix.name }}-${{ runner.arch }}
+          path: staged/
           if-no-files-found: error
+          overwrite: true
+          retention-days: 14
 
   # ---------------------------------------------------------------------------
   # End-to-end (Windows-only): the executable this repo ships, driving a real


### PR DESCRIPTION
The matrix compiles nova-nix for Linux, macOS and Windows on every run and then discards all three. Keeping them means a platform-specific failure can be reproduced on a real machine without installing a toolchain there, which until now was the only way to get a Windows binary at all.

Staged after the test step so a binary that failed its tests is never published, and `if-no-files-found: error` rather than a silent empty upload.

Groundwork for #12: an action installer needs published binaries, and this is the first step toward having any. Artifacts are login-gated and expire, so releases come next.

No changelog entry: nothing here changes nova-nix's behavior.