### PR TITLE
CI: the same dead flag, in the workflow that did not exist yet

### DIFF
--- a/.github/workflows/hackage.yml
+++ b/.github/workflows/hackage.yml
@@ -19,9 +19,6 @@ on:
         required: true
         type: string
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 permissions:
   contents: read
 


### PR DESCRIPTION
Follow-up to #168, which removed `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` from the three workflows that existed when its branch was cut. `hackage.yml` arrived in #167 after that point, carrying a copy of the flag, so the deletion missed it.

Neither action it uses is node20 (`actions/checkout@v6`, `haskell-actions/setup@v2`), and #168 measured that the flag does nothing even where a node20 action is present.

That is every copy gone.