### PR TITLE
CI: Hackage is its own workflow, dispatched, not a tag's side effect

### DIFF
--- a/.github/workflows/hackage.yml
+++ b/.github/workflows/hackage.yml
@@ -1,0 +1,100 @@
+name: Hackage
+
+# A Hackage version is immutable: uploading spends the number whether or not
+# the release turns out to be good.  That makes it a different decision from
+# cutting a release, taken at a different time, so it gets its own trigger
+# rather than riding along on a tag.
+#
+# Dispatched by hand, against a tag that already exists.  The alternative
+# considered was gating the job inside publish.yml behind an environment with
+# a required reviewer.  It works, but the approval expires after 30 days and
+# cancels the run with it, so deciding later means re-running a whole release
+# workflow whose GitHub-release job would then fail on a release that already
+# exists.  Deciding later is the normal case here, so the trigger models it.
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to upload, without a leading v (for example 0.7.0.0)"
+        required: true
+        type: string
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+permissions:
+  contents: read
+
+# Never cancel an upload in flight: a half-finished POST to Hackage is worse
+# than a slow one.
+concurrency:
+  group: hackage-${{ inputs.version }}
+  cancel-in-progress: false
+
+jobs:
+  upload:
+    name: Upload ${{ inputs.version }}
+    runs-on: ubuntu-latest
+    steps:
+      # The tag, not the default branch: what gets uploaded has to be the tree
+      # that was released, not whatever main has moved on to since.
+      - uses: actions/checkout@v6
+        with:
+          ref: v${{ inputs.version }}
+
+      - name: The tag names the committed version
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          ESCAPED=${VERSION//./\\.}
+          if ! grep -Eq "^version:[[:space:]]*${ESCAPED}[[:space:]]*$" nova-nix.cabal; then
+            echo "tag v${VERSION} does not name the committed version:" >&2
+            grep '^version:' nova-nix.cabal >&2
+            exit 1
+          fi
+
+      # The coupling publish.yml used to get from `needs: [package]`, restated
+      # here because this workflow runs on its own: the reversible half of a
+      # release goes first, so a version whose binaries never built cannot be
+      # spent on Hackage.
+      - name: Its release exists, with every asset attached
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          if ! gh release view "v${VERSION}" --json isDraft --jq '.isDraft' > draft.txt; then
+            echo "no published release v${VERSION}: cut the release before uploading to Hackage" >&2
+            exit 1
+          fi
+          if [ "$(cat draft.txt)" = "true" ]; then
+            echo "release v${VERSION} is still a draft" >&2
+            exit 1
+          fi
+          count=$(gh release view "v${VERSION}" --json assets --jq '.assets | length')
+          if [ "$count" -ne 4 ]; then
+            echo "expected 4 assets on v${VERSION} (3 archives + SHA256SUMS), found ${count}" >&2
+            exit 1
+          fi
+
+      - uses: haskell-actions/setup@v2
+        with:
+          ghc-version: "9.14.1"
+          cabal-version: "latest"
+
+      - name: Build sdist
+        run: cabal sdist
+
+      # The token travels via stdin into curl's config, never argv:
+      # command lines are readable process-wide for the upload's duration.
+      - name: Upload to Hackage
+        env:
+          HACKAGE_TOKEN: ${{ secrets.HACKAGE_TOKEN }}
+        run: |
+          SDIST=$(ls dist-newstyle/sdist/nova-nix-*.tar.gz)
+          curl --fail --silent --show-error \
+            --config - \
+            --form "package=@${SDIST}" \
+            https://hackage.haskell.org/packages/ \
+            <<< "header = \"Authorization: X-ApiKey ${HACKAGE_TOKEN}\""

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,14 +7,14 @@ on:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
-# Never cancel a publish: a Hackage upload is irreversible and a half-uploaded
-# release is worse than a slow one.
+# Never cancel a publish: assets are uploaded one at a time and a release that
+# is half-populated is worse than a slow one.
 concurrency:
   group: publish-${{ github.ref }}
   cancel-in-progress: false
 
 # Drop the default GITHUB_TOKEN to read-only by default; only the release job
-# widens it, and the Hackage upload uses its own token (HACKAGE_TOKEN).
+# widens it.
 permissions:
   contents: read
 
@@ -28,9 +28,8 @@ jobs:
     uses: ./.github/workflows/parity.yml
 
   # The tree is the source of truth: the tag must NAME the committed version,
-  # never rewrite it.  Its own job because two consumers depend on it now, and
-  # a mistyped tag must fail before either an immutable Hackage sdist or a
-  # public release exists.
+  # never rewrite it.  Its own job because two consumers depend on it, and a
+  # mistyped tag must fail before a public release exists to be found by it.
   check-tag:
     name: Check the tag
     runs-on: ubuntu-latest
@@ -172,9 +171,10 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
-  # Separate from the Hackage upload on purpose: a rejected Hackage POST is
-  # permanent (versions are immutable), so a combined job could never be
-  # re-run, while a release can be recreated freely.
+  # Hackage is not published from here.  A release can be deleted and cut
+  # again; a Hackage version cannot, so spending one is a separate decision
+  # taken at a separate time, and hackage.yml is dispatched by hand once a
+  # release has proved itself.
   release:
     name: GitHub release
     needs: [check-tag, package]
@@ -238,45 +238,3 @@ jobs:
             exit 1
           fi
           gh release edit "v${VERSION}" --draft=false
-
-  # Waits on package, not merely on the checks: a Hackage version is
-  # immutable, so an upload is the one step of a release that cannot be taken
-  # back, and it must not happen for a tag whose binaries do not build.  It
-  # does not wait on the release job as well, though the ordering reads
-  # naturally: that job is re-runnable and this one is not, so a failed
-  # `gh release create` would strand the upload behind a job that refuses to
-  # repeat once the release exists.
-  publish:
-    name: Publish to Hackage
-    needs: [check-tag, package]
-    # A Hackage version is immutable, so this is the one step of a release
-    # that no amount of re-running can take back.  The `hackage` environment
-    # requires a reviewer, which holds the job in `waiting` until a human
-    # approves it: a tag publishes the binaries immediately and asks before
-    # spending the version number.  Nothing else in the workflow references
-    # the environment, so the GitHub release is unaffected.
-    environment: hackage
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: haskell-actions/setup@v2
-        with:
-          ghc-version: "9.14.1"
-          cabal-version: "latest"
-
-      - name: Build sdist
-        run: cabal sdist
-
-      # The token travels via stdin into curl's config, never argv:
-      # command lines are readable process-wide for the upload's duration.
-      - name: Upload to Hackage
-        env:
-          HACKAGE_TOKEN: ${{ secrets.HACKAGE_TOKEN }}
-        run: |
-          SDIST=$(ls dist-newstyle/sdist/nova-nix-*.tar.gz)
-          curl --fail --silent --show-error \
-            --config - \
-            --form "package=@${SDIST}" \
-            https://hackage.haskell.org/packages/ \
-            <<< "header = \"Authorization: X-ApiKey ${HACKAGE_TOKEN}\""


### PR DESCRIPTION
A tag meant two things at once: publish binaries, and spend a Hackage version
number. The first is reversible - delete the release, cut it again. The second
is not, and the number is spent whether or not the release proves out. Coupling
them makes the irreversible decision run on the reversible one's schedule.

### Why not the environment gate

I built that first, in #160: keep the job in `publish.yml` behind an
environment with a required reviewer. It works, and it is the wrong shape for
the case it exists to serve.

An approval request expires after 30 days and cancels the run with it. So
"decide later" is only true for values of later under a month. Past that, there
is no button: you re-run the whole release workflow, which re-runs CI, parity
and packaging, and whose `release` job then fails because the release it would
create already exists. Deciding later is the normal case here, so the trigger
should model it rather than fight it.

It also leaves every tag's run sitting `waiting` and then `cancelled`, so a
release never shows a green run.

### What replaces it

`hackage.yml`, dispatched by hand with a version:

- checks out **the tag**, not the branch - what ships must be the tree that was
  released, not what `main` moved on to
- asserts the tag names the committed version, the same check `publish.yml`
  does before releasing
- asserts the release **exists, is published rather than draft, and carries all
  four assets**

That last one restates the coupling `needs: [package]` used to provide: a
version whose binaries never built cannot be spent on Hackage. The reversible
half still goes first, without a job graph to carry it.

`publish.yml` loses the `publish` job and the comments that promised it. The
`hackage` environment is deleted, since nothing references it.

### Checked

- `actionlint` clean on all four workflows
- `publish.yml`'s remaining jobs: `ci`, `parity`, `check-tag`, `package`,
  `release`
- no repository environments remain

Wants to land before `v0.7.0.0` so the tag does not carry the old behaviour.