### PR TITLE
CI: report required checks on merge_group for a merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,15 @@ on:
   # predecessor, not main, and a [main] filter leaves it checkless -
   # unmergeable under branch protection's required contexts.
   pull_request:
+  # The merge queue tests each entry against a temporary
+  # gh-readonly-queue/main branch, so every required check must also
+  # report there or the queue times the context out to a failure and
+  # ejects the pull request.  Same jobs, matched by check name; every
+  # required context comes from this one workflow, so the single
+  # trigger reaches all of them.  checks_requested is the only activity
+  # type the event has.
+  merge_group:
+    types: [checks_requested]
   workflow_call:
   # Run the suite against any branch without opening a pull request:
   # verifying a fix on a branch otherwise meant a throwaway PR, since


### PR DESCRIPTION
Groundwork for a merge queue (#138): adds the `merge_group: types: [checks_requested]` trigger so every required status check also runs and reports on the queue's temporary gh-readonly-queue/main branch. All eleven required contexts come from this one workflow, so the single trigger reaches them all under their existing names.

The trigger is inert until a merge queue is actually enabled in the branch settings, so it lands safely ahead of that. That is also the required order: the merge-group jobs must exist on main before the queue is turned on, or the first queued PR waits for jobs that are not there and times out. The concurrency block needs no change (a merge group's github.ref is a unique gh-readonly-queue/main ref, so each build self-isolates).

Merging this does NOT enable the queue; that is a branch-protection settings change (Require merge queue, method Rebase, grouping require-all-pass, and turn off Require branches up to date). Deliberately keeping #138 open until those settings are flipped.

Part of #138.