### PR TITLE
Changelog: one file per entry, so concurrent branches stop colliding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,29 @@ jobs:
             exit 1
           fi
 
+  # Fragments are pasted into CHANGELOG.md verbatim at release, so a malformed
+  # one is only noticed while cutting the release, which is the worst time.
+  changelog:
+    name: Changelog fragments
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Fragments are well-formed
+        run: |
+          status=0
+          for fragment in changelog.d/*.md; do
+            [ -e "$fragment" ] || continue
+            if ! head -n1 "$fragment" | grep -q '^- \*\*'; then
+              echo "$fragment: must open with a bold lead, '- **...**'" >&2
+              status=1
+            fi
+            if [ ! -s "$fragment" ]; then
+              echo "$fragment: is empty" >&2
+              status=1
+            fi
+          done
+          exit $status
+
   hlint:
     name: HLint
     needs: [ascii]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,13 +18,22 @@ and pull requests are welcome.
 
 ## Changelog
 
-User-visible changes get a bullet under `## Unreleased` in `CHANGELOG.md`: a
-bold lead sentence, then the why - the upstream behavior matched, the hazard
-closed, the reason the obvious approach does not work - in full sentences.
+User-visible changes get a bullet in a new file under `changelog.d/`, named
+after the change (`changelog.d/fetchgit-pinned-rev.md`): a bold lead sentence,
+then the why - the upstream behavior matched, the hazard closed, the reason the
+obvious approach does not work - in full sentences.
 
 The bold lead is what someone scanning a release reads. Everything after it is
 for whoever needs the reasoning, and it is worth the space. Match the entries
-already in the file; they are the specification.
+already in `CHANGELOG.md`; they are the specification.
+
+One file per entry rather than one shared section, because every branch
+appending to the same section collides there and nowhere else. Two branches
+adding entries touch two different files, so they cannot conflict.
+
+`CHANGELOG.md` stays the record of what shipped. At release the fragments are
+assembled under the new version heading with `scripts/assemble-changelog.sh`
+and removed, so nothing is written twice.
 
 ## Licensing of contributions
 

--- a/scripts/assemble-changelog.sh
+++ b/scripts/assemble-changelog.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Concatenate changelog.d/ fragments in the order they were added, for pasting
+# under a version heading in CHANGELOG.md when cutting a release.
+#
+# Order comes from git rather than from filenames: each fragment is added by
+# exactly one commit, so merge order is available and needs no coordination
+# between branches (a numeric prefix would just move the collision onto the
+# prefix).  A shallow clone cannot answer that question and the failure mode is
+# a silently empty release section, so the count is asserted against the
+# working tree rather than trusted.
+#
+# Portable to bash 3.2, which is what macOS ships: no mapfile, no readarray.
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+fragmentDir=changelog.d
+
+onDiskCount=$(find "$fragmentDir" -type f -name '*.md' | wc -l | tr -d ' ')
+if [ "$onDiskCount" -eq 0 ]; then
+  echo "no fragments in $fragmentDir/" >&2
+  exit 1
+fi
+
+# Fragments named by git, oldest commit first, filtered to the ones that still
+# exist: a file added and later renamed or removed is still named by the log.
+ordered=""
+orderedCount=0
+while IFS= read -r fragment; do
+  if [ -f "$fragment" ]; then
+    ordered="${ordered}${fragment}"$'\n'
+    orderedCount=$((orderedCount + 1))
+  fi
+done < <(
+  git log --reverse --diff-filter=A --format= --name-only -- "$fragmentDir" \
+    | grep -E "^${fragmentDir}/.*\.md$" || true
+)
+
+if [ "$orderedCount" -ne "$onDiskCount" ]; then
+  echo "git names ${orderedCount} fragment(s) but ${onDiskCount} exist on disk." >&2
+  echo "A shallow clone cannot see when a fragment was added: fetch full history" >&2
+  echo "(git fetch --unshallow) and run this again.  An uncommitted fragment is" >&2
+  echo "invisible here too." >&2
+  exit 1
+fi
+
+printf '%s' "$ordered" | while IFS= read -r fragment; do
+  cat "$fragment"
+  # A fragment need not end in a newline; the separator must not depend on it.
+  if [ -n "$(tail -c 1 "$fragment")" ]; then
+    echo
+  fi
+done


### PR DESCRIPTION
Closes #137.

The issue said "not during the current batch". That was right when it was
filed, and it stopped being right this week: the batch is what is colliding.
Four branches opened today, four conflicts, every one of them two adjacent
bullets under `## Unreleased` and nothing else. #148 could not be merged
because of it. The three branches still to migrate are mine, so the cost of
doing it now is me rewriting my own entries.

A change adds `changelog.d/<slug>.md` holding the bullet exactly as it would
have appeared. Same format, same prose rules, no frontmatter, nothing new to
learn. `CHANGELOG.md` remains the record of what shipped: at release the
fragments are assembled under the new version heading with
`scripts/assemble-changelog.sh` and removed.

Ordering comes from git, as the issue specified, since each fragment is added
by exactly one commit and a numeric prefix would just move the collision onto
the prefix.

## Two corrections to the sketch in the issue

**The pipeline exits non-zero.** It ends in
`while read -r f; do [ -f "$f" ] && cat "$f"; done`. When the last fragment does
not exist the test is false, that is the loop's exit status, and under `set -e`
the script dies with no output. An `if` avoids it.

**Git ordering needs full history, and nothing here has it.** No workflow sets
`fetch-depth`, so `actions/checkout` uses its depth-1 default. `git log
--diff-filter=A` on a shallow clone returns nothing, so the assembled section
comes back **empty** and the release ships with no changelog. That is a silent
failure at the worst possible moment, so the script asserts the count git names
against the files on disk and fails loudly with the fix in the message.

Also dropped `mapfile`, which the natural implementation reaches for. It is
bash 4+ and macOS ships 3.2, so it would fail on the machine this repo is
developed on.

## Checks

The script was exercised against real commits: fragments added in two separate
commits assemble in commit order, two added in one commit are ordered within
it, and a fragment with no trailing newline is still separated correctly.
Verified `bash -n` clean and run under bash 3.2.

The new CI job rejects a fragment that does not open with a bold lead, or that
is empty. Checked both directions locally: a malformed fragment exits 1, a
well-formed one exits 0. Fragments are pasted into `CHANGELOG.md` verbatim at
release, so a malformed one is otherwise found while cutting the release.

`## Unreleased` keeps the bullets already committed for the next version. This
does not rewrite them; it changes where the *next* entry goes.
