### PR TITLE
CI: delete the node24 force flag, which no longer does anything

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,6 @@ on:
   # pull_request was the only trigger that reached a non-main ref.
   workflow_dispatch:
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 # Drop the default GITHUB_TOKEN to read-only; nothing here writes via it.
 permissions:

--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -37,8 +37,6 @@ on:
       - ".github/workflows/parity.yml"
       - ".github/parity/**"
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 # Drop the default GITHUB_TOKEN to read-only; nothing here writes via it.
 permissions:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,8 +4,6 @@ on:
   push:
     tags: ['v*']
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 # Never cancel a publish: assets are uploaded one at a time and a release that
 # is half-populated is worse than a slow one.


### PR DESCRIPTION
`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` was set in all three workflows to pull
`hlint-setup` and `hlint-run` onto the node24 runtime, since both still declare
node20. GitHub has since made node24 the default and the flag stopped
mattering.

### Checked, not assumed

CI was dispatched against a branch with the flag removed everywhere. The HLint
job, the only job with a node20 action in it, passed and logged:

```
Node.js 20 is deprecated. The following actions target Node.js 20 but are being
forced to run on Node.js 24: haskell-actions/hlint-run@v2, haskell-actions/hlint-setup@v2
```

Identical to the message with the flag set. The runner does it on its own now.
Its second warning says so directly: the workflow "is running with Node 24 by
default", and `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION` is offered as the way
back to 20, which is the migration pointing the other way.

Two of the three workflows had no node20 action in them at all, so those copies
were doing nothing even before the default changed:

| workflow | node20 actions |
| --- | --- |
| `ci.yml` | `hlint-setup@v2`, `hlint-run@v2` |
| `parity.yml` | none |
| `publish.yml` | none |

### Why not a comment

The alternative was to keep the flag and document when to remove it. That would
have been a paragraph guarding a line that does not work, duplicating #60 and
adding a place for the explanation to rot. A workaround that has stopped
working is not a workaround, and "root causes, not bandaids" says to delete it.

The deprecation warning stays until `hlint-setup` and `hlint-run` ship a release
built on node24 (#60). It is cosmetic: they already run on it. #60 is updated
with what upstream has done - fixed on `main` on 2026-08-17, `v2` untouched
since 2024-06-17 - so that issue is waiting on a tag, not a fix.